### PR TITLE
Do not block Docker installation method on missing/inaccessible socket

### DIFF
--- a/src/server/methods.rs
+++ b/src/server/methods.rs
@@ -76,7 +76,7 @@ impl InstallationMethods {
             buf.push_str("or run `edgedb server install --interactive` \
                           and follow instructions");
         } else if self.docker.platform_supported {
-            buf.push_str("No installation method found:\n");
+            buf.push_str("no installation method available:\n");
             self.package.format_error(&mut buf);
             self.docker.format_error(&mut buf);
             buf.push_str("Consider installing docker: \

--- a/src/server/package.rs
+++ b/src/server/package.rs
@@ -87,12 +87,13 @@ impl PackageCandidate {
 
         if self.distro_supported {
             write!(buf,
-                " * Note: native packages are not supported for {} {}",
+                " * --method=native: native packages are \
+                not available for {} {}",
                 self.distro_name,
                 self.distro_version).unwrap();
         } else {
-            buf.push_str(" * Note: native packages are \
-                             not supported for this platform");
+            buf.push_str(" * --method=native: native packages are \
+                         not available for this OS");
         }
         buf.push('\n');
     }


### PR DESCRIPTION
There is no Docker deamon Unix socket on Windows (there's a TCP port and
a named pipe, though [1]).  But, more importantly, the CLI itself
doesn't use the socket in any way, so the check doesn't seem to be
useful.

[1] https://docs.docker.com/desktop/faqs/#how-do-i-connect-to-the-remote-docker-engine-api