### PR TITLE
Add a note on how to open a REPL after `edgedb server init`

### DIFF
--- a/src/server/unix.rs
+++ b/src/server/unix.rs
@@ -139,6 +139,8 @@ pub fn bootstrap(method: &dyn Method, settings: &init::Settings)
             })?;
             init_credentials(&settings, &inst)?;
             println!("Bootstrap complete. Server is up and runnning now.");
+            println!("To connect run:\n  edgedb -I{}",
+                     settings.name.escape_default());
         }
         _ => {
             let inst = method.get_instance(&settings.name)?;


### PR DESCRIPTION
Currently, we just show "Bootstrap complete. Server is up and runnning
now."