### PR TITLE
Fix uninstall on MacOS and better tests

### DIFF
--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -90,6 +90,11 @@ pub struct Uninstall {
 pub struct ListVersions {
     #[clap(long)]
     pub installed_only: bool,
+    /// Single column output
+    #[clap(long, possible_values=&[
+        "major-version", "installed", "available",
+    ])]
+    pub column: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -16,6 +16,12 @@ commands:
     container: ubuntu
     run: [cargo]
 
+  check: !Command
+    description: Run cargo check with all tests
+    symlink-name: cargo
+    container: ubuntu
+    run: [cargo, check, --tests, --features=github_action_install]
+
   cargo-expand: !Command
     description: Print macro-expanded form for the crate
     container: nightly


### PR DESCRIPTION
This adds `server list-versions --column=` parameter to the command-line, for easier tests and other scripting.