### PR TITLE
Determine release package version with normalization

### DIFF
--- a/.github/determine-version.py
+++ b/.github/determine-version.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+
+
+posint = r'(0|[1-9]\d*)'
+shortform = re.compile(
+    rf"""
+    ^
+    (?P<major>{posint})
+    \.
+    (?P<minor>{posint})
+    (
+        \.
+        (?P<micro>{posint})
+    )?
+    (
+        (?P<prekind>a|b|rc)
+        (?P<preval>{posint})
+    )?
+    $
+    """,
+    re.X,
+)
+prerelease_kinds = {"a": "alpha", "b": "beta", "rc": "rc"}
+
+
+def main():
+    if len(sys.argv) != 2 or not sys.argv[1].strip():
+        print(
+            "error: branch name not passed as a sole argument."
+            " On GHA pass it as part of `client_payload`.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    branch = sys.argv[1].strip()
+    if branch.startswith('v'):
+        version = branch[1:]
+    elif branch.startswith('release/'):
+        version = branch[len('release/'):]
+    else:
+        print(f'::set-output name=version::{branch}')
+        return
+
+    m = shortform.match(version)
+    if m:
+        major = m.group('major')
+        minor = m.group('minor')
+        micro = m.group('micro') or '0'
+        prekind = m.group('prekind')
+        preval = m.group('preval')
+        version = f"{major}.{minor}.{micro}"
+        if prekind:
+            longprekind = prerelease_kinds.get(prekind, "dev")
+            version += f"-{longprekind}.{preval}"
+
+    print(f'::set-output name=version::{version}')
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -11,10 +11,7 @@ jobs:
 
     steps:
     - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
+      run: .github/determine-version.py ${{ github.event.client_payload.branch }}
       id: whichver
 
     - name: Build
@@ -43,10 +40,7 @@ jobs:
 
     steps:
     - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
+      run: .github/determine-version.py ${{ github.event.client_payload.branch }}
       id: whichver
 
     - uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,7 @@ jobs:
 
     steps:
     - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
+      run: .github/determine-version.py ${{ github.event.client_payload.branch }}
       id: whichver
 
     - name: Build
@@ -39,10 +36,7 @@ jobs:
 
     steps:
     - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
+      run: .github/determine-version.py ${{ github.event.client_payload.branch }}
       id: whichver
 
     - name: Build
@@ -67,10 +61,7 @@ jobs:
 
     steps:
     - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
+      run: .github/determine-version.py ${{ github.event.client_payload.branch }}
       id: whichver
 
     - name: Build
@@ -95,10 +86,7 @@ jobs:
 
     steps:
     - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
+      run: .github/determine-version.py ${{ github.event.client_payload.branch }}
       id: whichver
 
     - name: Build
@@ -123,10 +111,7 @@ jobs:
 
     steps:
     - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
+      run: .github/determine-version.py ${{ github.event.client_payload.branch }}
       id: whichver
 
     - name: Build
@@ -151,10 +136,7 @@ jobs:
 
     steps:
     - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
+      run: .github/determine-version.py ${{ github.event.client_payload.branch }}
       id: whichver
 
     - name: Build
@@ -179,10 +161,7 @@ jobs:
 
     steps:
     - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
+      run: .github/determine-version.py ${{ github.event.client_payload.branch }}
       id: whichver
 
     - name: Build
@@ -207,10 +186,7 @@ jobs:
 
     steps:
     - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
+      run: .github/determine-version.py ${{ github.event.client_payload.branch }}
       id: whichver
 
     - name: Build
@@ -239,10 +215,7 @@ jobs:
 
     steps:
     - name: Determine package version
-      shell: bash
-      env:
-        BRANCH: "${{ github.event.client_payload.branch }}"
-      run: echo ::set-output name=version::${BRANCH#releases/}
+      run: .github/determine-version.py ${{ github.event.client_payload.branch }}
       id: whichver
 
     - uses: actions/checkout@v1


### PR DESCRIPTION
Examples:
```
$ .github/determine-version.py v1.0
::set-output name=version::1.0.0
$ .github/determine-version.py release/1.0a4
::set-output name=version::1.0.0-alpha.4
$ .github/determine-version.py release/0.2.4rc1
::set-output name=version::0.2.4-rc.1
$ .github/determine-version.py gibberish
::set-output name=version::gibberish
$ .github/determine-version.py ""
error: branch name not passed as a sole argument. On GHA pass it as part of `client_payload`.
$ .github/determine-version.py " "
error: branch name not passed as a sole argument. On GHA pass it as part of `client_payload`.
```