### PR TITLE
Remove reliance on GHA target matrix in release builds

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -45,7 +45,7 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       id: sdk1010cache
       with:
         path: ~/.cache/MacOSX10.10.sdk/
@@ -63,13 +63,13 @@ jobs:
       if: steps.sdk1010cache.outputs.cache-hit != 'true'
       run: |
         mkdir -p ~/.cache
-        rsync -a \
+        cp -a \
           /Applications/Xcode-6.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/ \
           ~/.cache/MacOSX10.10.sdk/
 
     - name: Select macOS SDK
       run: |
-        sudo rsync -a \
+        sudo cp -a \
           ~/.cache/MacOSX10.10.sdk/ \
           /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
         sudo xcode-select -s /Library/Developer/CommandLineTools

--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -1,23 +1,13 @@
-name: Build Test and Publish a Release
+name: Build, Test, and Publish a Release
 
 on:
   repository_dispatch:
     types: ["release"]
 
 jobs:
-<% if targets.linux %>
-  build-linux:
+<% for tgt in targets.linux %>
+  build-<< tgt.name >>:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [<% for tgt in targets.linux %>
-          << tgt.name >>,<% endfor %>
-        ]
-        include:<% for tgt in targets.linux %>
-          - target: << tgt.name >>
-            platform: << tgt.platform >>
-            platform_version: << tgt.platform_version >><% endfor %>
 
     steps:
     - name: Determine package version
@@ -26,60 +16,46 @@ jobs:
         BRANCH: "${{ github.event.client_payload.branch }}"
       run: echo ::set-output name=version::${BRANCH#releases/}
       id: whichver
-<% for tgt in targets.linux %>
-    - name: Build (${{ matrix.target }})
+
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/<< tgt.platform >><< "-{}".format(tgt.platform_version) if tgt.platform_version >>@master
-      if: matrix.target == '<< tgt.name >>'
       env:
         SRC_REF: "${{ github.event.client_payload.branch }}"
         PKG_VERSION: "${{ steps.whichver.outputs.version }}"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "<< tgt.platform >>"
+        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 <% if tgt.family == "generic" %>
         BUILD_GENERIC: true
 <% endif %>
-<% endfor %>
 
     - uses: actions/upload-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
-<% endif %>
-
-<% if targets.macos %>
-  build-macos:
+        name: builds-<< tgt.name >>
+        path: artifacts/<< tgt.name >>
+<% endfor %>
+<% for tgt in targets.macos %>
+  build-<< tgt.name >>:
     runs-on: macos-latest
     continue-on-error: true
 
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [<% for tgt in targets.macos %>
-          << tgt.name >>,<% endfor %>
-        ]
-        include:<% for tgt in targets.macos %>
-          - target: << tgt.name >>
-            platform: << tgt.platform >>
-            platform_version: << tgt.platform_version >><% endfor %>
-
     steps:
+    - name: Determine package version
+      shell: bash
+      env:
+        BRANCH: "${{ github.event.client_payload.branch }}"
+      run: echo ::set-output name=version::${BRANCH#releases/}
+      id: whichver
+
     - uses: actions/checkout@v1
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
-      id: whichver
-
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       id: sdk1010cache
       with:
         path: ~/.cache/MacOSX10.10.sdk/
@@ -97,25 +73,24 @@ jobs:
       if: steps.sdk1010cache.outputs.cache-hit != 'true'
       run: |
         mkdir -p ~/.cache
-        rsync -a \
+        cp -a \
           /Applications/Xcode-6.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/ \
           ~/.cache/MacOSX10.10.sdk/
 
     - name: Select macOS SDK
       run: |
-        sudo rsync -a \
+        sudo cp -a \
           ~/.cache/MacOSX10.10.sdk/ \
           /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
         sudo xcode-select -s /Library/Developer/CommandLineTools
 
-<% for tgt in targets.macos %>
-    - name: Build (${{ matrix.target }})
+    - name: Build
       env:
         SRC_REF: "${{ github.event.client_payload.branch }}"
         PKG_VERSION: "${{ steps.whichver.outputs.version }}"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "<< tgt.platform >>"
+        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
 <% if tgt.family == "generic" %>
@@ -124,65 +99,53 @@ jobs:
       run: |
         xcrun --show-sdk-path
         edgedb-pkg/integration/macos/build.sh
-<% endfor %>
+
     - uses: actions/upload-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
-<% endif %>
-
-<% if targets.linux %>
-  publish-linux:
-    needs: [build-linux]
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [<% for tgt in targets.linux %>
-          << tgt.name >>,<% endfor %>
-        ]
-        include:<% for tgt in targets.linux %>
-          - target: << tgt.name >>
-            platform: << tgt.platform >>
-            platform_version: << tgt.platform_version >><% endfor %>
-
-    steps:
-    - uses: actions/download-artifact@v1
-      with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
-
-<% for tgt in targets.linux %>
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/<< tgt.platform >><< "-{}".format(tgt.platform_version) if tgt.platform_version >>@master
-      if: matrix.target == '<< tgt.name >>'
-      env:
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+        name: builds-<< tgt.name >>
+        path: artifacts/<< tgt.name >>
 <% endfor %>
-<% endif %>
-
-<% if targets.macos %>
-  publish-macos:
-    needs: [build-macos]
-    runs-on: macos-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [<% for tgt in targets.macos %>
-          << tgt.name >>,<% endfor %>
-        ]
-        include:<% for tgt in targets.macos %>
-          - target: << tgt.name >>
-            platform: << tgt.platform >>
-            platform_version: << tgt.platform_version >><% endfor %>
+<% for tgt in targets.linux %>
+  publish-<< tgt.name >>:
+    needs: [build-<< tgt.name >>]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
+        name: builds-<< tgt.name >>
+        path: artifacts/<< tgt.name >>
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: << tgt.name >>
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/<< tgt.platform >><< "-{}".format(tgt.platform_version) if tgt.platform_version >>@master
+      env:
+        PKG_PLATFORM: "<< tgt.platform >>"
+        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+<% endfor %>
+<% for tgt in targets.macos %>
+  publish-<< tgt.name >>:
+    needs: [build-<< tgt.name >>]
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-<< tgt.name >>
+        path: artifacts/<< tgt.name >>
 
     - uses: actions/checkout@v1
       with:
@@ -190,14 +153,18 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-<% for tgt in targets.macos %>
-    - name: Publish (${{ matrix.target }})
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: << tgt.name >>
+
+    - name: Publish
       env:
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "<< tgt.platform >>"
+        PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
       run: |
         edgedb-pkg/integration/macos/publish.sh
 <% endfor %>
-
-<% endif %>

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -185,7 +185,7 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       id: sdk1010cache
       with:
         path: ~/.cache/MacOSX10.10.sdk/
@@ -203,13 +203,13 @@ jobs:
       if: steps.sdk1010cache.outputs.cache-hit != 'true'
       run: |
         mkdir -p ~/.cache
-        rsync -a \
+        cp -a \
           /Applications/Xcode-6.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/ \
           ~/.cache/MacOSX10.10.sdk/
 
     - name: Select macOS SDK
       run: |
-        sudo rsync -a \
+        sudo cp -a \
           ~/.cache/MacOSX10.10.sdk/ \
           /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
         sudo xcode-select -s /Library/Developer/CommandLineTools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build Test and Publish a Release
+name: Build, Test, and Publish a Release
 
 on:
   repository_dispatch:
@@ -6,46 +6,8 @@ on:
 
 jobs:
 
-  build-linux:
+  build-debian-stretch:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [
-          debian-stretch,
-          debian-buster,
-          ubuntu-xenial,
-          ubuntu-bionic,
-          ubuntu-focal,
-          centos-7,
-          centos-8,
-          linux-x86_64,
-        ]
-        include:
-          - target: debian-stretch
-            platform: debian
-            platform_version: stretch
-          - target: debian-buster
-            platform: debian
-            platform_version: buster
-          - target: ubuntu-xenial
-            platform: ubuntu
-            platform_version: xenial
-          - target: ubuntu-bionic
-            platform: ubuntu
-            platform_version: bionic
-          - target: ubuntu-focal
-            platform: ubuntu
-            platform_version: focal
-          - target: centos-7
-            platform: centos
-            platform_version: 7
-          - target: centos-8
-            platform: centos
-            platform_version: 8
-          - target: linux-x86_64
-            platform: linux
-            platform_version: x86_64
 
     steps:
     - name: Determine package version
@@ -55,142 +17,227 @@ jobs:
       run: echo ::set-output name=version::${BRANCH#releases/}
       id: whichver
 
-    - name: Build (${{ matrix.target }})
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
-      if: matrix.target == 'debian-stretch'
       env:
         SRC_REF: "${{ github.event.client_payload.branch }}"
         PKG_VERSION: "${{ steps.whichver.outputs.version }}"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "stretch"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-debian-stretch
+        path: artifacts/debian-stretch
+
+  build-debian-buster:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Determine package version
+      shell: bash
+      env:
+        BRANCH: "${{ github.event.client_payload.branch }}"
+      run: echo ::set-output name=version::${BRANCH#releases/}
+      id: whichver
+
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
-      if: matrix.target == 'debian-buster'
       env:
         SRC_REF: "${{ github.event.client_payload.branch }}"
         PKG_VERSION: "${{ steps.whichver.outputs.version }}"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "buster"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-debian-buster
+        path: artifacts/debian-buster
+
+  build-ubuntu-xenial:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Determine package version
+      shell: bash
+      env:
+        BRANCH: "${{ github.event.client_payload.branch }}"
+      run: echo ::set-output name=version::${BRANCH#releases/}
+      id: whichver
+
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
-      if: matrix.target == 'ubuntu-xenial'
       env:
         SRC_REF: "${{ github.event.client_payload.branch }}"
         PKG_VERSION: "${{ steps.whichver.outputs.version }}"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "xenial"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-ubuntu-xenial
+        path: artifacts/ubuntu-xenial
+
+  build-ubuntu-bionic:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Determine package version
+      shell: bash
+      env:
+        BRANCH: "${{ github.event.client_payload.branch }}"
+      run: echo ::set-output name=version::${BRANCH#releases/}
+      id: whichver
+
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
-      if: matrix.target == 'ubuntu-bionic'
       env:
         SRC_REF: "${{ github.event.client_payload.branch }}"
         PKG_VERSION: "${{ steps.whichver.outputs.version }}"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "bionic"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-ubuntu-bionic
+        path: artifacts/ubuntu-bionic
+
+  build-ubuntu-focal:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Determine package version
+      shell: bash
+      env:
+        BRANCH: "${{ github.event.client_payload.branch }}"
+      run: echo ::set-output name=version::${BRANCH#releases/}
+      id: whichver
+
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
-      if: matrix.target == 'ubuntu-focal'
       env:
         SRC_REF: "${{ github.event.client_payload.branch }}"
         PKG_VERSION: "${{ steps.whichver.outputs.version }}"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "focal"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-ubuntu-focal
+        path: artifacts/ubuntu-focal
+
+  build-centos-7:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Determine package version
+      shell: bash
+      env:
+        BRANCH: "${{ github.event.client_payload.branch }}"
+      run: echo ::set-output name=version::${BRANCH#releases/}
+      id: whichver
+
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-7@master
-      if: matrix.target == 'centos-7'
       env:
         SRC_REF: "${{ github.event.client_payload.branch }}"
         PKG_VERSION: "${{ steps.whichver.outputs.version }}"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "7"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-centos-7
+        path: artifacts/centos-7
+
+  build-centos-8:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Determine package version
+      shell: bash
+      env:
+        BRANCH: "${{ github.event.client_payload.branch }}"
+      run: echo ::set-output name=version::${BRANCH#releases/}
+      id: whichver
+
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
-      if: matrix.target == 'centos-8'
       env:
         SRC_REF: "${{ github.event.client_payload.branch }}"
         PKG_VERSION: "${{ steps.whichver.outputs.version }}"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "8"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
 
-    - name: Build (${{ matrix.target }})
+    - uses: actions/upload-artifact@v1
+      with:
+        name: builds-centos-8
+        path: artifacts/centos-8
+
+  build-linux-x86_64:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Determine package version
+      shell: bash
+      env:
+        BRANCH: "${{ github.event.client_payload.branch }}"
+      run: echo ::set-output name=version::${BRANCH#releases/}
+      id: whichver
+
+    - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linux-x86_64@master
-      if: matrix.target == 'linux-x86_64'
       env:
         SRC_REF: "${{ github.event.client_payload.branch }}"
         PKG_VERSION: "${{ steps.whichver.outputs.version }}"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "x86_64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
         BUILD_GENERIC: true
 
 
-
     - uses: actions/upload-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
+        name: builds-linux-x86_64
+        path: artifacts/linux-x86_64
 
 
-
-  build-macos:
+  build-macos-x86_64:
     runs-on: macos-latest
     continue-on-error: true
 
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [
-          macos-x86_64,
-        ]
-        include:
-          - target: macos-x86_64
-            platform: macos
-            platform_version: x86_64
-
     steps:
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-pkg
-        ref: master
-        path: edgedb-cli/edgedb-pkg
-
     - name: Determine package version
       shell: bash
       env:
@@ -198,7 +245,13 @@ jobs:
       run: echo ::set-output name=version::${BRANCH#releases/}
       id: whichver
 
-    - uses: actions/cache@v1
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-pkg
+        ref: master
+        path: edgedb-cli/edgedb-pkg
+
+    - uses: actions/cache@v2
       id: sdk1010cache
       with:
         path: ~/.cache/MacOSX10.10.sdk/
@@ -216,25 +269,24 @@ jobs:
       if: steps.sdk1010cache.outputs.cache-hit != 'true'
       run: |
         mkdir -p ~/.cache
-        rsync -a \
+        cp -a \
           /Applications/Xcode-6.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/ \
           ~/.cache/MacOSX10.10.sdk/
 
     - name: Select macOS SDK
       run: |
-        sudo rsync -a \
+        sudo cp -a \
           ~/.cache/MacOSX10.10.sdk/ \
           /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
         sudo xcode-select -s /Library/Developer/CommandLineTools
 
-
-    - name: Build (${{ matrix.target }})
+    - name: Build
       env:
         SRC_REF: "${{ github.event.client_payload.branch }}"
         PKG_VERSION: "${{ steps.whichver.outputs.version }}"
         PKG_REVISION: "<current-date>"
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "macos"
+        PKG_PLATFORM_VERSION: "x86_64"
         SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
 
@@ -246,146 +298,260 @@ jobs:
 
     - uses: actions/upload-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
+        name: builds-macos-x86_64
+        path: artifacts/macos-x86_64
 
 
-
-  publish-linux:
-    needs: [build-linux]
+  publish-debian-stretch:
+    needs: [build-debian-stretch]
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [
-          debian-stretch,
-          debian-buster,
-          ubuntu-xenial,
-          ubuntu-bionic,
-          ubuntu-focal,
-          centos-7,
-          centos-8,
-          linux-x86_64,
-        ]
-        include:
-          - target: debian-stretch
-            platform: debian
-            platform_version: stretch
-          - target: debian-buster
-            platform: debian
-            platform_version: buster
-          - target: ubuntu-xenial
-            platform: ubuntu
-            platform_version: xenial
-          - target: ubuntu-bionic
-            platform: ubuntu
-            platform_version: bionic
-          - target: ubuntu-focal
-            platform: ubuntu
-            platform_version: focal
-          - target: centos-7
-            platform: centos
-            platform_version: 7
-          - target: centos-8
-            platform: centos
-            platform_version: 8
-          - target: linux-x86_64
-            platform: linux
-            platform_version: x86_64
 
     steps:
     - uses: actions/download-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
+        name: builds-debian-stretch
+        path: artifacts/debian-stretch
 
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: debian-stretch
 
-    - name: Publish (${{ matrix.target }})
+    - name: Publish
       uses: edgedb/edgedb-pkg/integration/linux/upload/debian-stretch@master
-      if: matrix.target == 'debian-stretch'
       env:
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "stretch"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/debian-buster@master
-      if: matrix.target == 'debian-buster'
-      env:
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
 
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-xenial@master
-      if: matrix.target == 'ubuntu-xenial'
-      env:
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-bionic@master
-      if: matrix.target == 'ubuntu-bionic'
-      env:
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-focal@master
-      if: matrix.target == 'ubuntu-focal'
-      env:
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/centos-7@master
-      if: matrix.target == 'centos-7'
-      env:
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/centos-8@master
-      if: matrix.target == 'centos-8'
-      env:
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-    - name: Publish (${{ matrix.target }})
-      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
-      if: matrix.target == 'linux-x86_64'
-      env:
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
-        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
-
-
-
-
-  publish-macos:
-    needs: [build-macos]
-    runs-on: macos-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        target: [
-          macos-x86_64,
-        ]
-        include:
-          - target: macos-x86_64
-            platform: macos
-            platform_version: x86_64
+  publish-debian-buster:
+    needs: [build-debian-buster]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/download-artifact@v1
       with:
-        name: builds-${{ matrix.target }}
-        path: artifacts/${{ matrix.target }}
+        name: builds-debian-buster
+        path: artifacts/debian-buster
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: debian-buster
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/debian-buster@master
+      env:
+        PKG_PLATFORM: "debian"
+        PKG_PLATFORM_VERSION: "buster"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+
+  publish-ubuntu-xenial:
+    needs: [build-ubuntu-xenial]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-ubuntu-xenial
+        path: artifacts/ubuntu-xenial
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: ubuntu-xenial
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-xenial@master
+      env:
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "xenial"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+
+  publish-ubuntu-bionic:
+    needs: [build-ubuntu-bionic]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-ubuntu-bionic
+        path: artifacts/ubuntu-bionic
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: ubuntu-bionic
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-bionic@master
+      env:
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "bionic"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+
+  publish-ubuntu-focal:
+    needs: [build-ubuntu-focal]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-ubuntu-focal
+        path: artifacts/ubuntu-focal
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: ubuntu-focal
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/ubuntu-focal@master
+      env:
+        PKG_PLATFORM: "ubuntu"
+        PKG_PLATFORM_VERSION: "focal"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+
+  publish-centos-7:
+    needs: [build-centos-7]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-centos-7
+        path: artifacts/centos-7
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: centos-7
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/centos-7@master
+      env:
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "7"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+
+  publish-centos-8:
+    needs: [build-centos-8]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-centos-8
+        path: artifacts/centos-8
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: centos-8
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/centos-8@master
+      env:
+        PKG_PLATFORM: "centos"
+        PKG_PLATFORM_VERSION: "8"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+
+  publish-linux-x86_64:
+    needs: [build-linux-x86_64]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-linux-x86_64
+        path: artifacts/linux-x86_64
+
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: linux-x86_64
+
+    - name: Publish
+      uses: edgedb/edgedb-pkg/integration/linux/upload/linux-x86_64@master
+      env:
+        PKG_PLATFORM: "linux"
+        PKG_PLATFORM_VERSION: "x86_64"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
+        PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: edgedb/edgedb-docker
+        ref: master
+        path: edgedb/dockerfile
+
+
+  publish-macos-x86_64:
+    needs: [build-macos-x86_64]
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/download-artifact@v1
+      with:
+        name: builds-macos-x86_64
+        path: artifacts/macos-x86_64
 
     - uses: actions/checkout@v1
       with:
@@ -393,14 +559,18 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
+    - name: Describe
+      id: describe
+      uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: macos-x86_64
 
-    - name: Publish (${{ matrix.target }})
+    - name: Publish
       env:
-        PKG_PLATFORM: "${{ matrix.platform }}"
-        PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        PKG_PLATFORM: "macos"
+        PKG_PLATFORM_VERSION: "x86_64"
+        PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
       run: |
         edgedb-pkg/integration/macos/publish.sh
-
-
 


### PR DESCRIPTION
This mimics commit 8ede7c42238da5a1021a20aed7c096de08374711 that was done and tested for nightlies.

Also, just like in edgedb/edgedb, change the caching to v2 and rsync to cp to
make the cache actually work.