### PR TITLE
Better prefix of error message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
             if let Some(e) = e.downcast_ref::<commands::ExitCode>() {
                 e.exit();
             }
-            eprintln!("Error: {:#}", e);
+            eprintln!("edgedb error: {:#}", e);
             exit(1);
         }
     }

--- a/src/non_interactive.rs
+++ b/src/non_interactive.rs
@@ -94,9 +94,9 @@ pub async fn query(conn: &mut Connection, stmt: &str, options: &Options)
                             },
                             ..
                         } => {
-                            eprintln!("{}", error);
+                            eprintln!("edgedb error: {}", error);
                         }
-                        _ => eprintln!("{:#?}", e),
+                        _ => eprintln!("edgedb error: {:#}", e),
                     }
                     return Ok(());
                 }

--- a/src/self_install.rs
+++ b/src/self_install.rs
@@ -191,7 +191,7 @@ pub fn main(options: &SelfInstall) -> anyhow::Result<()> {
             if cfg!(windows) && !options.no_confirm {
                 // This is needed so user can read the message if console
                 // was open just for this process
-                eprintln!("Error: {:#}", e);
+                eprintln!("edgedb error: {:#}", e);
                 eprintln!("Press the Enter key to continue");
                 read_choice()?;
                 exit(1);

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -249,7 +249,7 @@ pub fn init(options: &Init) -> anyhow::Result<()> {
             Ok(()) => {}
             Err(e) => {
                 if e.is::<CannotCreateService>() {
-                    eprintln!("Error: {:#}", e);
+                    eprintln!("edgedb error: {:#}", e);
                     eprintln!("Bootstrapping complete, \
                         but there was an error creating the service. \
                         You can run server manually via: \n  \

--- a/src/server/uninstall.rs
+++ b/src/server/uninstall.rs
@@ -49,7 +49,8 @@ pub fn uninstall(options: &Uninstall) -> Result<(), anyhow::Error> {
         }
     }
     if !all {
-        eprintln!("Error: some instances are used. See messages above.");
+        eprintln!(
+            "edgedb error: some instances are used. See messages above.");
         return Err(ExitCode::new(2))?;
     }
     Ok(())

--- a/tests/func/migrations.rs
+++ b/tests/func/migrations.rs
@@ -43,7 +43,7 @@ fn initial() -> anyhow::Result<()> {
         .arg("create-migration")
         .arg("--non-interactive")
         .arg("--schema-dir=tests/migrations/db1/initial")
-        .assert().code(1).stderr("Error: Database must be updated \
+        .assert().code(1).stderr("edgedb error: Database must be updated \
             to the last miration on the filesystem for `create-migration`. \
             Run:\n  \
               edgedb migrate\n");
@@ -130,7 +130,7 @@ fn modified1() -> anyhow::Result<()> {
         .arg("create-migration")
         .arg("--non-interactive")
         .arg("--schema-dir=tests/migrations/db1/modified1")
-        .assert().code(1).stderr("Error: Database must be updated \
+        .assert().code(1).stderr("edgedb error: Database must be updated \
             to the last miration on the filesystem for `create-migration`. \
             Run:\n  \
               edgedb migrate\n");
@@ -221,7 +221,7 @@ r###"error: Unexpected 'create'
 3 │         create property text -> str;
   │         ^^^^^^^ error
 
-Error: cannot proceed until .esdl files are fixed
+edgedb error: cannot proceed until .esdl files are fixed
 "###);
     Ok(())
 }


### PR DESCRIPTION
If you're using edgedb CLI in the scripts, ocasionally you may see
somethign like this:
```
Error: authentication failed
```
This is not very clear whether it comes from edgedb CLI or any other
tool. Even if you enable `set +x` (i.e. tracing command run) in shell it
may still be confusing to run `docker run edgedb-image edgedb` or
`sudo edgedb`.

So it's quite common for unix tools to put their command name before the
error message:

```
edgedb error: authentication failed
```

This PR adds it consistently in fatal errors and few
other places but not in interactive usage, as in interactive case it
should be clean enough which utility is currently active.