### PR TITLE
Database-like format for priting duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "edgedb-client"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb-rust#dde93fe13d16b9e8f2056dade34e0d5b85c7f81d"
+source = "git+https://github.com/edgedb/edgedb-rust#cc3b64833a9c1b3ea519a88a2c42f05cfd185dac"
 dependencies = [
  "anyhow",
  "async-listen",
@@ -983,7 +983,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb-rust#dde93fe13d16b9e8f2056dade34e0d5b85c7f81d"
+source = "git+https://github.com/edgedb/edgedb-rust#cc3b64833a9c1b3ea519a88a2c42f05cfd185dac"
 dependencies = [
  "proc-macro2",
  "quote 1.0.8",
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb-rust#dde93fe13d16b9e8f2056dade34e0d5b85c7f81d"
+source = "git+https://github.com/edgedb/edgedb-rust#cc3b64833a9c1b3ea519a88a2c42f05cfd185dac"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/src/print/native.rs
+++ b/src/print/native.rs
@@ -113,11 +113,7 @@ impl FormatExt for Value {
             => prn.typed("cal::local_date", format!("{:?}", d)),
             V::LocalTime(t)
             => prn.typed("cal::local_time", format!("{:?}", t)),
-            V::Duration(d) => {
-                // TODO(tailhook) implement more DB-like duration display
-                prn.const_scalar(format_args!("{}{:?}",
-                    if d.is_negative() { "-" } else { "" }, d.abs_duration()))
-            }
+            V::Duration(d) => prn.typed("duration", d.to_string()),
             V::Json(d) => prn.const_scalar(format!("{:?}", d)),
             V::Set(items) => {
                 prn.set(|prn| {


### PR DESCRIPTION
Old format:
```
edgedb> WITH x := (SELECT <duration>'12345s') SELECT (x, <str>x);
{(12345s, '03:25:45')}
```
New format:
```
edgedb> WITH x := (SELECT <duration>'12345s') SELECT (x, <str>x);
{(<duration>'03:25:45', '03:25:45')}
```

Fixes #223