### PR TITLE
Initial client refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-ctrlc"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907279f6e91a51c8ec7cac24711e8308f21da7c10c7700ca2f7e125694ed2df1"
+dependencies = [
+ "ctrlc",
+ "futures-core",
+]
+
+[[package]]
 name = "async-h1"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +511,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7"
+dependencies = [
+ "nix 0.17.0",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +592,7 @@ version = "1.0.0-alpha.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "async-ctrlc",
  "async-listen",
  "async-std",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ which = {version="3.1.1", default-features=false}
 linked-hash-map = "0.5.3"
 term = "0.5"
 libc = "0.2.68"
+async-ctrlc = {version="1.2.0", features=["stream"]}
 
 [dev-dependencies]
 assert_cmd = {git="https://github.com/tailhook/assert_cmd", branch="edgedb_20190513"}

--- a/src/client.rs
+++ b/src/client.rs
@@ -474,9 +474,9 @@ impl<'a> Sequence<'a> {
     }
 
     // TODO(tailhook) figure out if this is the best way
-    pub async fn err_sync(&mut self) -> Result<(), anyhow::Error> {
+    pub async fn err_sync(mut self) -> Result<(), anyhow::Error> {
         self.writer.send_messages(&[ClientMessage::Sync]).await?;
-        timeout(Duration::from_secs(10), self.reader.wait_ready()).await??;
+        timeout(Duration::from_secs(10), self.expect_ready()).await??;
         Ok(())
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::str;
 use std::sync::Arc;
 use std::time::{Instant, Duration};
+use std::path::PathBuf;
 
 use anyhow::{self, Context};
 use async_std::prelude::StreamExt;
@@ -26,26 +27,52 @@ use edgedb_protocol::queryable::{Queryable};
 use edgedb_protocol::value::Value;
 use edgedb_protocol::descriptors::OutputTypedesc;
 
-use crate::options::Options;
-use crate::reader::{QueryableDecoder, QueryResponse};
+use crate::reader::{self, QueryableDecoder, QueryResponse};
 use crate::server_params::PostgresAddress;
 
 pub use crate::reader::Reader;
 
 
+#[derive(Debug, thiserror::Error)]
+#[error("Connection is inconsistent state. Please reconnect.")]
+pub struct ConnectionDirty;
+
+
+#[derive(Debug, thiserror::Error)]
+#[error("Password required for the specified user/host")]
+pub struct PasswordRequired;
+
+
+pub trait Sealed {}  // TODO(tailhook) private
+pub trait PublicParam: Sealed + typemap::Key + typemap::DebugAny + Send {}
+
+
 pub struct Connection {
     stream: ByteStream,
+    input_buf: BytesMut,
+    output_buf: BytesMut,
+    params: TypeMap<dyn typemap::DebugAny + Send>,
+    dirty: bool,
+}
+
+pub(crate) struct Sequence<'a> {
+    pub writer: Writer<'a>,
+    pub reader: Reader<'a>,
+    dirty: &'a mut bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct Builder {
+    addr: Addr,
+    user: Option<String>,
+    password: Option<String>,
+    database: Option<String>,
+    wait: Option<Duration>,
 }
 
 pub struct Writer<'a> {
     stream: &'a ByteStream,
-    outbuf: BytesMut,
-}
-
-pub struct Client<'a> {
-    pub writer: Writer<'a>,
-    pub reader: Reader<&'a ByteStream>,
-    pub params: TypeMap<dyn typemap::DebugAny + Send>,
+    outbuf: &'a mut BytesMut,
 }
 
 #[derive(Debug)]
@@ -53,18 +80,62 @@ pub struct NoResultExpected {
     pub completion_message: Bytes,
 }
 
+#[derive(Debug, Clone)]
+pub enum Addr {
+    Tcp(String, u16),
+    Unix(PathBuf),
+}
 
-impl Connection {
-    async fn connect_tcp<A>(addrs: A, options: &Options)
-        -> Result<Connection, anyhow::Error>
-        where A: ToSocketAddrs+fmt::Debug,
+impl Builder {
+    pub fn new() -> Builder {
+        Builder {
+            addr: Addr::Tcp("127.0.0.1".into(), 5656),
+            user: None,
+            password: None,
+            database: None,
+            wait: None,
+        }
+    }
+    pub fn unix_addr(&mut self, path: impl Into<PathBuf>) -> &mut Self {
+        self.addr = Addr::Unix(path.into());
+        self
+    }
+    pub fn tcp_addr(&mut self, addr: impl Into<String>, port: u16)
+        -> &mut Self
+    {
+        self.addr = Addr::Tcp(addr.into(), port);
+        self
+    }
+    pub fn user(&mut self, user: impl Into<String>) -> &mut Self {
+        self.user = Some(user.into());
+        self
+    }
+    pub fn password(&mut self, password: impl Into<String>) -> &mut Self {
+        self.password = Some(password.into());
+        self
+    }
+    pub fn database(&mut self, database: impl Into<String>) -> &mut Self {
+        self.database = Some(database.into());
+        self
+    }
+    pub fn get_effective_database(&self) -> String {
+        self.database.as_ref().or(self.user.as_ref())
+            .map(|x| x.clone())
+            .unwrap_or_else(|| whoami::username())
+    }
+    pub fn wait_until_available(&mut self, time: Duration) -> &mut Self {
+        self.wait = Some(time);
+        self
+    }
+    async fn connect_tcp(&self, addr: impl ToSocketAddrs + fmt::Debug)
+        -> anyhow::Result<ByteStream>
     {
         let start = Instant::now();
         let conn = loop {
-            let cres = TcpStream::connect(&addrs).await;
+            let cres = TcpStream::connect(&addr).await;
             match cres {
                 Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
-                    if let Some(wait) = options.wait_until_available {
+                    if let Some(wait) = self.wait {
                         if wait > start.elapsed() {
                             continue;
                         } else {
@@ -74,112 +145,86 @@ impl Connection {
                         }
                     } else {
                         Err(e).with_context(
-                            || format!("Can't connect to {:?}", addrs))?;
+                            || format!("Can't connect to {:?}", addr))?;
                     }
                 }
                 Err(e) => {
                     Err(e).with_context(
-                        || format!("Can't connect to {:?}", addrs))?;
+                        || format!("Can't connect to {:?}", addr))?;
                 }
                 Ok(conn) => break conn,
             }
         };
-        let s = ByteStream::new_tcp_detached(conn);
-        s.set_nodelay(true)?;
-        Ok(Connection {
-            stream: s,
-        })
+        Ok(ByteStream::new_tcp_detached(conn))
     }
     #[cfg(unix)]
-    pub async fn from_options(options: &Options)
-        -> Result<Connection, anyhow::Error>
+    async fn connect_unix(&self, path: &PathBuf) -> anyhow::Result<ByteStream>
     {
         use async_std::os::unix::net::UnixStream;
 
-        let unix_host = options.host.contains("/");
-        if options.admin || unix_host {
-            let prefix = if unix_host {
-                &options.host
-            } else {
-                "/var/run/edgedb"
-            };
-            let path = if prefix.contains(".s.EDGEDB") {
-                // it's the full path
-                prefix.into()
-            } else {
-                if options.admin {
-                    format!("{}/.s.EDGEDB.admin.{}", prefix, options.port)
-                } else {
-                    format!("{}/.s.EDGEDB.{}", prefix, options.port)
-                }
-            };
-            let start = Instant::now();
-            let conn = loop {
-                let cres = UnixStream::connect(&path).await;
-                match cres {
-                    Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
-                        if let Some(wait) = options.wait_until_available {
-                            if wait > start.elapsed() {
-                                continue;
-                            } else {
-                                Err(e).context(format!("Can't establish \
-                                                        connection for {:?}",
-                                                        wait))?
-                            }
+        let start = Instant::now();
+        let conn = loop {
+            let cres = UnixStream::connect(&path).await;
+            match cres {
+                Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
+                    if let Some(wait) = self.wait {
+                        if wait > start.elapsed() {
+                            continue;
                         } else {
-                            Err(e).with_context(|| format!(
-                                "Can't connect to unix socket {:?}", path))?
+                            Err(e).context(format!("Can't establish \
+                                                    connection for {:?}",
+                                                    wait))?
                         }
-                    }
-                    Err(e) => {
+                    } else {
                         Err(e).with_context(|| format!(
                             "Can't connect to unix socket {:?}", path))?
                     }
-                    Ok(conn) => break conn,
                 }
-            };
-            let s = ByteStream::new_unix_detached(conn);
-            s.set_nodelay(true)?;
-            Ok(Connection {
-                stream: s,
-            })
-        } else {
-            Ok(Connection::connect_tcp(
-                (&options.host[..], options.port),
-                options,
-            ).await?)
-        }
-    }
-
-    #[cfg(windows)]
-    pub async fn from_options(options: &Options)
-        -> anyhow::Result<Connection>
-    {
-        Ok(Connection::connect_tcp(
-            (&options.host[..], options.port),
-            options,
-        ).await?)
-    }
-
-    pub async fn authenticate<'x>(&'x mut self, options: &Options,
-        database: &str)
-        -> Result<Client<'x>, anyhow::Error>
-    {
-        let (rd, stream) = (&self.stream, &self.stream);
-        let reader = Reader::new(rd, options.debug_print_frames);
-        let mut cli = Client {
-            reader,
-            writer: Writer {
-                outbuf: BytesMut::with_capacity(8912),
-                stream,
-            },
-            params: TypeMap::custom(),
+                Err(e) => {
+                    Err(e).with_context(|| format!(
+                        "Can't connect to unix socket {:?}", path))?
+                }
+                Ok(conn) => break conn,
+            }
         };
+        Ok(ByteStream::new_unix_detached(conn))
+    }
+    #[cfg(windows)]
+    async fn connect_unix(&self, _path: &PathBuf)
+        -> anyhow::Result<ByteStream>
+    {
+        anyhow::bail!("Unix socket are not supported on windows");
+    }
+    pub async fn connect(&self) -> anyhow::Result<Connection> {
+        let user = if let Some(user) = &self.user {
+            user.clone()
+        } else {
+            whoami::username()
+        };
+        let database = if let Some(database) = &self.database {
+            database
+        } else {
+            &user
+        };
+        let sock = match &self.addr {
+            Addr::Tcp(host, port) => {
+                self.connect_tcp((host.as_ref(), *port)).await?
+            }
+            Addr::Unix(path) => self.connect_unix(path).await?,
+        };
+        let mut conn = Connection {
+            stream: sock,
+            input_buf: BytesMut::with_capacity(8192),
+            output_buf: BytesMut::with_capacity(8192),
+            params: TypeMap::custom(),
+            dirty: false,
+        };
+        let mut seq = conn.start_sequence().await?;
         let mut params = HashMap::new();
-        params.insert(String::from("user"), options.user.clone());
-        params.insert(String::from("database"), String::from(database));
+        params.insert(String::from("user"), user.clone());
+        params.insert(String::from("database"), database.clone());
 
-        cli.send_messages(&[
+        seq.send_messages(&[
             ClientMessage::ClientHandshake(ClientHandshake {
                 major_ver: 0,
                 minor_ver: 7,
@@ -188,18 +233,23 @@ impl Connection {
             }),
         ]).await?;
 
-        let mut msg = cli.reader.message().await?;
+        let mut msg = seq.message().await?;
         if let ServerMessage::ServerHandshake {..} = msg {
             eprintln!("WARNING: Connection negotiantion issue {:?}", msg);
             // TODO(tailhook) react on this somehow
-            msg = cli.reader.message().await?;
+            msg = seq.message().await?;
         }
         match msg {
             ServerMessage::Authentication(Authentication::Ok) => {}
             ServerMessage::Authentication(Authentication::Sasl { methods })
             => {
                 if methods.iter().any(|x| x == "SCRAM-SHA-256") {
-                    cli.scram(&options).await?;
+                    if let Some(password) = &self.password {
+                        scram(&mut seq, &user, password)
+                            .await?;
+                    } else {
+                        Err(PasswordRequired)?;
+                    }
                 } else {
                     return Err(anyhow::anyhow!("No supported authentication \
                         methods: {:?}", methods));
@@ -214,8 +264,9 @@ impl Connection {
             }
         }
 
+        let mut server_params = TypeMap::custom();
         loop {
-            let msg = cli.reader.message().await?;
+            let msg = seq.message().await?;
             match msg {
                 ServerMessage::ReadyForCommand(..) => break,
                 ServerMessage::ServerKeyData(_) => {
@@ -233,7 +284,7 @@ impl Connection {
                                     continue;
                                 }
                             };
-                            cli.params.insert::<PostgresAddress>(pgaddr);
+                            server_params.insert::<PostgresAddress>(pgaddr);
                         }
                         _ => {},
                     }
@@ -243,7 +294,57 @@ impl Connection {
                 }
             }
         }
-        Ok(cli)
+        seq.end_clean();
+        conn.params = server_params;
+        Ok(conn)
+    }
+
+}
+
+impl<'a> Sequence<'a> {
+
+    pub fn response<D: reader::Decode>(self, decoder: D)
+        -> QueryResponse<'a, D>
+    {
+        reader::QueryResponse {
+            seq: Some(self),
+            buffer: Vec::new(),
+            error: None,
+            complete: false,
+            decoder,
+        }
+    }
+
+    pub fn end_clean(self) {
+        *self.dirty = false;
+    }
+}
+
+impl Connection {
+    pub(crate) async fn start_sequence<'x>(&'x mut self)
+        -> anyhow::Result<Sequence<'x>>
+    {
+        if self.dirty {
+            anyhow::bail!("Connection is inconsistent state. \
+                Please reconnect.");
+        }
+        self.dirty = true;
+        let reader = Reader {
+            buf: &mut self.input_buf,
+            stream: &self.stream,
+        };
+        let writer = Writer {
+            outbuf: &mut self.output_buf,
+            stream: &self.stream,
+        };
+        Ok(Sequence { writer, reader, dirty: &mut self.dirty})
+    }
+
+    pub fn get_param<T: PublicParam>(&self)
+        -> Option<&<T as typemap::Key>::Value>
+        where <T as typemap::Key>::Value: Send + fmt::Debug
+    {
+        self.params.get::<T>()
     }
 }
 
@@ -263,88 +364,75 @@ impl<'a> Writer<'a> {
 
 }
 
-impl<'a> Client<'a> {
-    pub async fn scram(&mut self, options: &Options)
-        -> Result<(), anyhow::Error>
-    {
-        use edgedb_protocol::client_message::SaslInitialResponse;
-        use edgedb_protocol::client_message::SaslResponse;
-        use crate::options::Password::*;
+async fn scram(seq: &mut Sequence<'_>, user: &str, password: &str)
+    -> Result<(), anyhow::Error>
+{
+    use edgedb_protocol::client_message::SaslInitialResponse;
+    use edgedb_protocol::client_message::SaslResponse;
 
-        let password = match options.password {
-            NoPassword => return Err(anyhow::anyhow!("Password is required. \
-                Please specify --password or --password-from-stdin on the \
-                command-line.")),
-            FromTerminal => {
-                rpassword::read_password_from_tty(
-                    Some(&format!("Password for '{}': ",
-                                  options.user.escape_default())))?
-            }
-            Password(ref s) => s.clone(),
-        };
+    let scram = ScramClient::new(&user, &password, None);
 
-        let scram = ScramClient::new(&options.user, &password, None);
-
-        let (scram, first) = scram.client_first();
-        self.send_messages(&[
-            ClientMessage::AuthenticationSaslInitialResponse(
-                SaslInitialResponse {
-                method: "SCRAM-SHA-256".into(),
-                data: Bytes::copy_from_slice(first.as_bytes()),
-            }),
-        ]).await?;
-        let msg = self.reader.message().await?;
-        let data = match msg {
-            ServerMessage::Authentication(
-                Authentication::SaslContinue { data }
-            ) => data,
-            ServerMessage::ErrorResponse(err) => {
-                return Err(err.into());
-            }
-            msg => {
-                return Err(anyhow::anyhow!("Bad auth response: {:?}", msg));
-            }
-        };
-        let data = str::from_utf8(&data[..])
-            .map_err(|_| anyhow::anyhow!(
-                "invalid utf-8 in SCRAM-SHA-256 auth"))?;
-        let scram = scram.handle_server_first(&data)
-            .map_err(|e| anyhow::anyhow!("Authentication error: {}", e))?;
-        let (scram, data) = scram.client_final();
-        self.send_messages(&[
-            ClientMessage::AuthenticationSaslResponse(
-                SaslResponse {
-                    data: Bytes::copy_from_slice(data.as_bytes()),
-                }),
-        ]).await?;
-        let msg = self.reader.message().await?;
-        let data = match msg {
-            ServerMessage::Authentication(Authentication::SaslFinal { data })
-            => data,
-            ServerMessage::ErrorResponse(err) => {
-                return Err(anyhow::anyhow!(err));
-            }
-            msg => {
-                return Err(anyhow::anyhow!("Bad auth response: {:?}", msg));
-            }
-        };
-        let data = str::from_utf8(&data[..])
-            .map_err(|_| anyhow::anyhow!(
-                "invalid utf-8 in SCRAM-SHA-256 auth"))?;
-        scram.handle_server_final(&data)
-            .map_err(|e| anyhow::anyhow!("Authentication error: {}", e))?;
-        loop {
-            let msg = self.reader.message().await?;
-            match msg {
-                ServerMessage::Authentication(Authentication::Ok) => break,
-                msg => {
-                    eprintln!("WARNING: unsolicited message {:?}", msg);
-                }
-            };
+    let (scram, first) = scram.client_first();
+    seq.send_messages(&[
+        ClientMessage::AuthenticationSaslInitialResponse(
+            SaslInitialResponse {
+            method: "SCRAM-SHA-256".into(),
+            data: Bytes::copy_from_slice(first.as_bytes()),
+        }),
+    ]).await?;
+    let msg = seq.message().await?;
+    let data = match msg {
+        ServerMessage::Authentication(
+            Authentication::SaslContinue { data }
+        ) => data,
+        ServerMessage::ErrorResponse(err) => {
+            return Err(err.into());
         }
-        Ok(())
+        msg => {
+            return Err(anyhow::anyhow!("Bad auth response: {:?}", msg));
+        }
+    };
+    let data = str::from_utf8(&data[..])
+        .map_err(|_| anyhow::anyhow!(
+            "invalid utf-8 in SCRAM-SHA-256 auth"))?;
+    let scram = scram.handle_server_first(&data)
+        .map_err(|e| anyhow::anyhow!("Authentication error: {}", e))?;
+    let (scram, data) = scram.client_final();
+    seq.send_messages(&[
+        ClientMessage::AuthenticationSaslResponse(
+            SaslResponse {
+                data: Bytes::copy_from_slice(data.as_bytes()),
+            }),
+    ]).await?;
+    let msg = seq.message().await?;
+    let data = match msg {
+        ServerMessage::Authentication(Authentication::SaslFinal { data })
+        => data,
+        ServerMessage::ErrorResponse(err) => {
+            return Err(anyhow::anyhow!(err));
+        }
+        msg => {
+            return Err(anyhow::anyhow!("Bad auth response: {:?}", msg));
+        }
+    };
+    let data = str::from_utf8(&data[..])
+        .map_err(|_| anyhow::anyhow!(
+            "invalid utf-8 in SCRAM-SHA-256 auth"))?;
+    scram.handle_server_final(&data)
+        .map_err(|e| anyhow::anyhow!("Authentication error: {}", e))?;
+    loop {
+        let msg = seq.message().await?;
+        match msg {
+            ServerMessage::Authentication(Authentication::Ok) => break,
+            msg => {
+                eprintln!("WARNING: unsolicited message {:?}", msg);
+            }
+        };
     }
+    Ok(())
+}
 
+impl<'a> Sequence<'a> {
     pub async fn send_messages<'x, I>(&mut self, msgs: I)
         -> Result<(), anyhow::Error>
         where I: IntoIterator<Item=&'x ClientMessage>
@@ -352,31 +440,35 @@ impl<'a> Client<'a> {
         self.writer.send_messages(msgs).await
     }
 
+    pub async fn wait_ready(&mut self) -> Result<(), reader::ReadError> {
+        self.reader.wait_ready().await
+    }
+
+    pub fn message(&mut self) -> reader::MessageFuture<'_, 'a> {
+        self.reader.message()
+    }
+
+    // TODO(tailhook) figure out if this is the best way
     pub async fn err_sync(&mut self) -> Result<(), anyhow::Error> {
         self.writer.send_messages(&[ClientMessage::Sync]).await?;
         timeout(Duration::from_secs(10), self.reader.wait_ready()).await??;
         Ok(())
     }
 
-    pub async fn execute<S>(&mut self, request: S)
-        -> Result<Bytes, anyhow::Error>
-        where S: ToString,
-    {
-        self.send_messages(&[
-            ClientMessage::ExecuteScript(ExecuteScript {
-                headers: HashMap::new(),
-                script_text: request.to_string(),
-            }),
-        ]).await?;
+    pub async fn _process_exec(mut self) -> anyhow::Result<Bytes> {
         let status = loop {
             match self.reader.message().await? {
                 ServerMessage::CommandComplete(c) => {
                     self.reader.wait_ready().await?;
+                    self.end_clean();
                     break c.status_data;
                 }
                 ServerMessage::ErrorResponse(err) => {
+                    self.reader.wait_ready().await?;
+                    self.end_clean();
                     return Err(anyhow::anyhow!(err));
                 }
+                ServerMessage::Data(_) => { }
                 msg => {
                     eprintln!("WARNING: unsolicited message {:?}", msg);
                 }
@@ -461,108 +553,114 @@ impl<'a> Client<'a> {
         ]).await?;
         Ok(desc)
     }
+}
+
+impl Connection {
+    pub async fn execute<S>(&mut self, request: S)
+        -> Result<Bytes, anyhow::Error>
+        where S: ToString,
+    {
+        let mut seq = self.start_sequence().await?;
+        seq.send_messages(&[
+            ClientMessage::ExecuteScript(ExecuteScript {
+                headers: HashMap::new(),
+                script_text: request.to_string(),
+            }),
+        ]).await?;
+        let status = loop {
+            match seq.message().await? {
+                ServerMessage::CommandComplete(c) => {
+                    seq.wait_ready().await?;
+                    break c.status_data;
+                }
+                ServerMessage::ErrorResponse(err) => {
+                    return Err(anyhow::anyhow!(err));
+                }
+                msg => {
+                    eprintln!("WARNING: unsolicited message {:?}", msg);
+                }
+            }
+        };
+        seq.end_clean();
+        Ok(status)
+    }
 
     pub async fn query<R>(&mut self, request: &str, arguments: &Value)
-        -> Result<
-            QueryResponse<'_, &'a ByteStream, QueryableDecoder<R>>,
-            anyhow::Error
-        >
+        -> anyhow::Result<QueryResponse<'_, QueryableDecoder<R>>>
         where R: Queryable,
     {
-        let desc = self._query(request, arguments, IoFormat::Binary).await?;
+        let mut seq = self.start_sequence().await?;
+        let desc = seq._query(request, arguments, IoFormat::Binary).await?;
         match desc.root_pos() {
             Some(root_pos) => {
                 R::check_descriptor(
                     &desc.as_queryable_context(), root_pos)?;
-                Ok(self.reader.response(QueryableDecoder::new()))
+                Ok(seq.response(QueryableDecoder::new()))
             }
             None => {
-                Err(NoResultExpected {
-                    completion_message: self._process_exec().await?
-                })?
+                let completion_message = seq._process_exec().await?;
+                Err(NoResultExpected { completion_message })?
             }
         }
     }
 
     pub async fn query_json(&mut self, request: &str, arguments: &Value)
-        -> Result<
-            QueryResponse<'_, &'a ByteStream, QueryableDecoder<String>>,
-            anyhow::Error
-        >
+        -> anyhow::Result<QueryResponse<'_, QueryableDecoder<String>>>
     {
-        let desc = self._query(request, arguments, IoFormat::Json).await?;
+        let mut seq = self.start_sequence().await?;
+        let desc = seq._query(request, arguments, IoFormat::Json).await?;
         match desc.root_pos() {
             Some(root_pos) => {
                 String::check_descriptor(
                     &desc.as_queryable_context(), root_pos)?;
-                Ok(self.reader.response(QueryableDecoder::new()))
+                Ok(seq.response(QueryableDecoder::new()))
             }
             None => {
-                Err(NoResultExpected {
-                    completion_message: self._process_exec().await?
-                })?
+                let completion_message = seq._process_exec().await?;
+                Err(NoResultExpected { completion_message })?
             }
         }
     }
 
     pub async fn query_json_els(&mut self, request: &str, arguments: &Value)
         -> Result<
-            QueryResponse<'_, &'a ByteStream, QueryableDecoder<String>>,
+            QueryResponse<'_, QueryableDecoder<String>>,
             anyhow::Error
         >
     {
-        let desc = self._query(request, arguments,
+        let mut seq = self.start_sequence().await?;
+        let desc = seq._query(request, arguments,
             IoFormat::JsonElements).await?;
         match desc.root_pos() {
             Some(root_pos) => {
                 String::check_descriptor(
                     &desc.as_queryable_context(), root_pos)?;
-                Ok(self.reader.response(QueryableDecoder::new()))
+                Ok(seq.response(QueryableDecoder::new()))
             }
             None => {
-                Err(NoResultExpected {
-                    completion_message: self._process_exec().await?
-                })?
+                let completion_message = seq._process_exec().await?;
+                Err(NoResultExpected { completion_message })?
             }
         }
     }
 
     pub async fn query_dynamic(&mut self, request: &str, arguments: &Value)
-        -> Result<
-            QueryResponse<'_, &'a ByteStream, Arc<dyn Codec>>,
-            anyhow::Error
-        >
+        -> anyhow::Result<QueryResponse<'_, Arc<dyn Codec>>>
     {
-        let desc = self._query(request, arguments, IoFormat::Binary).await?;
+        let mut seq = self.start_sequence().await?;
+        let desc = seq._query(request, arguments, IoFormat::Binary).await?;
         let codec = desc.build_codec()?;
-        Ok(self.reader.response(codec))
+        Ok(seq.response(codec))
     }
 
-    pub async fn _process_exec(&mut self) -> Result<Bytes, anyhow::Error> {
-        let status = loop {
-            match self.reader.message().await? {
-                ServerMessage::CommandComplete(c) => {
-                    self.reader.wait_ready().await?;
-                    break c.status_data;
-                }
-                ServerMessage::ErrorResponse(err) => {
-                    return Err(anyhow::anyhow!(err));
-                }
-                ServerMessage::Data(_) => { }
-                msg => {
-                    eprintln!("WARNING: unsolicited message {:?}", msg);
-                }
-            }
-        };
-        Ok(status)
-    }
 
     #[allow(dead_code)]
     pub async fn execute_args(&mut self, request: &str, arguments: &Value)
         -> Result<Bytes, anyhow::Error>
     {
-        self._query(request, arguments, IoFormat::Binary).await?;
-        return self._process_exec().await;
+        let mut seq = self.start_sequence().await?;
+        seq._query(request, arguments, IoFormat::Binary).await?;
+        return seq._process_exec().await;
     }
 
     pub async fn get_version(&mut self) -> Result<String, anyhow::Error> {

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -9,7 +9,7 @@ use edgedb_protocol::server_message::ErrorResponse;
 use once_cell::sync::Lazy;
 use prettytable::{Table, Row, Cell};
 
-use crate::client::Client;
+use crate::client::Connection;
 use crate::commands::Options;
 use crate::repl;
 use crate::print::style::Styler;
@@ -495,7 +495,7 @@ fn list_settings(prompt: &mut repl::State) {
     table.printstd();
 }
 
-pub async fn execute<'x>(cli: &mut Client<'x>, cmd: &BackslashCmd,
+pub async fn execute(cli: &mut Connection, cmd: &BackslashCmd,
     prompt: &mut repl::State)
     -> Result<ExecuteResult, anyhow::Error>
 {

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -1,7 +1,6 @@
 use async_std::task;
 
 use crate::options::{Options, Command};
-use crate::client::Connection;
 use crate::non_interactive;
 use crate::commands;
 use crate::self_install;
@@ -21,10 +20,8 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
     match options.subcommand.as_ref().expect("subcommand is present") {
         Command::Common(cmd) => {
             task::block_on(async {
-                let mut conn = Connection::from_options(&options).await?;
-                let mut cli = conn.authenticate(
-                    &options, &options.database).await?;
-                commands::execute::common(&mut cli, cmd, &cmdopt).await?;
+                let mut conn = options.conn_params.connect().await?;
+                commands::execute::common(&mut conn, cmd, &cmdopt).await?;
                 Ok(())
             }).into()
         },
@@ -33,39 +30,31 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
         }
         Command::CreateSuperuserRole(opt) => {
             task::block_on(async {
-                let mut conn = Connection::from_options(&options).await?;
-                let mut cli = conn.authenticate(
-                    &options, &options.database).await?;
+                let mut conn = options.conn_params.connect().await?;
                 commands::roles::create_superuser(
-                    &mut cli, &cmdopt, opt).await?;
+                    &mut conn, &cmdopt, opt).await?;
                 Ok(())
             }).into()
         },
         Command::AlterRole(opt) => {
             task::block_on(async {
-                let mut conn = Connection::from_options(&options).await?;
-                let mut cli = conn.authenticate(
-                    &options, &options.database).await?;
-                commands::roles::alter(&mut cli, &cmdopt, opt).await?;
+                let mut conn = options.conn_params.connect().await?;
+                commands::roles::alter(&mut conn, &cmdopt, opt).await?;
                 Ok(())
             }).into()
         },
         Command::DropRole(opt) => {
             task::block_on(async {
-                let mut conn = Connection::from_options(&options).await?;
-                let mut cli = conn.authenticate(
-                    &options, &options.database).await?;
-                commands::roles::drop(&mut cli, &cmdopt, &opt.role).await?;
+                let mut conn = options.conn_params.connect().await?;
+                commands::roles::drop(&mut conn, &cmdopt, &opt.role).await?;
                 Ok(())
             }).into()
         },
         Command::Query(q) => {
             task::block_on(async {
-                let mut conn = Connection::from_options(&options).await?;
-                let mut cli = conn.authenticate(
-                    &options, &options.database).await?;
+                let mut conn = options.conn_params.connect().await?;
                 for query in &q.queries {
-                    non_interactive::query(&mut cli, query, &options).await?;
+                    non_interactive::query(&mut conn, query, &options).await?;
                 }
                 Ok(())
             }).into()

--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -1,12 +1,12 @@
 use edgeql_parser::helpers::{quote_string, quote_name};
 use crate::commands::Options;
 use crate::print;
-use crate::client::Client;
+use crate::client::Connection;
 use crate::commands::parser::{Configure, ConfigStr};
 use crate::commands::parser::{AuthParameter, PortParameter};
 
 
-async fn set_string(cli: &mut Client<'_>, name: &str, value: &ConfigStr)
+async fn set_string(cli: &mut Connection, name: &str, value: &ConfigStr)
     -> Result<(), anyhow::Error>
 {
     print::completion(&cli.execute(
@@ -16,7 +16,7 @@ async fn set_string(cli: &mut Client<'_>, name: &str, value: &ConfigStr)
     Ok(())
 }
 
-pub async fn configure(cli: &mut Client<'_>, _options: &Options,
+pub async fn configure(cli: &mut Connection, _options: &Options,
     cfg: &Configure)
     -> Result<(), anyhow::Error>
 {

--- a/src/commands/describe.rs
+++ b/src/commands/describe.rs
@@ -3,11 +3,11 @@ use async_std::prelude::StreamExt;
 use edgedb_protocol::value::Value;
 use crate::commands::Options;
 use crate::commands::helpers::quote_namespaced;
-use crate::client::Client;
+use crate::client::Connection;
 use crate::highlight;
 
 
-pub async fn describe<'x>(cli: &mut Client<'x>, options: &Options,
+pub async fn describe(cli: &mut Connection, options: &Options,
     name: &str, verbose: bool)
     -> Result<(), anyhow::Error>
 {

--- a/src/commands/dump.rs
+++ b/src/commands/dump.rs
@@ -78,7 +78,7 @@ pub async fn dump(cli: &mut Connection, _options: &Options, filename: &Path)
         let msg = seq.message().await?;
         match msg {
             ServerMessage::CommandComplete(..) => {
-                seq.wait_ready().await?;
+                seq.expect_ready().await?;
                 break;
             }
             ServerMessage::DumpBlock(packet) => {
@@ -103,6 +103,5 @@ pub async fn dump(cli: &mut Connection, _options: &Options, filename: &Path)
     if let Some(tmp_filename) = tmp_filename {
         fs::rename(tmp_filename, filename).await?;
     }
-    seq.end_clean();
     Ok(())
 }

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -2,12 +2,12 @@ use edgeql_parser::helpers::quote_name;
 
 use crate::commands::{self, Options};
 use crate::commands::parser::Common;
-use crate::client::Client;
+use crate::client::Connection;
 use crate::print;
 use crate::server_params::PostgresAddress;
 
 
-pub async fn common<'x>(cli: &mut Client<'x>, cmd: &Common, options: &Options)
+pub async fn common(cli: &mut Connection, cmd: &Common, options: &Options)
     -> Result<(), anyhow::Error>
 {
     use Common::*;
@@ -47,7 +47,7 @@ pub async fn common<'x>(cli: &mut Client<'x>, cmd: &Common, options: &Options)
                 &c.pattern, c.case_sensitive).await?;
         }
         Pgaddr => {
-            match cli.params.get::<PostgresAddress>() {
+            match cli.get_param::<PostgresAddress>() {
                 Some(addr) => {
                     println!("{}", serde_json::to_string_pretty(addr)?);
                 }

--- a/src/commands/list_aliases.rs
+++ b/src/commands/list_aliases.rs
@@ -6,7 +6,7 @@ use edgedb_derive::Queryable;
 use crate::commands::Options;
 use crate::commands::filter;
 use crate::table;
-use crate::client::Client;
+use crate::client::Connection;
 
 
 
@@ -17,7 +17,7 @@ struct Alias {
     klass: String,
 }
 
-pub async fn list_aliases<'x>(cli: &mut Client<'x>, options: &Options,
+pub async fn list_aliases(cli: &mut Connection, options: &Options,
     pattern: &Option<String>, system: bool, case_sensitive: bool,
     verbose: bool)
     -> Result<(), anyhow::Error>

--- a/src/commands/list_casts.rs
+++ b/src/commands/list_casts.rs
@@ -5,7 +5,7 @@ use prettytable::{Table, Row, Cell};
 use edgedb_derive::Queryable;
 use crate::commands::Options;
 use crate::commands::filter;
-use crate::client::Client;
+use crate::client::Connection;
 use crate::table;
 
 
@@ -18,7 +18,7 @@ struct Cast {
 }
 
 
-pub async fn list_casts<'x>(cli: &mut Client<'x>, options: &Options,
+pub async fn list_casts<'x>(cli: &mut Connection, options: &Options,
     pattern: &Option<String>, case_sensitive: bool)
     -> Result<(), anyhow::Error>
 {

--- a/src/commands/list_databases.rs
+++ b/src/commands/list_databases.rs
@@ -1,10 +1,10 @@
 use edgedb_protocol::value::Value;
 use crate::commands::Options;
 use crate::commands::list;
-use crate::client::Client;
+use crate::client::Connection;
 
 
-pub async fn list_databases<'x>(cli: &mut Client<'x>, options: &Options)
+pub async fn list_databases(cli: &mut Connection, options: &Options)
     -> Result<(), anyhow::Error>
 {
     let items = cli.query(

--- a/src/commands/list_indexes.rs
+++ b/src/commands/list_indexes.rs
@@ -5,7 +5,7 @@ use prettytable::{Table, Row, Cell};
 use edgedb_derive::Queryable;
 use crate::commands::Options;
 use crate::commands::filter;
-use crate::client::Client;
+use crate::client::Connection;
 use crate::table;
 
 
@@ -17,7 +17,7 @@ struct Index {
     subject_name: String,
 }
 
-pub async fn list_indexes<'x>(cli: &mut Client<'x>, options: &Options,
+pub async fn list_indexes(cli: &mut Connection, options: &Options,
     pattern: &Option<String>, system: bool, case_sensitive: bool,
     verbose: bool)
     -> Result<(), anyhow::Error>

--- a/src/commands/list_modules.rs
+++ b/src/commands/list_modules.rs
@@ -1,10 +1,10 @@
 use crate::commands::Options;
 use crate::commands::filter;
 use crate::commands::list;
-use crate::client::Client;
+use crate::client::Connection;
 
 
-pub async fn list_modules<'x>(cli: &mut Client<'x>, options: &Options,
+pub async fn list_modules(cli: &mut Connection, options: &Options,
     pattern: &Option<String>, case_sensitive: bool)
     -> Result<(), anyhow::Error>
 {

--- a/src/commands/list_object_types.rs
+++ b/src/commands/list_object_types.rs
@@ -5,7 +5,7 @@ use prettytable::{Table, Row, Cell};
 use edgedb_derive::Queryable;
 use crate::commands::Options;
 use crate::commands::filter;
-use crate::client::Client;
+use crate::client::Connection;
 use crate::table;
 
 
@@ -16,7 +16,7 @@ struct TypeRow {
     extending: String,
 }
 
-pub async fn list_object_types<'x>(cli: &mut Client<'x>, options: &Options,
+pub async fn list_object_types(cli: &mut Connection, options: &Options,
     pattern: &Option<String>, system: bool, case_sensitive: bool)
     -> Result<(), anyhow::Error>
 {

--- a/src/commands/list_ports.rs
+++ b/src/commands/list_ports.rs
@@ -5,7 +5,7 @@ use prettytable::{Table, Row, Cell};
 use edgedb_derive::Queryable;
 use edgedb_protocol::value::Value;
 use crate::commands::Options;
-use crate::client::Client;
+use crate::client::Connection;
 use crate::table;
 
 
@@ -20,7 +20,7 @@ struct PortRow {
     user: String,
 }
 
-pub async fn list_ports<'x>(cli: &mut Client<'x>, options: &Options)
+pub async fn list_ports<'x>(cli: &mut Connection, options: &Options)
     -> Result<(), anyhow::Error>
 {
     let mut items = cli.query::<PortRow>(r###"

--- a/src/commands/list_roles.rs
+++ b/src/commands/list_roles.rs
@@ -1,10 +1,10 @@
 use crate::commands::Options;
 use crate::commands::filter;
 use crate::commands::list;
-use crate::client::Client;
+use crate::client::Connection;
 
 
-pub async fn list_roles<'x>(cli: &mut Client<'x>, options: &Options,
+pub async fn list_roles<'x>(cli: &mut Connection, options: &Options,
     pattern: &Option<String>, case_sensitive: bool)
     -> Result<(), anyhow::Error>
 {

--- a/src/commands/list_scalar_types.rs
+++ b/src/commands/list_scalar_types.rs
@@ -5,7 +5,7 @@ use prettytable::{Table, Row, Cell};
 use edgedb_derive::Queryable;
 use crate::commands::Options;
 use crate::commands::filter;
-use crate::client::Client;
+use crate::client::Connection;
 use crate::table;
 
 
@@ -17,7 +17,7 @@ struct ScalarType {
     kind: String,
 }
 
-pub async fn list_scalar_types<'x>(cli: &mut Client<'x>, options: &Options,
+pub async fn list_scalar_types<'x>(cli: &mut Connection, options: &Options,
     pattern: &Option<String>, system: bool, case_sensitive: bool)
     -> Result<(), anyhow::Error>
 {

--- a/src/commands/psql.rs
+++ b/src/commands/psql.rs
@@ -3,15 +3,15 @@ use std::process::Command;
 use std::ffi::OsString;
 
 use anyhow::Context;
-use crate::client::Client;
+use crate::client::Connection;
 use crate::commands::Options;
 use crate::server_params::PostgresAddress;
 
 
-pub async fn psql<'x>(cli: &mut Client<'x>, _options: &Options)
+pub async fn psql<'x>(cli: &mut Connection, _options: &Options)
     -> Result<(), anyhow::Error>
 {
-    match cli.params.get::<PostgresAddress>() {
+    match cli.get_param::<PostgresAddress>() {
         Some(addr) => {
             let mut cmd = Command::new("psql");
             let path = if cfg!(feature="dev_mode") {

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -154,7 +154,6 @@ pub async fn restore<'x>(cli: &mut Connection, options: &Options,
             }
             ServerMessage::ErrorResponse(err) => {
                 seq.err_sync().await.ok();
-                seq.end_clean();
                 return Err(anyhow::anyhow!(err)
                     .context("Error initiating restore protocol"));
             }
@@ -170,8 +169,9 @@ pub async fn restore<'x>(cli: &mut Connection, options: &Options,
         .await;
     if let Err(..) = result {
         seq.err_sync().await.ok();
+    } else {
+        seq.end_clean();
     }
-    seq.end_clean();
     result
 }
 

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -154,6 +154,7 @@ pub async fn restore<'x>(cli: &mut Connection, options: &Options,
             }
             ServerMessage::ErrorResponse(err) => {
                 seq.err_sync().await.ok();
+                seq.end_clean();
                 return Err(anyhow::anyhow!(err)
                     .context("Error initiating restore protocol"));
             }

--- a/src/commands/roles.rs
+++ b/src/commands/roles.rs
@@ -1,6 +1,6 @@
 use edgeql_parser::helpers::{quote_string, quote_name};
 use crate::commands::Options;
-use crate::client::Client;
+use crate::client::Connection;
 use crate::options::{RoleParams};
 use crate::print;
 
@@ -30,7 +30,7 @@ fn process_params(options: &RoleParams) -> Result<Vec<String>, anyhow::Error> {
     Ok(result)
 }
 
-pub async fn create_superuser(cli: &mut Client<'_>, _options: &Options,
+pub async fn create_superuser(cli: &mut Connection, _options: &Options,
     role: &RoleParams)
     -> Result<(), anyhow::Error>
 {
@@ -52,7 +52,7 @@ pub async fn create_superuser(cli: &mut Client<'_>, _options: &Options,
     Ok(())
 }
 
-pub async fn alter(cli: &mut Client<'_>, _options: &Options,
+pub async fn alter(cli: &mut Connection, _options: &Options,
     role: &RoleParams)
     -> Result<(), anyhow::Error>
 {
@@ -72,7 +72,7 @@ pub async fn alter(cli: &mut Client<'_>, _options: &Options,
     Ok(())
 }
 
-pub async fn drop(cli: &mut Client<'_>, _options: &Options,
+pub async fn drop(cli: &mut Connection, _options: &Options,
     name: &str)
     -> Result<(), anyhow::Error>
 {

--- a/src/commands/type_names.rs
+++ b/src/commands/type_names.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use edgedb_derive::Queryable;
 use edgedb_protocol::value::Value;
-use crate::client::Client;
+use crate::client::Connection;
 
 
 #[derive(Queryable)]
@@ -15,7 +15,7 @@ struct Row {
 }
 
 
-pub async fn get_type_names<'x>(cli: &mut Client<'x>)
+pub async fn get_type_names(cli: &mut Connection)
     -> Result<HashMap<Uuid, String>, anyhow::Error>
 {
     let mut items = cli.query::<Row>(

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -468,6 +468,9 @@ async fn _interactive_main(options: &Options, state: &mut repl::State)
             }
             prompt::Input::Text(inp) => inp,
         };
+        if !state.in_transaction() {
+            state.ensure_connection().await?;
+        }
         for item in ToDo::new(&inp) {
             let result = match item {
                 ToDoItem::Backslash(text) => {

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::io;
 use std::mem::replace;
 use std::str;
 
@@ -9,8 +8,8 @@ use async_std::prelude::StreamExt;
 use async_std::io::stdout;
 use async_std::io::prelude::WriteExt;
 use async_std::sync::{channel};
-use colorful::Colorful;
 use bytes::{Bytes, BytesMut};
+use colorful::Colorful;
 
 use edgedb_protocol::client_message::ClientMessage;
 use edgedb_protocol::client_message::{Prepare, IoFormat, Cardinality};
@@ -30,29 +29,71 @@ use crate::variables::input_variables;
 use crate::error_display::print_query_error;
 use crate::outputs::tab_separated;
 
-use crate::client::Connection;
-
 
 const QUERY_OPT_IMPLICIT_LIMIT: u16 = 0xFF01;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Shutting down on user request")]
+pub struct CleanShutdown;
+
+struct ToDo<'a> {
+    tail: &'a str,
+}
+
+pub enum ToDoItem<'a> {
+    Query(&'a str),
+    Backslash(&'a str),
+}
+
+impl ToDo<'_> {
+    fn new(source: &str) -> ToDo {
+        ToDo { tail: source.trim() }
+    }
+}
+
+impl<'a> Iterator for ToDo<'a> {
+    type Item = ToDoItem<'a>;
+    fn next(&mut self) -> Option<ToDoItem<'a>> {
+        let tail = self.tail.trim_start();
+        if tail.starts_with("\\") {
+            let len = backslash::full_statement(&tail);
+            self.tail = &tail[len..];
+            return Some(ToDoItem::Backslash(&tail[..len]));
+        } else if tail.trim() == "" {
+            return None;
+        } else {
+            let len = full_statement(&tail.as_bytes(), None)
+                .unwrap_or(tail.len());
+            self.tail = &tail[len..];
+            return Some(ToDoItem::Query(&tail[..len]));
+        }
+    }
+}
 
 
 pub fn main(options: Options) -> Result<(), anyhow::Error> {
     let (control_wr, control_rd) = channel(1);
     let (repl_wr, repl_rd) = channel(1);
     let state = repl::State {
-        control: control_wr,
-        data: repl_rd,
+        prompt: repl::PromptRpc {
+            control: control_wr,
+            data: repl_rd,
+        },
         print: print::Config::new()
             .max_items(100)
             .colors(atty::is(atty::Stream::Stdout))
             .clone(),
         verbose_errors: false,
         last_error: None,
-        database: options.conn_params.get_effective_database(),
         implicit_limit: Some(100),
         output_mode: options.output_mode,
         input_mode: repl::InputMode::Emacs,
         history_limit: 100,
+        database: options.conn_params.get_effective_database(),
+        conn_params: options.conn_params.clone(),
+        last_version: None,
+        connection: None,
+        initial_text: "".into(),
     };
     let handle = task::spawn(_main(options, state));
     prompt::main(repl_wr, control_rd)?;
@@ -63,47 +104,44 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
 pub async fn _main(options: Options, mut state: repl::State)
     -> anyhow::Result<()>
 {
-    let mut banner = false;
-    let mut version = None;
-    loop {
-        let mut conn = options.conn_params.connect().await?;
-        let fetched_version = conn.get_version().await?;
-        if !banner || version.as_ref() != Some(&fetched_version) {
-            println!("{} {}",
-                "EdgeDB".light_gray(),
-                fetched_version[..].light_gray());
-            version = Some(fetched_version);
-        }
-        if !banner {
-            println!("{}", r#"Type "\?" for help."#.light_gray());
-            banner = true;
-        }
-        match _interactive_main(conn, &options, &mut state).await {
-            Ok(()) => return Ok(()),
-            Err(e) => {
-                if let Some(err) = e.downcast_ref::<backslash::ChangeDb>() {
-                    state.database = err.target.clone();
-                    continue;
-                }
-                if let Some(err) = e.downcast_ref::<ReadError>() {
-                    match err {
-                        ReadError::Eos => {
-                            eprintln!("Connection is broken. Reconnecting...");
-                            continue;
-                        }
-                        _ => {}
-                    }
-                }
-                if let Some(err) = e.downcast_ref::<io::Error>() {
-                    if err.kind() == io::ErrorKind::BrokenPipe {
-                        eprintln!("Connection is broken. Reconnecting...");
-                        continue;
-                    }
-                }
-                return Err(e);
+    let mut conn = state.conn_params.connect().await?;
+    let fetched_version = conn.get_version().await?;
+    println!("{} {}",
+        "EdgeDB".light_gray(),
+        fetched_version[..].light_gray());
+    state.last_version = Some(fetched_version);
+    println!("{}", r#"Type "\?" for help."#.light_gray());
+    state.connection = Some(conn);
+    match _interactive_main(&options, &mut state).await {
+        Ok(()) => return Ok(()),
+        Err(e) => {
+            if e.is::<CleanShutdown>() {
+                return Ok(());
             }
+            return Err(e);
         }
     }
+    /*{
+        Ok(()) => return Ok(()),
+        Err(e) => {
+            if let Some(err) = e.downcast_ref::<ReadError>() {
+                match err {
+                    ReadError::Eos => {
+                        eprintln!("Connection is broken. Reconnecting...");
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(err) = e.downcast_ref::<io::Error>() {
+                if err.kind() == io::ErrorKind::BrokenPipe {
+                    eprintln!("Connection is broken. Reconnecting...");
+                    continue;
+                }
+            }
+            return Err(e);
+        }
+    }
+    */
 }
 
 fn _check_json_limit(json: &serde_json::Value, path: &mut String, limit: usize)
@@ -153,317 +191,313 @@ fn check_json_limit(json: &serde_json::Value, path: &str, limit: usize) -> bool
     return true;
 }
 
-async fn _interactive_main(mut cli: Connection, options: &Options,
-    mut state: &mut repl::State)
-    -> Result<(), anyhow::Error>
+async fn execute_backslash(mut state: &mut repl::State, text: &str)
+    -> anyhow::Result<()>
+{
+    use backslash::ExecuteResult::*;
+
+    let cmd = match backslash::parse(text) {
+        Ok(cmd) => cmd,
+        Err(e) => {
+            eprintln!("Error parsing backslash command: {}",
+                      e.message);
+            // Quick-edit command on error
+            state.initial_text = text.into();
+            return Ok(());
+        }
+    };
+    let res = backslash::execute(&cmd.command, &mut state).await;
+    match res {
+        Ok(Skip) => {},
+        Ok(Quit) => {
+            state.terminate().await;
+            return Ok(());
+        }
+        Ok(Input(text)) => state.initial_text = text,
+        Err(e) => {
+            eprintln!("Error executing command: {}", e);
+            // Quick-edit command on error
+            state.initial_text = text.into();
+            state.last_error = Some(e);
+        }
+    }
+    Ok(())
+}
+
+async fn execute_query(options: &Options, mut state: &mut repl::State,
+    statement: &str)
+    -> anyhow::Result<()>
 {
     use crate::repl::OutputMode::*;
-    let mut initial = String::new();
+
     let statement_name = Bytes::from_static(b"");
 
+    let mut headers = HashMap::new();
+    if let Some(implicit_limit) = state.implicit_limit {
+        headers.insert(
+            QUERY_OPT_IMPLICIT_LIMIT,
+            Bytes::from(format!("{}", implicit_limit+1)));
+    }
+    let cli = state.connection.as_mut().expect("connection established");
+
+    let mut seq = cli.start_sequence().await?;
+    seq.send_messages(&[
+        ClientMessage::Prepare(Prepare {
+            headers,
+            io_format: match state.output_mode {
+                Default | TabSeparated => IoFormat::Binary,
+                Json => IoFormat::Json,
+                JsonElements => IoFormat::JsonElements,
+            },
+            expected_cardinality: Cardinality::Many,
+            statement_name: statement_name.clone(),
+            command_text: String::from(statement),
+        }),
+        ClientMessage::Flush,
+    ]).await?;
+
     loop {
-        let inp = match
-            state.edgeql_input(&replace(&mut initial, String::new())).await
-        {
-            prompt::Input::Eof => {
-                let mut seq = cli.start_sequence().await?;
-                seq.send_messages(&[ClientMessage::Terminate]).await?;
-                match seq.message().await {
-                    Err(ReadError::Eos) => {}
-                    Err(e) => {
-                        eprintln!("WARNING: error on terminate: {}", e);
-                    }
-                    Ok(msg) => {
-                        eprintln!("WARNING: unsolicited message {:?}", msg);
-                    }
-                }
+        let msg = seq.message().await?;
+        match msg {
+            ServerMessage::PrepareComplete(..) => {
+                break;
+            }
+            ServerMessage::ErrorResponse(err) => {
+                print_query_error(&err, statement, state.verbose_errors)?;
+                state.last_error = Some(err.into());
+                seq.err_sync().await?;
                 return Ok(());
             }
-            prompt::Input::Interrupt => continue,
-            prompt::Input::Text(inp) => inp,
-        };
-        if inp.trim().is_empty() {
-            continue;
+            _ => {
+                eprintln!("WARNING: unsolicited message {:?}", msg);
+            }
         }
-        let mut current_offset = 0;
-        'statement_loop: while inp[current_offset..].trim() != "" {
-            let inp_tail = &inp[current_offset..].trim_start();
-            current_offset = inp.len() - inp_tail.len();
-            if inp_tail.starts_with("\\") {
-                use backslash::ExecuteResult::*;
-                let len = backslash::full_statement(&inp_tail);
-                current_offset += len;
-                let cmd = match backslash::parse(&inp_tail[..len]) {
-                    Ok(cmd) => cmd,
-                    Err(e) => {
-                        eprintln!("Error parsing backslash command: {}",
-                                  e.message);
-                        if inp_tail[len..].trim().is_empty() {
-                            // Quick-edit command on error
-                            initial = inp_tail[..len].trim_start().into();
-                        }
-                        continue 'statement_loop;
-                    }
-                };
-                let res = backslash::execute(&mut cli,
-                    &cmd.command, &mut state).await;
-                match res {
-                    Ok(Skip) => continue,
-                    Ok(Quit) => return Ok(()),
-                    Ok(Input(text)) => initial = text,
-                    Err(e) => {
-                        if e.is::<backslash::ChangeDb>() {
-                            if !inp_tail[len..].trim().is_empty() {
-                                eprintln!("WARNING: subsequent commands after \
-                                           \\connect are ignored");
-                            }
-                            return Err(e);
-                        }
-                        eprintln!("Error executing command: {}", e);
-                        // Quick-edit command on error
-                        initial = inp.trim_start().into();
-                        state.last_error = Some(e);
+    }
+
+    seq.send_messages(&[
+        ClientMessage::DescribeStatement(DescribeStatement {
+            headers: HashMap::new(),
+            aspect: DescribeAspect::DataDescription,
+            statement_name: statement_name.clone(),
+        }),
+        ClientMessage::Flush,
+    ]).await?;
+
+    let data_description = loop {
+        let msg = seq.message().await?;
+        match msg {
+            ServerMessage::CommandDataDescription(data_desc) => {
+                break data_desc;
+            }
+            ServerMessage::ErrorResponse(err) => {
+                eprintln!("{}", err.display(state.verbose_errors));
+                state.last_error = Some(err.into());
+                seq.expect_ready().await?;
+                return Ok(());
+            }
+            _ => {
+                eprintln!("WARNING: unsolicited message {:?}", msg);
+            }
+        }
+    };
+    if options.debug_print_descriptors {
+        println!("Descriptor: {:?}", data_description);
+    }
+    let desc = data_description.output()?;
+    let indesc = data_description.input()?;
+    if options.debug_print_descriptors {
+        println!("InputDescr {:#?}", indesc.descriptors());
+        println!("Output Descr {:#?}", desc.descriptors());
+    }
+    let codec = desc.build_codec()?;
+    if options.debug_print_codecs {
+        println!("Codec {:#?}", codec);
+    }
+    let incodec = indesc.build_codec()?;
+    if options.debug_print_codecs {
+        println!("Input Codec {:#?}", incodec);
+    }
+
+    let input = match input_variables(&indesc, &mut state.prompt).await {
+        Ok(input) => input,
+        Err(e) => {
+            eprintln!("{:#}", e);
+            state.last_error = Some(e);
+            seq.end_clean();
+            return Ok(());
+        }
+    };
+
+    let mut arguments = BytesMut::with_capacity(8);
+    incodec.encode(&mut arguments, &input)?;
+
+    seq.send_messages(&[
+        ClientMessage::Execute(Execute {
+            headers: HashMap::new(),
+            statement_name: statement_name.clone(),
+            arguments: arguments.freeze(),
+        }),
+        ClientMessage::Sync,
+    ]).await?;
+
+    let mut items = seq.response(codec);
+    if desc.root_pos().is_none() {
+        match items.get_completion().await {
+            Ok(ref val) => print::completion(val),
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                state.last_error = Some(e.into());
+            }
+        }
+        return Ok(());
+    }
+
+    let mut cfg = state.print.clone();
+    if let Some((w, _h)) = term_size::dimensions_stdout() {
+        // update max_width each time
+        cfg.max_width(w);
+    }
+    match state.output_mode {
+        TabSeparated => {
+            let mut index = 0;
+            while let Some(row) = items.next().await.transpose()? {
+                if let Some(limit) = state.implicit_limit {
+                    if index >= limit {
+                        eprintln!("ERROR: Too many rows. Consider \
+                            putting an explicit LIMIT clause, \
+                            or increase the implicit limit \
+                            using `\\set limit`.");
+                        items.skip_remaining().await?;
+                        return Ok(());
                     }
                 }
-                continue 'statement_loop;
-            }
-            let slen = full_statement(&inp_tail.as_bytes(), None)
-                .unwrap_or(inp_tail.len());
-            let statement = &inp_tail[..slen];
-            current_offset += slen;
-            let mut headers = HashMap::new();
-            if let Some(implicit_limit) = state.implicit_limit {
-                headers.insert(
-                    QUERY_OPT_IMPLICIT_LIMIT,
-                    Bytes::from(format!("{}", implicit_limit+1)));
-            }
-
-            let mut seq = cli.start_sequence().await?;
-            seq.send_messages(&[
-                ClientMessage::Prepare(Prepare {
-                    headers,
-                    io_format: match state.output_mode {
-                        Default | TabSeparated => IoFormat::Binary,
-                        Json => IoFormat::Json,
-                        JsonElements => IoFormat::JsonElements,
-                    },
-                    expected_cardinality: Cardinality::Many,
-                    statement_name: statement_name.clone(),
-                    command_text: String::from(statement),
-                }),
-                ClientMessage::Flush,
-            ]).await?;
-
-            loop {
-                let msg = seq.message().await?;
-                match msg {
-                    ServerMessage::PrepareComplete(..) => {
-                        break;
-                    }
-                    ServerMessage::ErrorResponse(err) => {
-                        print_query_error(&err, statement, state.verbose_errors)?;
-                        state.last_error = Some(err.into());
-                        seq.err_sync().await?;
-                        continue 'statement_loop;
-                    }
-                    _ => {
-                        eprintln!("WARNING: unsolicited message {:?}", msg);
-                    }
-                }
-            }
-
-            seq.send_messages(&[
-                ClientMessage::DescribeStatement(DescribeStatement {
-                    headers: HashMap::new(),
-                    aspect: DescribeAspect::DataDescription,
-                    statement_name: statement_name.clone(),
-                }),
-                ClientMessage::Flush,
-            ]).await?;
-
-            let data_description = loop {
-                let msg = seq.message().await?;
-                match msg {
-                    ServerMessage::CommandDataDescription(data_desc) => {
-                        break data_desc;
-                    }
-                    ServerMessage::ErrorResponse(err) => {
-                        eprintln!("{}", err.display(state.verbose_errors));
-                        state.last_error = Some(err.into());
-                        seq.expect_ready().await?;
-                        continue 'statement_loop;
-                    }
-                    _ => {
-                        eprintln!("WARNING: unsolicited message {:?}", msg);
-                    }
-                }
-            };
-            if options.debug_print_descriptors {
-                println!("Descriptor: {:?}", data_description);
-            }
-            let desc = data_description.output()?;
-            let indesc = data_description.input()?;
-            if options.debug_print_descriptors {
-                println!("InputDescr {:#?}", indesc.descriptors());
-                println!("Output Descr {:#?}", desc.descriptors());
-            }
-            let codec = desc.build_codec()?;
-            if options.debug_print_codecs {
-                println!("Codec {:#?}", codec);
-            }
-            let incodec = indesc.build_codec()?;
-            if options.debug_print_codecs {
-                println!("Input Codec {:#?}", incodec);
-            }
-
-            let input = match input_variables(&indesc, state).await {
-                Ok(input) => input,
-                Err(e) => {
-                    eprintln!("{:#}", e);
-                    state.last_error = Some(e);
-                    seq.end_clean();
-                    continue 'statement_loop;
-                }
-            };
-
-            let mut arguments = BytesMut::with_capacity(8);
-            incodec.encode(&mut arguments, &input)?;
-
-            seq.send_messages(&[
-                ClientMessage::Execute(Execute {
-                    headers: HashMap::new(),
-                    statement_name: statement_name.clone(),
-                    arguments: arguments.freeze(),
-                }),
-                ClientMessage::Sync,
-            ]).await?;
-
-            let mut items = seq.response(codec);
-            if desc.root_pos().is_none() {
-                match items.get_completion().await {
-                    Ok(ref val) => print::completion(val),
+                let mut text = match tab_separated::format_row(&row) {
+                    Ok(text) => text,
                     Err(e) => {
                         eprintln!("Error: {}", e);
-                        state.last_error = Some(e.into());
+                        // exhaust the iterator to get connection in the
+                        // consistent state
+                        items.skip_remaining().await?;
+                        return Ok(());
+                    }
+                };
+                // trying to make writes atomic if possible
+                text += "\n";
+                stdout().write_all(text.as_bytes()).await?;
+                index += 1;
+            }
+        }
+        Default => {
+            match print::native_to_stdout(items, &cfg).await {
+                Ok(()) => {}
+                Err(e) => {
+                    match e {
+                        PrintError::StreamErr {
+                            source: ReadError::RequestError {
+                                ref error, ..},
+                            ..
+                        } => {
+                            eprintln!("{}", error);
+                        }
+                        _ => eprintln!("{:#?}", e),
+                    }
+                    state.last_error = Some(e.into());
+                    return Ok(());
+                }
+            }
+            println!();
+        }
+        Json => {
+            while let Some(row) = items.next().await.transpose()? {
+                let text = match row {
+                    Value::Str(s) => s,
+                    _ => return Err(anyhow::anyhow!(
+                        "postres returned non-string in JSON mode")),
+                };
+                let jitems: serde_json::Value;
+                jitems = serde_json::from_str(&text)
+                    .context("cannot decode json result")?;
+                if let Some(limit) = state.implicit_limit {
+                    if !check_json_limit(&jitems, "", limit) {
+                        items.skip_remaining().await?;
+                        return Ok(());
                     }
                 }
-                continue 'statement_loop;
+                let jitems = jitems.as_array()
+                    .ok_or_else(|| anyhow::anyhow!(
+                        "non-array returned from \
+                         postgres in JSON mode"))?;
+                // trying to make writes atomic if possible
+                let mut data = print::json_to_string(jitems, &cfg)?;
+                data += "\n";
+                stdout().write_all(data.as_bytes()).await?;
             }
+        }
+        JsonElements => {
+            let mut index = 0;
+            while let Some(row) = items.next().await.transpose()? {
+                let text = match row {
+                    Value::Str(s) => s,
+                    _ => return Err(anyhow::anyhow!(
+                        "postgres returned non-string in JSON mode")),
+                };
+                let value: serde_json::Value;
+                value = serde_json::from_str(&text)
+                    .context("cannot decode json result")?;
+                let path = format!(".[{}]", index);
+                if let Some(limit) = state.implicit_limit {
+                    if index >= limit {
+                        print_json_limit_error(&path);
+                        items.skip_remaining().await?;
+                        return Ok(());
+                    }
+                    if !check_json_limit(&value, &path, limit) {
+                        items.skip_remaining().await?;
+                        return Ok(());
+                    }
+                }
+                // trying to make writes atomic if possible
+                let mut data;
+                data = print::json_item_to_string(&value, &cfg)?;
+                data += "\n";
+                stdout().write_all(data.as_bytes()).await?;
+                index += 1;
+            }
+        }
+    }
+    state.last_error = None;
+    return Ok(());
+}
 
-            let mut cfg = state.print.clone();
-            if let Some((w, _h)) = term_size::dimensions_stdout() {
-                // update max_width each time
-                cfg.max_width(w);
+async fn _interactive_main(options: &Options, state: &mut repl::State)
+    -> Result<(), anyhow::Error>
+{
+    loop {
+        state.ensure_connection().await?;
+        let cur_initial = replace(&mut state.initial_text, String::new());
+        let inp = match state.edgeql_input(&cur_initial).await {
+            prompt::Input::Eof => {
+                state.terminate().await;
+                return Err(CleanShutdown)?;
             }
-            match state.output_mode {
-                TabSeparated => {
-                    let mut index = 0;
-                    while let Some(row) = items.next().await.transpose()? {
-                        if let Some(limit) = state.implicit_limit {
-                            if index >= limit {
-                                eprintln!("ERROR: Too many rows. Consider \
-                                    putting an explicit LIMIT clause, \
-                                    or increase the implicit limit \
-                                    using `\\set limit`.");
-                                items.skip_remaining().await?;
-                                continue 'statement_loop;
-                            }
-                        }
-                        let mut text = match tab_separated::format_row(&row) {
-                            Ok(text) => text,
-                            Err(e) => {
-                                eprintln!("Error: {}", e);
-                                // exhaust the iterator to get connection in the
-                                // consistent state
-                                items.skip_remaining().await?;
-                                continue 'statement_loop;
-                            }
-                        };
-                        // trying to make writes atomic if possible
-                        text += "\n";
-                        stdout().write_all(text.as_bytes()).await?;
-                        index += 1;
-                    }
+            prompt::Input::Interrupt => {
+                if state.in_transaction() {
+                    eprintln!("WARNING: Transaction cancelled")
                 }
-                Default => {
-                    match print::native_to_stdout(items, &cfg).await {
-                        Ok(()) => {}
-                        Err(e) => {
-                            match e {
-                                PrintError::StreamErr {
-                                    source: ReadError::RequestError {
-                                        ref error, ..},
-                                    ..
-                                } => {
-                                    eprintln!("{}", error);
-                                }
-                                _ => eprintln!("{:#?}", e),
-                            }
-                            state.last_error = Some(e.into());
-                            continue 'statement_loop;
-                        }
-                    }
-                    println!();
+                state.reconnect().await?;
+                continue;
+            }
+            prompt::Input::Text(inp) => inp,
+        };
+        for item in ToDo::new(&inp) {
+            match item {
+                ToDoItem::Backslash(text) => {
+                    execute_backslash(state, text).await?;
                 }
-                Json => {
-                    while let Some(row) = items.next().await.transpose()? {
-                        let text = match row {
-                            Value::Str(s) => s,
-                            _ => return Err(anyhow::anyhow!(
-                                "postres returned non-string in JSON mode")),
-                        };
-                        let jitems: serde_json::Value;
-                        jitems = serde_json::from_str(&text)
-                            .context("cannot decode json result")?;
-                        if let Some(limit) = state.implicit_limit {
-                            if !check_json_limit(&jitems, "", limit) {
-                                items.skip_remaining().await?;
-                                continue 'statement_loop;
-                            }
-                        }
-                        let jitems = jitems.as_array()
-                            .ok_or_else(|| anyhow::anyhow!(
-                                "non-array returned from \
-                                 postgres in JSON mode"))?;
-                        // trying to make writes atomic if possible
-                        let mut data = print::json_to_string(jitems, &cfg)?;
-                        data += "\n";
-                        stdout().write_all(data.as_bytes()).await?;
-                    }
-                }
-                JsonElements => {
-                    let mut index = 0;
-                    while let Some(row) = items.next().await.transpose()? {
-                        let text = match row {
-                            Value::Str(s) => s,
-                            _ => return Err(anyhow::anyhow!(
-                                "postres returned non-string in JSON mode")),
-                        };
-                        let value: serde_json::Value;
-                        value = serde_json::from_str(&text)
-                            .context("cannot decode json result")?;
-                        let path = format!(".[{}]", index);
-                        if let Some(limit) = state.implicit_limit {
-                            if index >= limit {
-                                print_json_limit_error(&path);
-                                items.skip_remaining().await?;
-                                continue 'statement_loop;
-                            }
-                            if !check_json_limit(&value, &path, limit) {
-                                items.skip_remaining().await?;
-                                continue 'statement_loop;
-                            }
-                        }
-                        // trying to make writes atomic if possible
-                        let mut data;
-                        data = print::json_item_to_string(&value, &cfg)?;
-                        data += "\n";
-                        stdout().write_all(data.as_bytes()).await?;
-                        index += 1;
-                    }
+                ToDoItem::Query(statement) => {
+                    execute_query(options, state, statement).await?;
                 }
             }
-            state.last_error = None;
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,16 @@ fn _main() -> Result<(), anyhow::Error> {
     }
 
     let opt = Options::from_args_and_env();
-    env_logger::init_from_env(env_logger::Env::default()
-        .default_filter_or("warn"));
+
+    let mut builder = env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or("warn")
+    );
+    if opt.debug_print_frames {
+        builder.filter_module("edgedb::incoming::frame",
+                              log::LevelFilter::Debug);
+    }
+    builder.init();
+
     if opt.subcommand.is_some() {
         commands::cli::main(opt)
     } else {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -96,8 +96,7 @@ impl State {
         match &self.connection {
             Some(c) if c.is_consistent() => {}
             Some(_) => {
-                eprintln!("Connection is in inconsistent state, \
-                    Reconnecting...");
+                eprintln!("Reconnecting...");
                 self.reconnect().await?;
             }
             None => {

--- a/src/server_params.rs
+++ b/src/server_params.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use typemap::Key;
 
+use crate::client::{Sealed, PublicParam};
+
 
 #[derive(Deserialize, Debug, Serialize)]
 pub struct PostgresAddress {
@@ -18,3 +20,6 @@ pub struct PostgresAddress {
 impl Key for PostgresAddress {
     type Value = PostgresAddress;
 }
+
+impl Sealed for PostgresAddress { }
+impl PublicParam for PostgresAddress { }

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -14,7 +14,7 @@ use crate::prompt;
 pub struct Canceled;
 
 
-pub async fn input_variables(desc: &InputTypedesc, state: &mut repl::State)
+pub async fn input_variables(desc: &InputTypedesc, state: &mut repl::PromptRpc)
     -> Result<Value, anyhow::Error>
 {
     if desc.is_empty_tuple() {
@@ -46,7 +46,7 @@ pub async fn input_variables(desc: &InputTypedesc, state: &mut repl::State)
 }
 
 async fn input_item(name: &str, mut item: &Descriptor, all: &InputTypedesc,
-    state: &mut repl::State)
+    state: &mut repl::PromptRpc)
     -> Result<Value, anyhow::Error>
 {
     match item {

--- a/tests/func/dump_restore.rs
+++ b/tests/func/dump_restore.rs
@@ -2,20 +2,27 @@ use crate::SERVER;
 
 #[test]
 fn dump_restore_cycle() {
+    println!("before");
     SERVER.admin_cmd().arg("create-database").arg("dump_01")
         .assert().success();
+    println!("dbcreated");
     SERVER.database_cmd("dump_01").arg("query")
         .arg("CREATE TYPE Hello { CREATE REQUIRED PROPERTY name -> str; }")
         .arg("INSERT Hello { name := 'world' }")
         .assert().success();
+    println!("Created");
     SERVER.database_cmd("dump_01").arg("dump").arg("dump_01.dump")
         .assert().success();
+    println!("dumped");
     SERVER.admin_cmd().arg("create-database").arg("restore_01")
         .assert().success();
+    println!("created2");
     SERVER.database_cmd("restore_01").arg("restore").arg("dump_01.dump")
         .assert().success();
+    println!("restored");
     SERVER.database_cmd("restore_01").arg("query")
         .arg("SELECT Hello.name")
         .assert().success()
         .stdout("\"world\"\n");
+    println!("query");
 }


### PR DESCRIPTION
Two major features:
1. Connection is now 'static (no borrowed `Client` any more)
2. If connection is errored in the middle of sequence of messages, like
   making a request, it's marked as "dirty" and is unusable any more (so
   messages can't go out of sync)

This includes few tools to manage dirty state, more things can be
improved later.