### PR TITLE
Remove reliance on GHA target matrix in nightly builds

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -10,58 +10,33 @@ on:
       - nightly
 
 jobs:
-<% if targets.linux %>
-  build-linux:
+<% for tgt in targets.linux %>
+  build-<< tgt.name >>:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [<% for tgt in targets.linux %>
-          << tgt.name >>,<% endfor %>
-        ]
-        include:<% for tgt in targets.linux %>
-          - target: << tgt.name >>
-            platform: << tgt.platform >>
-            platform_version: << tgt.platform_version >><% endfor %>
 
     steps:
-<% for tgt in targets.linux %>
-    - name: Build (${{ matrix.target }})
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/<< tgt.platform >><< "-{}".format(tgt.platform_version) if tgt.platform_version >>@master
-      if: matrix.target == '<< tgt.name >>'
       env:
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "<< tgt.platform >>"
+        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 <% if tgt.family == "generic" %>
         BUILD_GENERIC: true
 <% endif %>
-<% endfor %>
 
     - uses: actions/upload-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
-<% endif %>
-
-<% if targets.macos %>
-  build-macos:
+        name: builds-<< tgt.name >>
+        path: artifacts/<< tgt.name >>
+<% endfor %>
+<% for tgt in targets.macos %>
+  build-<< tgt.name >>:
     runs-on: macos-latest
     continue-on-error: true
-
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [<% for tgt in targets.macos %>
-          << tgt.name >>,<% endfor %>
-        ]
-        include:<% for tgt in targets.macos %>
-          - target: << tgt.name >>
-            platform: << tgt.platform >>
-            platform_version: << tgt.platform_version >><% endfor %>
 
     steps:
     - uses: actions/checkout@v1
@@ -99,13 +74,12 @@ jobs:
           /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
         sudo xcode-select -s /Library/Developer/CommandLineTools
 
-<% for tgt in targets.macos %>
-    - name: Build (${{ matrix.target }})
+    - name: Build
       env:
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "<< tgt.platform >>"
+        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
 <% if tgt.family == "generic" %>
@@ -114,66 +88,118 @@ jobs:
       run: |
         xcrun --show-sdk-path
         edgedb-pkg/integration/macos/build.sh
-<% endfor %>
+
     - uses: actions/upload-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
-<% endif %>
-
-<% if targets.linux %>
-  publish-linux:
-    needs: [build-linux]
+        name: builds-<< tgt.name >>
+        path: artifacts/<< tgt.name >>
+<% endfor %>
+<% for tgt in targets.linux %>
+  test-<< tgt.name >>:
+    needs: [build-<< tgt.name >>]
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [<% for tgt in targets.linux %>
-          << tgt.name >>,<% endfor %>
-        ]
-        include:<% for tgt in targets.linux %>
-          - target: << tgt.name >>
-            platform: << tgt.platform >>
-            platform_version: << tgt.platform_version >><% endfor %>
 
     steps:
     - uses: actions/download-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
+        name: builds-<< tgt.name >>
+        path: artifacts/<< tgt.name >>
 
-<% for tgt in targets.linux %>
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/<< tgt.platform >><< "-{}".format(tgt.platform_version) if tgt.platform_version >>@master
-      if: matrix.target == '<< tgt.name >>'
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/<< tgt.name >>@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-<% endfor %>
-<% endif %>
+        PKG_PLATFORM: "<< tgt.platform >>"
+        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
 
-<% if targets.macos %>
-  publish-macos:
-    needs: [build-macos]
+<% endfor %>
+<% for tgt in targets.macos %>
+  test-<< tgt.name >>:
+    needs: [build-<< tgt.name >>]
     runs-on: macos-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [<% for tgt in targets.macos %>
-          << tgt.name >>,<% endfor %>
-        ]
-        include:<% for tgt in targets.macos %>
-          - target: << tgt.name >>
-            platform: << tgt.platform >>
-            platform_version: << tgt.platform_version >><% endfor %>
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb/edgedb-pkg
+
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-<< tgt.name >>
+        path: artifacts/<< tgt.name >>
+
+    - name: Test
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "<< tgt.platform >>"
+        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
+      run: |
+        edgedb-pkg/integration/macos/test.sh
+<% endfor %>
+<% for tgt in targets.linux %>
+  publish-<< tgt.name >>:
+    needs: [test-<< tgt.name >>]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
+        name: builds-<< tgt.name >>
+        path: artifacts/<< tgt.name >>
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: << tgt.name >>
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/<< tgt.platform >><< "-{}".format(tgt.platform_version) if tgt.platform_version >>@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "<< tgt.platform >>"
+        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/<< tgt.name >>@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "<< tgt.platform >>"
+        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+    <% if tgt.name == 'debian-stretch' %>
+
+    - name: Publish Docker Image
+      uses: elgohr/Publish-Docker-Github-Action@2.6
+      with:
+        name: edgedb/edgedb:nightly
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        snapshot: true
+        workdir: dockerfile
+        buildargs: version=${{ steps.describe.outputs.version-slot }},subdist=.nightly
+    <% endif %>
+<% endfor %>
+<% for tgt in targets.macos %>
+  publish-<< tgt.name >>:
+    needs: [test-<< tgt.name >>]
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-<< tgt.name >>
+        path: artifacts/<< tgt.name >>
 
     - uses: actions/checkout@v1
       with:
@@ -181,15 +207,19 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-<% for tgt in targets.macos %>
-    - name: Publish (${{ matrix.target }})
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: << tgt.name >>
+
+    - name: Publish
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "<< tgt.platform >>"
+        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
       run: |
         edgedb-pkg/integration/macos/publish.sh
 <% endfor %>
-
-<% endif %>

--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -95,52 +95,8 @@ jobs:
         path: artifacts/<< tgt.name >>
 <% endfor %>
 <% for tgt in targets.linux %>
-  test-<< tgt.name >>:
-    needs: [build-<< tgt.name >>]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-<< tgt.name >>
-        path: artifacts/<< tgt.name >>
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/<< tgt.name >>@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "<< tgt.platform >>"
-        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
-
-<% endfor %>
-<% for tgt in targets.macos %>
-  test-<< tgt.name >>:
-    needs: [build-<< tgt.name >>]
-    runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb/edgedb-pkg
-
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-<< tgt.name >>
-        path: artifacts/<< tgt.name >>
-
-    - name: Test
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "<< tgt.platform >>"
-        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
-      run: |
-        edgedb-pkg/integration/macos/test.sh
-<% endfor %>
-<% for tgt in targets.linux %>
   publish-<< tgt.name >>:
-    needs: [test-<< tgt.name >>]
+    needs: [build-<< tgt.name >>]
     runs-on: ubuntu-latest
 
     steps:
@@ -164,35 +120,15 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/<< tgt.name >>@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "<< tgt.platform >>"
-        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
     - uses: actions/checkout@v1
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: edgedb/dockerfile
-    <% if tgt.name == 'debian-stretch' %>
-
-    - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@2.6
-      with:
-        name: edgedb/edgedb:nightly
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        snapshot: true
-        workdir: dockerfile
-        buildargs: version=${{ steps.describe.outputs.version-slot }},subdist=.nightly
-    <% endif %>
 <% endfor %>
 <% for tgt in targets.macos %>
   publish-<< tgt.name >>:
-    needs: [test-<< tgt.name >>]
+    needs: [build-<< tgt.name >>]
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,169 +11,172 @@ on:
 
 jobs:
 
-  build-linux:
+  build-debian-stretch:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [
-          debian-stretch,
-          debian-buster,
-          ubuntu-xenial,
-          ubuntu-bionic,
-          ubuntu-focal,
-          centos-7,
-          centos-8,
-          linux-x86_64,
-        ]
-        include:
-          - target: debian-stretch
-            platform: debian
-            platform_version: stretch
-          - target: debian-buster
-            platform: debian
-            platform_version: buster
-          - target: ubuntu-xenial
-            platform: ubuntu
-            platform_version: xenial
-          - target: ubuntu-bionic
-            platform: ubuntu
-            platform_version: bionic
-          - target: ubuntu-focal
-            platform: ubuntu
-            platform_version: focal
-          - target: centos-7
-            platform: centos
-            platform_version: 7
-          - target: centos-8
-            platform: centos
-            platform_version: 8
-          - target: linux-x86_64
-            platform: linux
-            platform_version: x86_64
 
     steps:
-
-    - name: Build (${{ matrix.target }})
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
-      if: matrix.target == 'debian-stretch'
       env:
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "stretch"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-debian-stretch
+        path: artifacts/debian-stretch
+
+  build-debian-buster:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
-      if: matrix.target == 'debian-buster'
       env:
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "buster"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-debian-buster
+        path: artifacts/debian-buster
+
+  build-ubuntu-xenial:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
-      if: matrix.target == 'ubuntu-xenial'
       env:
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "xenial"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-ubuntu-xenial
+        path: artifacts/ubuntu-xenial
+
+  build-ubuntu-bionic:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
-      if: matrix.target == 'ubuntu-bionic'
       env:
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "bionic"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-ubuntu-bionic
+        path: artifacts/ubuntu-bionic
+
+  build-ubuntu-focal:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
-      if: matrix.target == 'ubuntu-focal'
       env:
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "focal"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-ubuntu-focal
+        path: artifacts/ubuntu-focal
+
+  build-centos-7:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-7@master
-      if: matrix.target == 'centos-7'
       env:
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "7"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-centos-7
+        path: artifacts/centos-7
+
+  build-centos-8:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
-      if: matrix.target == 'centos-8'
       env:
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "8"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-centos-8
+        path: artifacts/centos-8
+
+  build-linux-x86_64:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linux-x86_64@master
-      if: matrix.target == 'linux-x86_64'
       env:
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "x86_64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
         BUILD_GENERIC: true
 
 
-
     - uses: actions/upload-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
+        name: builds-linux-x86_64
+        path: artifacts/linux-x86_64
 
 
-
-  build-macos:
+  build-macos-x86_64:
     runs-on: macos-latest
     continue-on-error: true
-
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [
-          macos-x86_64,
-        ]
-        include:
-          - target: macos-x86_64
-            platform: macos
-            platform_version: x86_64
 
     steps:
     - uses: actions/checkout@v1
@@ -211,13 +214,12 @@ jobs:
           /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
         sudo xcode-select -s /Library/Developer/CommandLineTools
 
-
-    - name: Build (${{ matrix.target }})
+    - name: Build
       env:
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "macos"
+        PKG_PLATFORM_VERSION: "x86_64"
         SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
 
@@ -229,154 +231,521 @@ jobs:
 
     - uses: actions/upload-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
+        name: builds-macos-x86_64
+        path: artifacts/macos-x86_64
 
 
-
-  publish-linux:
-    needs: [build-linux]
+  test-debian-stretch:
+    needs: [build-debian-stretch]
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [
-          debian-stretch,
-          debian-buster,
-          ubuntu-xenial,
-          ubuntu-bionic,
-          ubuntu-focal,
-          centos-7,
-          centos-8,
-          linux-x86_64,
-        ]
-        include:
-          - target: debian-stretch
-            platform: debian
-            platform_version: stretch
-          - target: debian-buster
-            platform: debian
-            platform_version: buster
-          - target: ubuntu-xenial
-            platform: ubuntu
-            platform_version: xenial
-          - target: ubuntu-bionic
-            platform: ubuntu
-            platform_version: bionic
-          - target: ubuntu-focal
-            platform: ubuntu
-            platform_version: focal
-          - target: centos-7
-            platform: centos
-            platform_version: 7
-          - target: centos-8
-            platform: centos
-            platform_version: 8
-          - target: linux-x86_64
-            platform: linux
-            platform_version: x86_64
 
     steps:
     - uses: actions/download-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
+        name: builds-debian-stretch
+        path: artifacts/debian-stretch
 
-
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/debian-stretch@master
-      if: matrix.target == 'debian-stretch'
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/debian-stretch@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "stretch"
 
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/debian-buster@master
-      if: matrix.target == 'debian-buster'
+
+  test-debian-buster:
+    needs: [build-debian-buster]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-debian-buster
+        path: artifacts/debian-buster
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "buster"
 
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-xenial@master
-      if: matrix.target == 'ubuntu-xenial'
+
+  test-ubuntu-xenial:
+    needs: [build-ubuntu-xenial]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-ubuntu-xenial
+        path: artifacts/ubuntu-xenial
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-xenial@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "xenial"
 
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-bionic@master
-      if: matrix.target == 'ubuntu-bionic'
+
+  test-ubuntu-bionic:
+    needs: [build-ubuntu-bionic]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-ubuntu-bionic
+        path: artifacts/ubuntu-bionic
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "bionic"
 
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-focal@master
-      if: matrix.target == 'ubuntu-focal'
+
+  test-ubuntu-focal:
+    needs: [build-ubuntu-focal]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-ubuntu-focal
+        path: artifacts/ubuntu-focal
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "focal"
 
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/centos-7@master
-      if: matrix.target == 'centos-7'
+
+  test-centos-7:
+    needs: [build-centos-7]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-centos-7
+        path: artifacts/centos-7
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/centos-7@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "7"
 
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/centos-8@master
-      if: matrix.target == 'centos-8'
+
+  test-centos-8:
+    needs: [build-centos-8]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-centos-8
+        path: artifacts/centos-8
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "8"
 
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      if: matrix.target == 'linux-x86_64'
+
+  test-linux-x86_64:
+    needs: [build-linux-x86_64]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-linux-x86_64
+        path: artifacts/linux-x86_64
+
+    - name: Test
+      uses: edgedb/edgedb-pkg/integration/linux/test/linux-x86_64@master
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "x86_64"
 
 
 
-
-  publish-macos:
-    needs: [build-macos]
+  test-macos-x86_64:
+    needs: [build-macos-x86_64]
     runs-on: macos-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [
-          macos-x86_64,
-        ]
-        include:
-          - target: macos-x86_64
-            platform: macos
-            platform_version: x86_64
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb/edgedb-pkg
+
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-macos-x86_64
+        path: artifacts/macos-x86_64
+
+    - name: Test
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "macos"
+        PKG_PLATFORM_VERSION: "x86_64"
+      run: |
+        edgedb-pkg/integration/macos/test.sh
+
+
+  publish-debian-stretch:
+    needs: [test-debian-stretch]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
+        name: builds-debian-stretch
+        path: artifacts/debian-stretch
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: debian-stretch
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/debian-stretch@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "stretch"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-stretch@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "stretch"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+    
+
+    - name: Publish Docker Image
+      uses: elgohr/Publish-Docker-Github-Action@2.6
+      with:
+        name: edgedb/edgedb:nightly
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        snapshot: true
+        workdir: dockerfile
+        buildargs: version=${{ steps.describe.outputs.version-slot }},subdist=.nightly
+    
+
+  publish-debian-buster:
+    needs: [test-debian-buster]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-debian-buster
+        path: artifacts/debian-buster
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: debian-buster
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/debian-buster@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "buster"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-buster@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "buster"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+    
+
+  publish-ubuntu-xenial:
+    needs: [test-ubuntu-xenial]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-ubuntu-xenial
+        path: artifacts/ubuntu-xenial
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: ubuntu-xenial
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-xenial@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "xenial"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-xenial@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "xenial"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+    
+
+  publish-ubuntu-bionic:
+    needs: [test-ubuntu-bionic]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-ubuntu-bionic
+        path: artifacts/ubuntu-bionic
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: ubuntu-bionic
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-bionic@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "bionic"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-bionic@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "bionic"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+    
+
+  publish-ubuntu-focal:
+    needs: [test-ubuntu-focal]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-ubuntu-focal
+        path: artifacts/ubuntu-focal
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: ubuntu-focal
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-focal@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "focal"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-focal@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "focal"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+    
+
+  publish-centos-7:
+    needs: [test-centos-7]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-centos-7
+        path: artifacts/centos-7
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: centos-7
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/centos-7@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "7"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-7@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "7"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+    
+
+  publish-centos-8:
+    needs: [test-centos-8]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-centos-8
+        path: artifacts/centos-8
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: centos-8
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/centos-8@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "8"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-8@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "8"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+    
+
+  publish-linux-x86_64:
+    needs: [test-linux-x86_64]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-linux-x86_64
+        path: artifacts/linux-x86_64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-x86_64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "x86_64"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - name: Test Published
+      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-x86_64@master
+      env:
+        PKG_SUBDIST: "nightly"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "x86_64"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+    
+
+
+  publish-macos-x86_64:
+    needs: [test-macos-x86_64]
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-macos-x86_64
+        path: artifacts/macos-x86_64
 
     - uses: actions/checkout@v1
       with:
@@ -384,15 +753,19 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: macos-x86_64
 
-    - name: Publish (${{ matrix.target }})
+    - name: Publish
       env:
         PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "macos"
+        PKG_PLATFORM_VERSION: "x86_64"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
       run: |
         edgedb-pkg/integration/macos/publish.sh
-
-
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -235,178 +235,8 @@ jobs:
         path: artifacts/macos-x86_64
 
 
-  test-debian-stretch:
-    needs: [build-debian-stretch]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-debian-stretch
-        path: artifacts/debian-stretch
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-stretch@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-
-
-  test-debian-buster:
-    needs: [build-debian-buster]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-debian-buster
-        path: artifacts/debian-buster
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-
-
-  test-ubuntu-xenial:
-    needs: [build-ubuntu-xenial]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-ubuntu-xenial
-        path: artifacts/ubuntu-xenial
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-xenial@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-
-
-  test-ubuntu-bionic:
-    needs: [build-ubuntu-bionic]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-ubuntu-bionic
-        path: artifacts/ubuntu-bionic
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-
-
-  test-ubuntu-focal:
-    needs: [build-ubuntu-focal]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-ubuntu-focal
-        path: artifacts/ubuntu-focal
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-focal@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-
-
-  test-centos-7:
-    needs: [build-centos-7]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-centos-7
-        path: artifacts/centos-7
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-7@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-
-
-  test-centos-8:
-    needs: [build-centos-8]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-centos-8
-        path: artifacts/centos-8
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-
-
-  test-linux-x86_64:
-    needs: [build-linux-x86_64]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-linux-x86_64
-        path: artifacts/linux-x86_64
-
-    - name: Test
-      uses: edgedb/edgedb-pkg/integration/linux/test/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-
-
-
-  test-macos-x86_64:
-    needs: [build-macos-x86_64]
-    runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb/edgedb-pkg
-
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-macos-x86_64
-        path: artifacts/macos-x86_64
-
-    - name: Test
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "macos"
-        PKG_PLATFORM_VERSION: "x86_64"
-      run: |
-        edgedb-pkg/integration/macos/test.sh
-
-
   publish-debian-stretch:
-    needs: [test-debian-stretch]
+    needs: [build-debian-stretch]
     runs-on: ubuntu-latest
 
     steps:
@@ -430,34 +260,14 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-stretch@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "stretch"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
     - uses: actions/checkout@v1
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: edgedb/dockerfile
-    
-
-    - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@2.6
-      with:
-        name: edgedb/edgedb:nightly
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        snapshot: true
-        workdir: dockerfile
-        buildargs: version=${{ steps.describe.outputs.version-slot }},subdist=.nightly
-    
 
   publish-debian-buster:
-    needs: [test-debian-buster]
+    needs: [build-debian-buster]
     runs-on: ubuntu-latest
 
     steps:
@@ -481,23 +291,14 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/debian-buster@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "debian"
-        PKG_PLATFORM_VERSION: "buster"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
     - uses: actions/checkout@v1
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: edgedb/dockerfile
-    
 
   publish-ubuntu-xenial:
-    needs: [test-ubuntu-xenial]
+    needs: [build-ubuntu-xenial]
     runs-on: ubuntu-latest
 
     steps:
@@ -521,23 +322,14 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-xenial@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "xenial"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
     - uses: actions/checkout@v1
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: edgedb/dockerfile
-    
 
   publish-ubuntu-bionic:
-    needs: [test-ubuntu-bionic]
+    needs: [build-ubuntu-bionic]
     runs-on: ubuntu-latest
 
     steps:
@@ -561,23 +353,14 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-bionic@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "bionic"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
     - uses: actions/checkout@v1
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: edgedb/dockerfile
-    
 
   publish-ubuntu-focal:
-    needs: [test-ubuntu-focal]
+    needs: [build-ubuntu-focal]
     runs-on: ubuntu-latest
 
     steps:
@@ -601,23 +384,14 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/ubuntu-focal@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "ubuntu"
-        PKG_PLATFORM_VERSION: "focal"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
     - uses: actions/checkout@v1
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: edgedb/dockerfile
-    
 
   publish-centos-7:
-    needs: [test-centos-7]
+    needs: [build-centos-7]
     runs-on: ubuntu-latest
 
     steps:
@@ -641,23 +415,14 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-7@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "7"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
     - uses: actions/checkout@v1
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: edgedb/dockerfile
-    
 
   publish-centos-8:
-    needs: [test-centos-8]
+    needs: [build-centos-8]
     runs-on: ubuntu-latest
 
     steps:
@@ -681,23 +446,14 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/centos-8@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "centos"
-        PKG_PLATFORM_VERSION: "8"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
     - uses: actions/checkout@v1
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: edgedb/dockerfile
-    
 
   publish-linux-x86_64:
-    needs: [test-linux-x86_64]
+    needs: [build-linux-x86_64]
     runs-on: ubuntu-latest
 
     steps:
@@ -721,24 +477,15 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - name: Test Published
-      uses: edgedb/edgedb-pkg/integration/linux/testpublished/linux-x86_64@master
-      env:
-        PKG_SUBDIST: "nightly"
-        PKG_PLATFORM: "linux"
-        PKG_PLATFORM_VERSION: "x86_64"
-        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
-
     - uses: actions/checkout@v1
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: edgedb/dockerfile
-    
 
 
   publish-macos-x86_64:
-    needs: [test-macos-x86_64]
+    needs: [build-macos-x86_64]
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
This mimics the change from https://github.com/edgedb/edgedb/pull/1518. It makes builds faster and more concurrent.