### PR TITLE
First version of edgedb-init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,7 @@ dependencies = [
  "native-tls",
  "num-bigint",
  "once_cell",
+ "openssl",
  "os-release",
  "predicates",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ shutdown_hooks = "0.1.0"
 rexpect = {git="https://github.com/tailhook/rexpect", branch="default_terminal_size"}
 tar = "0.4.26"
 test-case = "1.0.0"
+openssl = "0.10.29"
 
 [features]
 dev_mode = []

--- a/edgedb-init.sh
+++ b/edgedb-init.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-# This is just a little script that can be downloaded from the internet to
-# install eddgedb CLI tools. It just does platform detection, downloads the
-# installer and runs it.
+# Portions Copyright (c) 2020 MagicStack Inc.
+# Portions Copyright (c) 2016 The Rust Project Developers.
+#
+# This is a simple script that can be downloaded from https://edgedb.com to
+# install `edgedb` CLI tools. Its job is to detect the host platform and to 
+# download and run the relevant installer.
 
 set -u
 

--- a/edgedb-init.sh
+++ b/edgedb-init.sh
@@ -96,7 +96,7 @@ main() {
     ensure chmod u+x "$_file"
     if [ ! -x "$_file" ]; then
         printf '%s\n' "Cannot execute $_file (likely because of mounting /tmp as noexec)." 1>&2
-        printf '%s\n' "Please copy the file to a location where you can execute binaries and run ./edgedb-cli${_ext} _init." 1>&2
+        printf '%s\n' "Please copy the file to a location where you can execute binaries and run ./edgedb-cli${_ext} _self_install." 1>&2
         exit 1
     fi
 
@@ -109,9 +109,9 @@ main() {
             err "Unable to run interactively. Run with -y to accept defaults, --help for additional options"
         fi
 
-        ignore "$_file" _init "$@" < /dev/tty
+        ignore "$_file" _self_install "$@" < /dev/tty
     else
-        ignore "$_file" _init "$@"
+        ignore "$_file" _self_install "$@"
     fi
 
     local _retval=$?

--- a/edgedb-init.sh
+++ b/edgedb-init.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+
+# This is just a little script that can be downloaded from the internet to
+# install eddgedb CLI tools. It just does platform detection, downloads the
+# installer and runs it.
+
+set -u
+
+EDGEDB_PKG_ROOT="${EDGEDB_PKG_ROOT:-https://packages.edgedb.com}"
+
+usage() {
+    cat 1>&2 <<EOF
+edgedb-init
+The installer for edgedb command-line tools
+
+USAGE:
+    edgedb-init [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help              Prints help information
+        --nightly           Install nightly version of command-line tools
+    -y                      Disable confirmation prompt
+        --no-modify-path    Do not configure the PATH environment variable
+    -q, --quiet             Disable progress output
+    -v, --verbose           Enable verbose output
+    -V, --version           Prints version information
+EOF
+}
+
+main() {
+    downloader --check
+    need_cmd uname
+    need_cmd mktemp
+    need_cmd chmod
+    need_cmd mkdir
+    need_cmd rm
+    need_cmd rmdir
+
+    get_architecture || return 1
+    local _arch="$RETVAL"
+    assert_nz "$_arch" "arch"
+
+    # initial check of arguments
+    local need_tty=yes
+    local suffix=""
+    for arg in "$@"; do
+        case "$arg" in
+            --nightly)
+                suffix="nightly"
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -y)
+                # user wants to skip the prompt -- we don't need /dev/tty
+                need_tty=no
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    local _ext=""
+    case "$_arch" in
+        *windows*)
+            _ext=".exe"
+            ;;
+    esac
+    local _url="${EDGEDB_PKG_ROOT}/dist/${_arch}${suffix:+.}${suffix}/edgedb-cli_latest${suffix:+_}${suffix}${_ext}"
+
+    local _dir
+    _dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t edgedb)"
+    local _file="${_dir}/edgedb${_ext}"
+
+    local _ansi_escapes_are_valid=false
+    if [ -t 2 ]; then
+        if [ "${TERM+set}" = 'set' ]; then
+            case "$TERM" in
+                xterm*|rxvt*|urxvt*|linux*|vt*)
+                    _ansi_escapes_are_valid=true
+                ;;
+            esac
+        fi
+    fi
+
+
+    if $_ansi_escapes_are_valid; then
+        printf "\33[1minfo:\33[0m downloading installer\n" 1>&2
+    else
+        printf '%s\n' 'info: downloading installer' 1>&2
+    fi
+
+    ensure mkdir -p "$_dir"
+    ensure downloader "$_url" "$_file"
+    ensure chmod u+x "$_file"
+    if [ ! -x "$_file" ]; then
+        printf '%s\n' "Cannot execute $_file (likely because of mounting /tmp as noexec)." 1>&2
+        printf '%s\n' "Please copy the file to a location where you can execute binaries and run ./edgedb-cli${_ext} _init." 1>&2
+        exit 1
+    fi
+
+    if [ "$need_tty" = "yes" ]; then
+        # The installer is going to want to ask for confirmation by
+        # reading stdin.  This script was piped into `sh` though and
+        # doesn't have stdin to pass to its children. Instead we're going
+        # to explicitly connect /dev/tty to the installer's stdin.
+        if [ ! -t 1 ]; then
+            err "Unable to run interactively. Run with -y to accept defaults, --help for additional options"
+        fi
+
+        ignore "$_file" _init "$@" < /dev/tty
+    else
+        ignore "$_file" _init "$@"
+    fi
+
+    local _retval=$?
+
+    ignore rm "$_file"
+    ignore rmdir "$_dir"
+
+    return "$_retval"
+}
+
+get_architecture() {
+    local _ostype="$(uname -s)"
+    local _cputype="$(uname -m)"
+
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = i386 ]; then
+        # Darwin `uname -m` lies
+        if sysctl hw.optional.x86_64 | grep -q ': 1'; then
+            _cputype=x86_64
+        fi
+    fi
+
+    case "$_ostype" in
+
+        Linux)
+            _ostype=linux
+            ;;
+
+        Darwin)
+            _ostype=macos
+            ;;
+
+        MINGW* | MSYS* | CYGWIN*)
+            _ostype=windows
+            ;;
+
+        *)
+            err "unrecognized OS type: $_ostype"
+            ;;
+
+    esac
+
+    case "$_cputype" in
+
+        x86_64 | x86-64 | x64 | amd64)
+            _cputype=x86_64
+            ;;
+
+        *)
+            err "unknown CPU type: $_cputype"
+
+    esac
+
+    local _arch="${_ostype}-${_cputype}"
+
+    RETVAL="$_arch"
+}
+
+say() {
+    printf 'edgedb-init: %s\n' "$1"
+}
+
+err() {
+    say "$1" >&2
+    exit 1
+}
+
+need_cmd() {
+    if ! check_cmd "$1"; then
+        err "need '$1' (command not found)"
+    fi
+}
+
+check_cmd() {
+    command -v "$1" > /dev/null 2>&1
+}
+
+assert_nz() {
+    if [ -z "$1" ]; then err "assert_nz $2"; fi
+}
+
+# Run a command that should never fail. If the command fails execution
+# will immediately terminate with an error showing the failing
+# command.
+ensure() {
+    if ! "$@"; then err "command failed: $*"; fi
+}
+
+# This is just for indicating that commands' results are being
+# intentionally ignored. Usually, because it's being executed
+# as part of error handling.
+ignore() {
+    "$@"
+}
+
+# This wraps curl or wget. Try curl first, if not installed,
+# use wget instead.
+downloader() {
+    local _dld
+    if check_cmd curl; then
+        _dld=curl
+    elif check_cmd wget; then
+        _dld=wget
+    else
+        _dld='curl or wget' # to be used in error message of need_cmd
+    fi
+
+    if [ "$1" = --check ]; then
+        need_cmd "$_dld"
+    elif [ "$_dld" = curl ]; then
+        if ! check_help_for curl --proto --tlsv1.2; then
+            echo "Warning: Not forcing TLS v1.2, this is potentially less secure"
+            curl --silent --show-error --fail --location "$1" --output "$2"
+        else
+            curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if ! check_help_for wget --https-only --secure-protocol; then
+            echo "Warning: Not forcing TLS v1.2, this is potentially less secure"
+            wget "$1" -O "$2"
+        else
+            wget --https-only --secure-protocol=TLSv1_2 "$1" -O "$2"
+        fi
+    else
+        err "Unknown downloader"   # should not reach here
+    fi
+}
+
+check_help_for() {
+    local _cmd
+    local _arg
+    local _ok
+    _cmd="$1"
+    _ok="y"
+    shift
+
+    # If we're running on OS-X, older than 10.13, then we always
+    # fail to find these options to force fallback
+    if check_cmd sw_vers; then
+        if [ "$(sw_vers -productVersion | cut -d. -f2)" -lt 13 ]; then
+            # Older than 10.13
+            echo "Warning: Detected OS X platform older than 10.13"
+            _ok="n"
+        fi
+    fi
+
+    for _arg in "$@"; do
+        if ! "$_cmd" --help | grep -q -- "$_arg"; then
+            _ok="n"
+        fi
+    done
+
+    test "$_ok" = "y"
+}
+
+main "$@" || exit 1

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -4,6 +4,7 @@ use crate::options::{Options, Command};
 use crate::client::Connection;
 use crate::non_interactive;
 use crate::commands;
+use crate::self_install;
 use crate::server;
 use crate::print::style::Styler;
 
@@ -69,5 +70,8 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
                 Ok(())
             }).into()
         },
+        Command::_SelfInstall(s) => {
+            self_install::main(s)
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod print;
 mod prompt;
 mod reader;
 mod repl;
+mod self_install;
 mod server;
 mod server_params;
 mod statement;

--- a/src/options.rs
+++ b/src/options.rs
@@ -8,6 +8,7 @@ use whoami;
 
 use crate::repl::OutputMode;
 use crate::commands::parser::Common;
+use crate::self_install;
 use crate::server;
 
 
@@ -89,6 +90,8 @@ pub enum Command {
     DropRole(RoleName),
     Query(Query),
     Server(server::options::ServerCommand),
+    #[clap(setting=AppSettings::Hidden, name="_self_install")]
+    _SelfInstall(self_install::SelfInstall),
     #[clap(flatten)]
     Common(Common),
 }

--- a/src/self_install.rs
+++ b/src/self_install.rs
@@ -1,0 +1,274 @@
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::{PathBuf, Path};
+
+use anyhow::Context;
+use clap::Clap;
+use dirs::{home_dir, executable_dir};
+use prettytable::{Table, Row, Cell};
+use users::get_current_uid;
+
+use crate::table;
+
+
+#[derive(Clap, Clone, Debug)]
+pub struct SelfInstall {
+    /// Install nightly version of command-line tools
+    #[clap(long)]
+    pub nightly: bool,
+    /// Enable verbose output
+    #[clap(short="v", long)]
+    pub verbose: bool,
+    /// Disable progress output
+    #[clap(short="q", long)]
+    pub quiet: bool,
+    /// Disable confirmation prompt
+    #[clap(short="y")]
+    pub no_confirm: bool,
+    /// Do not configure the PATH environment variable
+    #[clap(long)]
+    pub no_modify_path: bool,
+}
+
+pub struct Settings {
+    system: bool,
+    installation_path: PathBuf,
+    modify_path: bool,
+    rc_files: Vec<PathBuf>,
+}
+
+fn print_long_description(settings: &Settings) {
+    println!(r###"
+Welcome to EdgeDB!
+
+This will install the EdgeDB command-line tools.
+
+It will add `edgedb` binary to the {dir_kind} bin directory located at:
+
+  {installation_path}
+{profile_update}
+"###,
+        dir_kind=if settings.system { "system" } else { "user" },
+        installation_path=settings.installation_path.display(),
+        profile_update=if cfg!(windows) {
+            format!(r###"
+This path will then be added to your `PATH` environment variable by
+modifying the `HKEY_CURRENT_USER/Environment/PATH` registry key.
+"###)
+        } else if settings.modify_path {
+            format!(r###"
+This path will then be added to your PATH environment variable by
+modifying the profile file{s} located at:
+
+{rc_files}
+"###,
+            s=if settings.rc_files.len() > 1 { "s" } else { "" },
+            rc_files=settings.rc_files.iter()
+                     .map(|p| format!("  {}", p.display()))
+                     .collect::<Vec<_>>()
+                     .join("\n"),
+            )
+        } else if should_modify_path(&settings.installation_path) {
+            format!(r###"
+Path {installation_path} should be added to ath PATH manually after
+installation.
+"###,
+                installation_path=settings.installation_path.display())
+        } else {
+            r###"
+This path is already in your PATH environment variable, so no profile will
+be modified.
+"###.into()
+        },
+    )
+}
+
+fn should_modify_path(dir: &Path) -> bool {
+    if let Some(all_paths) = env::var_os("PATH") {
+        for path in env::split_paths(&all_paths) {
+            if path == dir {
+                // not needed
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+fn get_rc_files() -> anyhow::Result<Vec<PathBuf>> {
+    let mut rc_files = Vec::new();
+
+    let home_dir = home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
+    rc_files.push(home_dir.join(".profile"));
+
+    if let Ok(shell) = env::var("SHELL") {
+        if shell.contains("zsh") {
+            let var = env::var_os("ZDOTDIR");
+            let zdotdir = var.as_deref()
+                .map_or_else(|| home_dir.as_path(), Path::new);
+            let zprofile = zdotdir.join(".zprofile");
+            rc_files.push(zprofile);
+        }
+    }
+
+    let bash_profile = home_dir.join(".bash_profile");
+    // Only update .bash_profile if it exists because creating .bash_profile
+    // will cause .profile to not be read
+    if bash_profile.exists() {
+        rc_files.push(bash_profile);
+    }
+
+    Ok(rc_files)
+}
+
+fn ensure_line(path: &PathBuf, line: &str) -> anyhow::Result<()> {
+    if path.exists() {
+        let text = fs::read_to_string(path)
+            .context("cannot read file")?;
+        if text.contains(line) {
+            return Ok(())
+        }
+    }
+    let mut file = fs::OpenOptions::new().create(true).append(true).open(path)
+        .context("cannot file for append (writing)")?;
+    file.write(format!("{}\n", line).as_bytes(),)
+        .context("cannot append to file")?;
+    Ok(())
+}
+
+fn print_post_install_message(settings: &Settings) {
+    if cfg!(windows) {
+        print!(r###"# EdgeDB command-line tool is installed now. Great!
+
+To get started you need installation directory ({dir}) in your `PATH`
+environment variable. Future applications will automatically have the
+correct environment, but you may need to restart your current shell.
+"###,
+            dir=settings.installation_path.display());
+    } else if settings.modify_path {
+        print!(r###"# EdgeDB command-line tool is installed now. Great!
+
+To get started you need installation directory ({dir}) in your `PATH`
+environment variable. Next time you log in this will be done
+automatically.
+
+To configure your current shell run `export PATH="{dir}:$PATH"`
+"###,
+            dir=settings.installation_path.display());
+    } else {
+        println!(r###"EdgeDB command-line tool is installed now. Great!"###);
+    }
+}
+
+pub fn main(options: &SelfInstall) -> anyhow::Result<()> {
+    let settings = if cfg!(windows) {
+        let installation_path = home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine home dir"))?
+            .join("EdgeDB/CLI");
+        Settings {
+            system: false,
+            modify_path: !options.no_modify_path &&
+                         should_modify_path(&installation_path),
+            installation_path,
+            rc_files: Vec::new(),
+        }
+    } else if get_current_uid() == 0 {
+        Settings {
+            system: true,
+            modify_path: false,
+            installation_path: PathBuf::from("/usr/bin"),
+            rc_files: Vec::new(),
+        }
+    } else {
+        let installation_path = if cfg!(target_os="macos") {
+            PathBuf::from("/usr/local/bin")
+        } else {
+            executable_dir()
+            .ok_or_else(|| {
+                anyhow::anyhow!("Cannot determine executable dir")
+            })?
+        };
+        Settings {
+            rc_files: get_rc_files()?,
+            system: false,
+            modify_path: !options.no_modify_path &&
+                         should_modify_path(&installation_path),
+            installation_path,
+        }
+    };
+    if !options.quiet {
+        print_long_description(&settings);
+        settings.print();
+        if !options.no_confirm {
+            // TODO(tailhook) ask confirmation
+        }
+    }
+
+    let tmp_path = settings.installation_path.join(".edgedb.tmp");
+    let path = if cfg!(windows) {
+        settings.installation_path.join("edgedb.exe")
+    } else {
+        settings.installation_path.join("edgedb")
+    };
+    let exe_path = env::current_exe()
+        .with_context(|| format!("cannot determine running executable path"))?;
+    fs::create_dir_all(&settings.installation_path)
+        .with_context(|| format!("failed to create {:?}",
+                                 settings.installation_path))?;
+    fs::remove_file(&tmp_path).ok();
+    fs::copy(&exe_path, &tmp_path)
+        .with_context(|| format!("failed to write {:?}", tmp_path))?;
+    fs::rename(&tmp_path, &path)
+        .with_context(|| format!("failed to rename {:?}", tmp_path))?;
+
+    if settings.modify_path {
+        #[cfg(windows)] {
+            windows_add_to_path(&settings.installation_path);
+        }
+        #[cfg(unix)] {
+            let line = format!("\nexport PATH=\"{}:$PATH\"",
+                               settings.installation_path.display());
+            for path in &settings.rc_files {
+                ensure_line(&path, &line)
+                    .with_context(|| format!("failed to update profile file {:?}",
+                                             path))?;
+            }
+        }
+    }
+
+    print_post_install_message(&settings);
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn windows_add_to_path(installation_path: &Path) -> Result<()> {
+    anyhow::bail!("adding to PATH for windows is not implemented yet");
+}
+
+impl Settings {
+    pub fn print(&self) {
+        let mut table = Table::new();
+        table.add_row(Row::new(vec![
+            Cell::new("Instalation Path"),
+            Cell::new(&self.installation_path.display().to_string()),
+        ]));
+        table.add_row(Row::new(vec![
+            Cell::new("Modify PATH Variable"),
+            Cell::new(if self.modify_path { "yes" } else { "no" }),
+        ]));
+        if self.modify_path {
+            table.add_row(Row::new(vec![
+                Cell::new("Profile Files"),
+                Cell::new(&self.rc_files.iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n")),
+            ]));
+        }
+        table.set_format(*table::FORMAT);
+        table.printstd();
+    }
+}

--- a/tests/server/centos.rs
+++ b/tests/server/centos.rs
@@ -6,6 +6,9 @@ pub fn dockerfile(codename: &str) -> String {
     format!(r###"
         FROM centos:{codename}
         RUN yum -y install sudo
+        RUN adduser --uid 1000 --home /home/user \
+            --shell /bin/bash --group users \
+            user
         ADD ./edgedb /usr/bin/edgedb
         ADD ./sudoers /etc/sudoers
     "###, codename=codename)
@@ -20,7 +23,7 @@ fn sudo_install(release: u32, nightly: bool)
 {
     docker::sudo_test(
         &dockerfile(&format!("{}", release)),
-        &format!("edgedb_server_test:centos{}_sudo", release),
+        &format!("edgedb_test:centos{}_sudo", release),
         nightly)
 }
 
@@ -31,6 +34,6 @@ fn refuse_to_reinstall(release: u32, nightly: bool)
 {
     docker::install_twice_test(
         &dockerfile(&format!("{}", release)),
-        &format!("edgedb_server_test:centos{}_sudo", release),
+        &format!("edgedb_test:centos{}_sudo", release),
         nightly)
 }

--- a/tests/server/certs.rs
+++ b/tests/server/certs.rs
@@ -1,0 +1,151 @@
+use openssl::asn1::Asn1Time;
+use openssl::bn::{BigNum, MsbOption};
+use openssl::error::ErrorStack;
+use openssl::hash::MessageDigest;
+use openssl::pkey::{PKey, PKeyRef, Private};
+use openssl::rsa::Rsa;
+use openssl::x509::extension::{AuthorityKeyIdentifier, BasicConstraints};
+use openssl::x509::extension::{KeyUsage, SubjectAlternativeName};
+use openssl::x509::extension::{SubjectKeyIdentifier};
+use openssl::x509::{X509NameBuilder, X509Ref, X509Req, X509ReqBuilder, X509};
+
+pub struct Certs {
+    pub ca_cert: Vec<u8>,
+    pub nginx_cert: Vec<u8>,
+    pub nginx_key: Vec<u8>,
+}
+
+/// Make a CA certificate and private key
+fn mk_ca_cert() -> Result<(X509, PKey<Private>), ErrorStack> {
+    let rsa = Rsa::generate(2048)?;
+    let privkey = PKey::from_rsa(rsa)?;
+
+    let mut x509_name = X509NameBuilder::new()?;
+    x509_name.append_entry_by_text("C", "US")?;
+    x509_name.append_entry_by_text("ST", "TX")?;
+    x509_name.append_entry_by_text("O", "Test CA organization")?;
+    x509_name.append_entry_by_text("CN", "ca test")?;
+    let x509_name = x509_name.build();
+
+    let mut cert_builder = X509::builder()?;
+    cert_builder.set_version(2)?;
+    let serial_number = {
+        let mut serial = BigNum::new()?;
+        serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
+        serial.to_asn1_integer()?
+    };
+    cert_builder.set_serial_number(&serial_number)?;
+    cert_builder.set_subject_name(&x509_name)?;
+    cert_builder.set_issuer_name(&x509_name)?;
+    cert_builder.set_pubkey(&privkey)?;
+    let not_before = Asn1Time::days_from_now(0)?;
+    cert_builder.set_not_before(&not_before)?;
+    let not_after = Asn1Time::days_from_now(365)?;
+    cert_builder.set_not_after(&not_after)?;
+
+    cert_builder.append_extension(BasicConstraints::new().critical().ca().build()?)?;
+    cert_builder.append_extension(
+        KeyUsage::new()
+            .critical()
+            .key_cert_sign()
+            .crl_sign()
+            .build()?,
+    )?;
+
+    let subject_key_identifier =
+        SubjectKeyIdentifier::new().build(&cert_builder.x509v3_context(None, None))?;
+    cert_builder.append_extension(subject_key_identifier)?;
+
+    cert_builder.sign(&privkey, MessageDigest::sha256())?;
+    let cert = cert_builder.build();
+
+    Ok((cert, privkey))
+}
+
+/// Make a X509 request with the given private key
+fn mk_request(privkey: &PKey<Private>) -> Result<X509Req, ErrorStack> {
+    let mut req_builder = X509ReqBuilder::new()?;
+    req_builder.set_pubkey(&privkey)?;
+
+    let mut x509_name = X509NameBuilder::new()?;
+    x509_name.append_entry_by_text("C", "US")?;
+    x509_name.append_entry_by_text("ST", "TX")?;
+    x509_name.append_entry_by_text("O", "Edgedb Test")?;
+    x509_name.append_entry_by_text("CN", "edgedb-test-http")?;
+    let x509_name = x509_name.build();
+    req_builder.set_subject_name(&x509_name)?;
+
+    req_builder.sign(&privkey, MessageDigest::sha256())?;
+    let req = req_builder.build();
+    Ok(req)
+}
+
+/// Make a certificate and private key signed by the given CA cert and private key
+fn mk_ca_signed_cert(
+    ca_cert: &X509Ref,
+    ca_privkey: &PKeyRef<Private>,
+) -> Result<(X509, PKey<Private>), ErrorStack> {
+    let rsa = Rsa::generate(2048)?;
+    let privkey = PKey::from_rsa(rsa)?;
+
+    let req = mk_request(&privkey)?;
+
+    let mut cert_builder = X509::builder()?;
+    cert_builder.set_version(2)?;
+    let serial_number = {
+        let mut serial = BigNum::new()?;
+        serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
+        serial.to_asn1_integer()?
+    };
+    cert_builder.set_serial_number(&serial_number)?;
+    cert_builder.set_subject_name(req.subject_name())?;
+    cert_builder.set_issuer_name(ca_cert.subject_name())?;
+    cert_builder.set_pubkey(&privkey)?;
+    let not_before = Asn1Time::days_from_now(0)?;
+    cert_builder.set_not_before(&not_before)?;
+    let not_after = Asn1Time::days_from_now(365)?;
+    cert_builder.set_not_after(&not_after)?;
+
+    cert_builder.append_extension(BasicConstraints::new().build()?)?;
+
+    cert_builder.append_extension(
+        KeyUsage::new()
+            .critical()
+            .non_repudiation()
+            .digital_signature()
+            .key_encipherment()
+            .build()?,
+    )?;
+
+    let subject_key_identifier =
+        SubjectKeyIdentifier::new().build(&cert_builder.x509v3_context(Some(ca_cert), None))?;
+    cert_builder.append_extension(subject_key_identifier)?;
+
+    let auth_key_identifier = AuthorityKeyIdentifier::new()
+        .keyid(false)
+        .issuer(false)
+        .build(&cert_builder.x509v3_context(Some(ca_cert), None))?;
+    cert_builder.append_extension(auth_key_identifier)?;
+
+    let subject_alt_name = SubjectAlternativeName::new()
+        .dns("edgedb-test-http")
+        .build(&cert_builder.x509v3_context(Some(ca_cert), None))?;
+    cert_builder.append_extension(subject_alt_name)?;
+
+    cert_builder.sign(&ca_privkey, MessageDigest::sha256())?;
+    let cert = cert_builder.build();
+
+    Ok((cert, privkey))
+}
+
+impl Certs {
+    pub fn new() -> anyhow::Result<Certs> {
+        let (ca_cert, ca_privkey) = mk_ca_cert()?;
+        let (cert, privkey) = mk_ca_signed_cert(&ca_cert, &ca_privkey)?;
+        Ok(Certs {
+            ca_cert: ca_cert.to_pem()?,
+            nginx_cert: cert.to_pem()?,
+            nginx_key: privkey.private_key_to_pem_pkcs8()?,
+        })
+    }
+}

--- a/tests/server/debian.rs
+++ b/tests/server/debian.rs
@@ -7,6 +7,9 @@ pub fn dockerfile(codename: &str) -> String {
         FROM debian:{codename}
         RUN apt-get update
         RUN apt-get install -y ca-certificates sudo gnupg2 apt-transport-https
+        RUN adduser --uid 1000 --home /home/user \
+            --shell /bin/bash --ingroup users --gecos "EdgeDB Test User" \
+            user
         ADD ./edgedb /usr/bin/edgedb
         ADD ./sudoers /etc/sudoers
     "###, codename=codename)
@@ -19,6 +22,6 @@ pub fn dockerfile(codename: &str) -> String {
 fn sudo_install(codename: &str, nightly: bool) -> Result<(), anyhow::Error> {
     docker::sudo_test(
         &dockerfile(codename),
-        &format!("edgedb_server_test:{}_sudo", codename),
+        &format!("edgedb_test:{}_sudo", codename),
         nightly)
 }

--- a/tests/server/docker.rs
+++ b/tests/server/docker.rs
@@ -1,69 +1,127 @@
-use assert_cmd::Command;
-
-use std::fs;
 use std::env;
+use std::fs;
+use std::path::Path;
 
+use assert_cmd::Command;
 use tar::{Builder, Header};
 
-fn sudoers() -> &'static str {
+pub struct Context {
+    tar: Builder<Vec<u8>>,
+}
+
+pub fn sudoers() -> &'static str {
     r###"
         root        ALL=(ALL:ALL) SETENV: ALL
-        bin   	ALL=(ALL:ALL)	NOPASSWD: ALL  # for centos
-        daemon	ALL=(ALL:ALL)	NOPASSWD: ALL  # for ubuntu + debian
+        user        ALL=(ALL:ALL) NOPASSWD: ALL
     "###
 }
 
-fn make_context(dockerfile: &str, sudoers: &str)
-    -> Result<Vec<u8>, anyhow::Error>
+impl Context {
+    pub fn new() -> Context {
+        Context {
+            tar: Builder::new(Vec::with_capacity(1048576)),
+        }
+    }
+    pub fn add_file_mode(mut self, filename: impl AsRef<Path>,
+        data: impl AsRef<[u8]>, mode: u32)
+        -> anyhow::Result<Self>
+    {
+        let data = data.as_ref();
+        let filename = filename.as_ref();
+        let mut header = Header::new_gnu();
+        header.set_size(data.len() as u64);
+        header.set_path(filename)?;
+        header.set_mode(mode);
+        header.set_cksum();
+        self.tar.append(&header, data)?;
+        Ok(self)
+    }
+    pub fn add_file(self, filename: impl AsRef<Path>,
+        data: impl AsRef<[u8]>)
+        -> anyhow::Result<Self>
+    {
+        self.add_file_mode(filename, data, 0o644)
+    }
+    pub fn add_sudoers(self) -> anyhow::Result<Self> {
+        self.add_file("sudoers", sudoers())
+    }
+    pub fn add_bin(self) -> anyhow::Result<Self> {
+        self.add_file_mode("edgedb",
+            fs::read(env!("CARGO_BIN_EXE_edgedb"))?,
+            0o755)
+    }
+    pub fn build(mut self) -> anyhow::Result<Vec<u8>> {
+        self.tar.finish()?;
+        Ok(self.tar.into_inner()?)
+    }
+}
+
+pub fn build_image(context: Context, tagname: &str) -> anyhow::Result<()> {
+    Command::new("docker")
+        .arg("build").arg("-")
+        .arg("-t").arg(tagname)
+        .write_stdin(context.build()?)
+        .assert()
+        .success();
+    Ok(())
+}
+
+pub fn run_bg(container_name: &str, tagname: &str) -> std::process::Child {
+    std::process::Command::new("docker")
+        .arg("run")
+        .arg("--rm")
+        .arg("--name").arg(container_name)
+        .arg(tagname)
+        .spawn()
+        .expect("can run docker command")
+}
+
+pub fn stop(container_name: &str) {
+    Command::new("docker")
+        .arg("stop")
+        .arg(container_name)
+        .assert();
+}
+
+pub fn run(tagname: &str, script: &str) -> assert_cmd::assert::Assert {
+    Command::new("docker")
+        .arg("run")
+        .arg("--rm")
+        .arg("-u").arg("1000")
+        .arg(tagname)
+        .args(&["sh", "-exc", script])
+        .assert()
+}
+
+pub fn run_with(tagname: &str, script: &str, link: &str)
+    -> assert_cmd::assert::Assert
 {
-    let buf = Vec::with_capacity(1048576);
-    let mut arch = Builder::new(buf);
-
-    let mut header = Header::new_gnu();
-    header.set_size(dockerfile.len() as u64);
-    header.set_path("Dockerfile")?;
-    header.set_cksum();
-    arch.append(&header, dockerfile.as_bytes())?;
-
-    let mut header = Header::new_gnu();
-    header.set_size(sudoers.len() as u64);
-    header.set_path("sudoers")?;
-    header.set_cksum();
-    arch.append(&header, sudoers.as_bytes())?;
-
-    let bin = fs::read(env!("CARGO_BIN_EXE_edgedb"))?;
-    let mut header = Header::new_gnu();
-    header.set_size(bin.len() as u64);
-    header.set_path("edgedb")?;
-    header.set_mode(0o755);
-    header.set_cksum();
-    arch.append(&header, &bin[..])?;
-
-    arch.finish()?;
-    Ok(arch.into_inner()?)
+    Command::new("docker")
+        .arg("run")
+        .arg("--rm")
+        .arg("-u").arg("1000")
+        .arg(format!("--link={0}:{0}", link))
+        .arg(tagname)
+        .args(&["sh", "-exc", script])
+        .assert()
 }
 
 pub fn sudo_test(dockerfile: &str, tagname: &str, nightly: bool)
     -> Result<(), anyhow::Error>
 {
-    let context = make_context(&dockerfile, sudoers())?;
-    Command::new("docker")
-        .arg("build").arg("-")
-        .arg("-t").arg(tagname)
-        .write_stdin(context)
-        .assert()
-        .success();
-    Command::new("docker")
-        .args(&["run", "--rm", "-u", "1"])
-        .arg(tagname)
-        .args(&["sh", "-exc", &format!(r###"
-            RUST_LOG=info edgedb server install {arg}
-            echo --- DONE ---
-            edgedb-server --help
-        "###, arg=if nightly { "--nightly" } else {""})])
+    let context = Context::new()
+        .add_file("Dockerfile", dockerfile)?
+        .add_sudoers()?
+        .add_bin()?;
+    build_image(context, tagname)?;
+    run(tagname, &format!(
+            r###"
+                RUST_LOG=info edgedb server install {arg}
+                echo --- DONE ---
+                edgedb-server --help
+            "###, arg=if nightly { "--nightly" } else {""})
+        ).success()
         // add edgedb-server --version check since alpha3
-        .assert()
-        .success()
         .stdout(predicates::str::contains("--- DONE ---"))
         .stdout(predicates::function::function(|data: &str| {
             let tail = &data[data.find("--- DONE ---").unwrap()..];
@@ -76,23 +134,18 @@ pub fn sudo_test(dockerfile: &str, tagname: &str, nightly: bool)
 pub fn install_twice_test(dockerfile: &str, tagname: &str, nightly: bool)
     -> Result<(), anyhow::Error>
 {
-    let context = make_context(&dockerfile, sudoers())?;
-    Command::new("docker")
-        .arg("build").arg("-")
-        .arg("-t").arg(tagname)
-        .write_stdin(context)
-        .assert()
-        .success();
-    Command::new("docker")
-        .args(&["run", "--rm", "-u", "1"])
-        .arg(tagname)
-        .args(&["sh", "-exc", &format!(r###"
-            RUST_LOG=info edgedb server install {arg}
-            echo --- DONE --- 1>&2
-            RUST_LOG=info edgedb server install
-        "###, arg=if nightly { "--nightly" } else {""})])
-        .assert()
-        .code(51)
+    let context = Context::new()
+        .add_file("Dockerfile", dockerfile)?
+        .add_sudoers()?
+        .add_bin()?;
+    build_image(context, tagname)?;
+    run(tagname, &format!(
+            r###"
+                RUST_LOG=info edgedb server install {arg}
+                echo --- DONE --- 1>&2
+                RUST_LOG=info edgedb server install
+            "###, arg=if nightly { "--nightly" } else {""})
+        ).code(51)
         .stderr(predicates::str::contains("--- DONE ---"))
         .stderr(predicates::function::function(|data: &str| {
             let tail = &data[data.find("--- DONE ---").unwrap()..];

--- a/tests/server/main.rs
+++ b/tests/server/main.rs
@@ -1,5 +1,7 @@
 #[cfg(target_env="musl")]
 mod docker;
+#[cfg(target_env="musl")]
+mod certs;
 
 // Tests are running under musl, because we need to upload a CLI binary to the
 // docker container. The most universal way to do that is to build a static
@@ -10,4 +12,6 @@ mod ubuntu;
 mod debian;
 #[cfg(target_env="musl")]
 mod centos;
+#[cfg(target_env="musl")]
+mod self_install;
 

--- a/tests/server/self_install.rs
+++ b/tests/server/self_install.rs
@@ -1,0 +1,170 @@
+use std::fs;
+use std::process::{Child};
+use std::sync::Mutex;
+use std::thread::sleep;
+use std::time::Duration;
+
+use test_case::test_case;
+
+use crate::docker;
+use crate::certs::Certs;
+use once_cell::sync::Lazy;
+
+
+static HTTP: Lazy<HttpGuard> = Lazy::new(|| HttpGuard::start());
+
+const HTTP_CONTAINER: &str = "edgedb-test-http";
+
+struct HttpGuard {
+    certs: Certs,
+    shutdown_info: Mutex<ShutdownInfo>,
+}
+
+pub struct ShutdownInfo {
+    process: Child,
+}
+
+
+impl HttpGuard {
+    fn start() -> HttpGuard {
+        HttpGuard::_start().expect("can start http")
+    }
+    fn _start() -> anyhow::Result<HttpGuard> {
+        let certs = Certs::new()?;
+        docker::build_image(
+            docker::Context::new()
+                .add_file("Dockerfile", dockerfile_http())?
+                .add_file("default.conf", default_conf())?
+                .add_file("nginx-selfsigned.crt", &certs.nginx_cert)?
+                .add_file("nginx-selfsigned.key", &certs.nginx_key)?
+                .add_file("edgedb-init.sh", fs::read("./edgedb-init.sh")?)?
+                .add_sudoers()?
+                .add_bin()?,
+            "edgedb_test:http_server")?;
+        let process = docker::run_bg(
+            HTTP_CONTAINER, "edgedb_test:http_server");
+        shutdown_hooks::add_shutdown_hook(stop_process);
+        sleep(Duration::from_secs(1));
+        Ok(HttpGuard {
+            certs,
+            shutdown_info: Mutex::new(ShutdownInfo {
+                process,
+            }),
+        })
+    }
+    fn url(&self) -> &'static str {
+        // docker DNS
+        "https://edgedb-test-http"
+    }
+    fn container(&self) -> &'static str {
+        HTTP_CONTAINER
+    }
+    fn cert(&self) -> &[u8] {
+        &self.certs.ca_cert
+    }
+}
+
+pub fn dockerfile_centos(release: &str) -> String {
+    format!(r###"
+        FROM centos:{release}
+        RUN yum -y install sudo curl
+        ADD ./selfsigned.crt /etc/pki/ca-trust/source/anchors/selfsigned.crt
+        ADD ./sudoers /etc/sudoers
+        RUN update-ca-trust
+        RUN useradd --uid 1000 --home /home/user \
+            --shell /bin/bash --group users \
+            user
+        ENV EDGEDB_PKG_ROOT {url}
+    "###,
+        url=HTTP.url(),
+        release=release)
+}
+
+pub fn dockerfile_deb(distro: &str, codename: &str) -> String {
+    format!(r###"
+        FROM {distro}:{codename}
+        RUN apt-get update
+        RUN apt-get install -y ca-certificates curl \
+            sudo gnupg2 apt-transport-https
+        ADD ./selfsigned.crt /usr/local/share/ca-certificates/selfsigned.crt
+        ADD ./sudoers /etc/sudoers
+        RUN update-ca-certificates
+        RUN adduser --uid 1000 --home /home/user \
+            --shell /bin/bash --ingroup users \
+            user
+        ENV EDGEDB_PKG_ROOT {url}
+    "###,
+        url=HTTP.url(),
+        distro=distro,
+        codename=codename)
+}
+
+pub fn default_conf() -> &'static str {
+    r###"
+        server {
+                listen 80 default_server;
+                listen [::]:80 default_server;
+                listen 443 ssl http2 default_server;
+                listen [::]:443 ssl http2 default_server;
+                ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
+                ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
+                location / {
+                        root /http;
+                }
+                location = /404.html {
+                        internal;
+                }
+        }
+    "###
+}
+
+pub fn dockerfile_http() -> &'static str {
+    r###"
+        FROM nginx
+        ADD ./default.conf /etc/nginx/conf.d/default.conf
+        ADD ./nginx-selfsigned.crt /etc/ssl/certs/nginx-selfsigned.crt
+        ADD ./nginx-selfsigned.key /etc/ssl/private/nginx-selfsigned.key
+        ADD ./edgedb-init.sh /http/init.sh
+        ADD ./edgedb /http/dist/linux-x86_64/edgedb-cli_latest
+    "###
+}
+
+#[test_case("cli_bionic", dockerfile_deb("ubuntu", "bionic"))]
+#[test_case("cli_centos7", dockerfile_centos("7"))]
+#[test_case("cli_buster", dockerfile_deb("debian", "buster"))]
+fn cli_install(tagname: &str, dockerfile: String)
+    -> anyhow::Result<()>
+{
+    docker::build_image(
+        docker::Context::new()
+            .add_file("Dockerfile", dockerfile)?
+            .add_file("selfsigned.crt", HTTP.cert())?
+            .add_sudoers()?,
+        tagname)?;
+    docker::run_with(tagname,
+        &format!(r###"
+            echo "HOME $HOME"
+            whoami
+            cat /etc/passwd
+            curl --proto '=https' --tlsv1.2 -sSf {url}/init.sh | sh -s -- -y
+            . ~/.profile
+            echo --- DONE ---
+            edgedb --version
+        "###, url=HTTP.url()),
+        HTTP.container())
+        .success()
+        .stdout(predicates::str::contains("--- DONE ---"))
+        .stdout(predicates::function::function(|data: &str| {
+            let tail = &data[data.find("--- DONE ---").unwrap()..];
+            assert!(tail.contains(
+                concat!("edgedb-cli ", env!("CARGO_PKG_VERSION"))));
+            true
+        }));
+   Ok(())
+}
+
+extern fn stop_process() {
+    let mut sinfo = HTTP.shutdown_info.lock().expect("shutdown mutex works");
+    docker::stop(HTTP.container());
+    sinfo.process.wait().ok();
+}

--- a/tests/server/ubuntu.rs
+++ b/tests/server/ubuntu.rs
@@ -7,6 +7,9 @@ pub fn dockerfile(codename: &str) -> String {
         FROM ubuntu:{codename}
         RUN apt-get update
         RUN apt-get install -y ca-certificates sudo gnupg2 apt-transport-https
+        RUN adduser --uid 1000 --home /home/user \
+            --shell /bin/bash --ingroup users --gecos "EdgeDB Test User" \
+            user
         ADD ./edgedb /usr/bin/edgedb
         ADD ./sudoers /etc/sudoers
     "###, codename=codename)
@@ -22,7 +25,7 @@ fn sudo_install(codename: &str, nightly: bool)
 {
     docker::sudo_test(
         &dockerfile(codename),
-        &format!("edgedb_server_test:{}_sudo", codename),
+        &format!("edgedb_test:{}_sudo", codename),
         nightly)
 }
 
@@ -33,6 +36,6 @@ fn refuse_to_reinstall(codename: &str, nightly: bool)
 {
     docker::install_twice_test(
         &dockerfile(codename),
-        &format!("edgedb_server_test:{}_sudo", codename),
+        &format!("edgedb_test:{}_sudo", codename),
         nightly)
 }

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -145,3 +145,8 @@ containers:
     - !Container ubuntu
     - !Sh 'cargo install cargo-tree cargo-fuzz cargo-outdated cargo-bloat --root=/usr'
     environ: *environ
+
+  test_install:
+    setup:
+    - !Ubuntu focal
+    - !Install [ca-certificates, curl]


### PR DESCRIPTION
Mostly similar to Rust implementation, except:
1. On linuxes we install directly into `~/.local/bin` since we have only one binary
2. When run as root CLI is installed directly into `/usr/bin` instead of bailing out
3. On MacOS we install into `/usr/local` (untested yet)
4. Windows support is incomplete yet

#74 