### PR TITLE
Fix upgrade on non-systemd and manually running instances

### DIFF
--- a/src/server/detect.rs
+++ b/src/server/detect.rs
@@ -56,6 +56,11 @@ impl<T> Lazy<T> {
     pub fn lazy() -> Lazy<T> {
         Lazy(OnceCell::new())
     }
+    pub fn eager(val:T) -> Lazy<T> {
+        let cell = OnceCell::new();
+        cell.set(val).map_err(|_| "cell failed").unwrap();
+        Lazy(cell)
+    }
     pub fn get_or_init<F>(&self, f: F) -> &T
         where F: FnOnce() -> T
     {

--- a/src/server/docker.rs
+++ b/src/server/docker.rs
@@ -1304,6 +1304,16 @@ impl<O: CurrentOs + ?Sized> Instance for DockerInstance<'_, O> {
     fn get_command(&self) -> anyhow::Result<Command> {
         anyhow::bail!("no get_command is supported for docker instances");
     }
+    fn upgrade<'x>(&'x self, meta: &Metadata)
+        -> anyhow::Result<InstanceRef<'x>>
+    {
+        Ok(DockerInstance {
+            method: self.method,
+            name: self.name.clone(),
+            container: Lazy::lazy(),
+            metadata: Lazy::eager(meta.clone()),
+        }.into_ref())
+    }
 }
 
 impl<O: CurrentOs + ?Sized> fmt::Debug for DockerInstance<'_, O> {

--- a/src/server/errors.rs
+++ b/src/server/errors.rs
@@ -5,3 +5,7 @@ pub struct InstanceNotFound(#[source] pub anyhow::Error);
 #[derive(Debug, thiserror::Error)]
 #[error("cannot create service")]
 pub struct CannotCreateService(#[source] pub anyhow::Error);
+
+#[derive(Debug, thiserror::Error)]
+#[error("cannot start service")]
+pub struct CannotStartService(#[source] pub anyhow::Error);

--- a/src/server/linux.rs
+++ b/src/server/linux.rs
@@ -165,6 +165,20 @@ impl Instance for LocalInstance<'_> {
         cmd.arg("--default-database-user=edgedb");
         Ok(cmd)
     }
+    fn upgrade<'x>(&'x self, meta: &Metadata)
+        -> anyhow::Result<InstanceRef<'x>>
+    {
+        Ok(LocalInstance {
+            method: self.method,
+            name: self.name.clone(),
+            path: self.path.clone(),
+            slot: Lazy::eager(meta.slot.as_ref()
+                .expect("linux packages always have a slot").clone()),
+            current_version: Lazy::eager(meta.current_version.as_ref()
+                .expect("current version is known during upgrade").clone()),
+            metadata: Lazy::eager(meta.clone()),
+        }.into_ref())
+    }
 }
 
 

--- a/src/server/macos.rs
+++ b/src/server/macos.rs
@@ -406,7 +406,7 @@ impl LocalInstance<'_> {
     }
 }
 
-impl Instance for LocalInstance<'_> {
+impl<'a> Instance for LocalInstance<'a> {
     fn name(&self) -> &str {
         &self.name
     }
@@ -497,6 +497,20 @@ impl Instance for LocalInstance<'_> {
         cmd.arg("--default-database=edgedb");
         cmd.arg("--default-database-user=edgedb");
         Ok(cmd)
+    }
+    fn upgrade(&self, meta: &Metadata)
+        -> anyhow::Result<InstanceRef<'_>>
+    {
+        Ok(LocalInstance {
+            method: self.method,
+            name: self.name.clone(),
+            path: self.path.clone(),
+            slot: Lazy::eager(meta.slot.as_ref()
+                .expect("macos packages always have a slot").clone()),
+            current_version: Lazy::eager(meta.current_version.as_ref()
+                .expect("current version is known during upgrade").clone()),
+            metadata: Lazy::eager(meta.clone()),
+        }.into_ref())
     }
 }
 

--- a/src/server/os_trait.rs
+++ b/src/server/os_trait.rs
@@ -10,6 +10,7 @@ use crate::server::distribution::{MajorVersion, DistributionRef};
 use crate::server::init::{self, Storage};
 use crate::server::install;
 use crate::server::upgrade;
+use crate::server::metadata::Metadata;
 use crate::server::methods::{InstallationMethods, InstallMethod};
 use crate::server::options::{Start, Stop, Restart, StartConf, Upgrade, Destroy};
 use crate::server::status::Status;
@@ -41,6 +42,7 @@ pub trait Instance: fmt::Debug {
     fn service_status(&self) -> anyhow::Result<()>;
     fn get_connector(&self, admin: bool) -> anyhow::Result<client::Builder>;
     fn get_command(&self) -> anyhow::Result<Command>;
+    fn upgrade(&self, meta: &Metadata) -> anyhow::Result<InstanceRef<'_>>;
     fn into_ref<'x>(self) -> InstanceRef<'x>
         where Self: Sized + 'x
     {
@@ -164,6 +166,11 @@ impl InstanceRef<'_> {
     }
     pub fn service_status(&self) -> anyhow::Result<()> {
         self.0.service_status()
+    }
+    pub fn upgrade(&self, meta: &Metadata)
+        -> anyhow::Result<InstanceRef<'_>>
+    {
+        self.0.upgrade(meta)
     }
 }
 

--- a/tests/docker.rs
+++ b/tests/docker.rs
@@ -128,6 +128,7 @@ pub fn run_systemd(tagname: &str, script: &str)
 {
     let script = format!(r###"
         export XDG_RUNTIME_DIR=/run/user/1000
+        export RUST_LOG=info
         /lib/systemd/systemd --user --log-level=debug &
 
         {script}


### PR DESCRIPTION
Also:
* Fixes shutdown of the foreground processes
* Adds a test for centos 7 with --method=pacakge