### PR TITLE
Nicer message when we were unable to bootstrap a service

### DIFF
--- a/src/server/control.rs
+++ b/src/server/control.rs
@@ -25,7 +25,7 @@ pub fn get_instance<'x>(methods: &'x Methods, name: &str)
         match meth.get_instance(name) {
             Ok(inst) => return Ok(inst),
             Err(e) => {
-                errors.push(format!("  {}: {}", meth_name.short_name(), e));
+                errors.push(format!("  {}: {:#}", meth_name.short_name(), e));
             }
         }
     }

--- a/src/server/errors.rs
+++ b/src/server/errors.rs
@@ -1,3 +1,7 @@
 #[derive(Debug, thiserror::Error)]
 #[error("instance not found")]
 pub struct InstanceNotFound(#[source] pub anyhow::Error);
+
+#[derive(Debug, thiserror::Error)]
+#[error("cannot create service")]
+pub struct CannotCreateService(#[source] pub anyhow::Error);


### PR DESCRIPTION
This is important on WSL or Centos7 (and potentially others like Alpine)

Now it prints something like that:
```
Failed to get D-Bus connection: No such file or directory
Error: cannot create service: process "systemctl" "--user" "daemon-reload" failed: exit code: 1
Bootrapping complete, but there was an error creating a service. You can run server manually via:
  edgedb server start --foreground test10
```
And still exits with erroneous code `2`. Still this is friendly enough
to be useful.

This PR also fixes bug of removing bootstrapped directory which popped up in 1-alpha6.