### PR TITLE
workflows: Publish the binary as a generic Docker layer

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -126,12 +126,28 @@ jobs:
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+<% if tgt.family == "generic" %>
+    - name: Prepare docker context
+      run: |
+        mkdir -p dockerctx
+        cp artifacts/<< tgt.name >>/edgedb-cli* dockerctx/edgedb
+        chmod +x dockerctx/edgedb
+        printf 'FROM scratch\nENV EDGEDB_USER edgedb\nADD edgedb /usr/bin/\nENTRYPOINT ["/usr/bin/edgedb"]\n' \
+          >dockerctx/Dockerfile
+        tag=$(date +%Y%m%d%H%M%S)$(echo "${GITHUB_SHA}" | cut -c1-6)
+        echo ::set-env name=SNAPSHOT_TAG::${tag}
 
-    - uses: actions/checkout@v1
+    - name: Publish docker image
+      uses: elgohr/Publish-Docker-Github-Action@2.19
+      env:
+        PKG_PLATFORM_FULL: "<<tgt.platform>><< "-{}".format(tgt.platform_version) if tgt.platform_version >>"
       with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
+        name: edgedb/edgedb-cli
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        workdir: dockerctx
+        tags: "${{ env.PKG_PLATFORM_FULL }}-nightly,${{ env.PKG_PLATFORM_FULL }}-nightly-${{ env.SNAPSHOT_TAG }}"
+<% endif %>
 <% endfor %>
 <% for tgt in targets.macos %>
   publish-<< tgt.name >>:

--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -135,12 +135,28 @@ jobs:
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
+<% if tgt.family == "generic" %>
+    - name: Prepare docker context
+      run: |
+        mkdir -p dockerctx
+        cp artifacts/<< tgt.name >>/edgedb-cli* dockerctx/edgedb
+        chmod +x dockerctx/edgedb
+        printf 'FROM scratch\nENV EDGEDB_USER edgedb\nADD edgedb /usr/bin/\nENTRYPOINT ["/usr/bin/edgedb"]\n' \
+          >dockerctx/Dockerfile
+        ver=$(dockerctx/edgedb --version | cut -f2 -d' ')
+        echo ::set-env name=CLI_VERSION::${ver}
 
-    - uses: actions/checkout@v1
+    - name: Publish docker image
+      uses: elgohr/Publish-Docker-Github-Action@2.19
+      env:
+        PKG_PLATFORM_FULL: "<<tgt.platform>><< "-{}".format(tgt.platform_version) if tgt.platform_version >>"
       with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
+        name: edgedb/edgedb-cli
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        workdir: dockerctx
+        tags: "${{ env.PKG_PLATFORM_FULL }}-latest,${{ env.PKG_PLATFORM_FULL }}-${{ env.CLI_VERSION }}"
+<% endif %>
 <% endfor %>
 <% for tgt in targets.macos %>
   publish-<< tgt.name >>:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -267,11 +267,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-debian-buster:
     needs: [build-debian-buster]
@@ -298,11 +293,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-ubuntu-xenial:
     needs: [build-ubuntu-xenial]
@@ -329,11 +319,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-ubuntu-bionic:
     needs: [build-ubuntu-bionic]
@@ -360,11 +345,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-ubuntu-focal:
     needs: [build-ubuntu-focal]
@@ -391,11 +371,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-centos-7:
     needs: [build-centos-7]
@@ -422,11 +397,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-centos-8:
     needs: [build-centos-8]
@@ -453,11 +423,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-linux-x86_64:
     needs: [build-linux-x86_64]
@@ -484,11 +449,27 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
+    - name: Prepare docker context
+      run: |
+        mkdir -p dockerctx
+        cp artifacts/linux-x86_64/edgedb-cli* dockerctx/edgedb
+        chmod +x dockerctx/edgedb
+        printf 'FROM scratch\nENV EDGEDB_USER edgedb\nADD edgedb /usr/bin/\nENTRYPOINT ["/usr/bin/edgedb"]\n' \
+          >dockerctx/Dockerfile
+        tag=$(date +%Y%m%d%H%M%S)$(echo "${GITHUB_SHA}" | cut -c1-6)
+        echo ::set-env name=SNAPSHOT_TAG::${tag}
+
+    - name: Publish docker image
+      uses: elgohr/Publish-Docker-Github-Action@2.19
+      env:
+        PKG_PLATFORM_FULL: "linux-x86_64"
       with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
+        name: edgedb/edgedb-cli
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        workdir: dockerctx
+        tags: "${{ env.PKG_PLATFORM_FULL }}-nightly,${{ env.PKG_PLATFORM_FULL }}-nightly-${{ env.SNAPSHOT_TAG }}"
+
 
 
   publish-macos-x86_64:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,11 +353,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-debian-buster:
     needs: [build-debian-buster]
@@ -383,11 +378,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-ubuntu-xenial:
     needs: [build-ubuntu-xenial]
@@ -413,11 +403,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-ubuntu-bionic:
     needs: [build-ubuntu-bionic]
@@ -443,11 +428,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-ubuntu-focal:
     needs: [build-ubuntu-focal]
@@ -473,11 +453,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-centos-7:
     needs: [build-centos-7]
@@ -503,11 +478,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-centos-8:
     needs: [build-centos-8]
@@ -533,11 +503,6 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
 
   publish-linux-x86_64:
     needs: [build-linux-x86_64]
@@ -563,11 +528,27 @@ jobs:
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
         PACKAGE_UPLOAD_SSH_KEY: "${{ secrets.PACKAGE_UPLOAD_SSH_KEY }}"
 
-    - uses: actions/checkout@v1
+    - name: Prepare docker context
+      run: |
+        mkdir -p dockerctx
+        cp artifacts/linux-x86_64/edgedb-cli* dockerctx/edgedb
+        chmod +x dockerctx/edgedb
+        printf 'FROM scratch\nENV EDGEDB_USER edgedb\nADD edgedb /usr/bin/\nENTRYPOINT ["/usr/bin/edgedb"]\n' \
+          >dockerctx/Dockerfile
+        ver=$(dockerctx/edgedb --version | cut -f2 -d' ')
+        echo ::set-env name=CLI_VERSION::${ver}
+
+    - name: Publish docker image
+      uses: elgohr/Publish-Docker-Github-Action@2.19
+      env:
+        PKG_PLATFORM_FULL: "linux-x86_64"
       with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: edgedb/dockerfile
+        name: edgedb/edgedb-cli
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        workdir: dockerctx
+        tags: "${{ env.PKG_PLATFORM_FULL }}-latest,${{ env.PKG_PLATFORM_FULL }}-${{ env.CLI_VERSION }}"
+
 
 
   publish-macos-x86_64:


### PR DESCRIPTION
This adds a step which publishes the static build as a docker image
containing only itself, intended to be used as a layer in application
images.