### PR TITLE
Editorial pass on self-install messages

### DIFF
--- a/src/self_install.rs
+++ b/src/self_install.rs
@@ -46,9 +46,9 @@ fn print_long_description(settings: &Settings) {
     println!(r###"
 Welcome to EdgeDB!
 
-This will install the EdgeDB command-line tools.
+This will install the official EdgeDB command-line tools.
 
-It will add `edgedb` binary to the {dir_kind} bin directory located at:
+The `edgedb` binary will be placed in the {dir_kind} bin directory located at:
 
   {installation_path}
 {profile_update}
@@ -143,15 +143,15 @@ fn ensure_line(path: &PathBuf, line: &str) -> anyhow::Result<()> {
 
 fn print_post_install_message(settings: &Settings) {
     if cfg!(windows) {
-        print!(r###"# EdgeDB command-line tool is installed now!
+        print!(r###"# The EdgeDB command-line tool is now installed!
 
-We've updated your environment configuration to have {dir} in your `PATH`
-environment variable. Next time you open the terminal it will be configured
-automatically.
+We've updated your environment configuration to have {dir}
+in your `PATH` environment variable. You may need to reopen the terminal for
+this change to take effect, and for the `edgedb` command to become available.
 "###,
             dir=settings.installation_path.display());
     } else if settings.modify_path {
-        print!(r###"# EdgeDB command-line tool is installed now!
+        print!(r###"# The EdgeDB command-line tool is now installed!
 
 We've updated your shell profile to have {dir} in your `PATH`
 environment variable. Next time you open the terminal it will be configured
@@ -163,9 +163,9 @@ For this session please run:
             dir=settings.installation_path.display(),
             env_path=settings.env_file.display());
     } else {
-        println!(r###"EdgeDB command-line tool is installed now!"###);
+        println!(r###"The EdgeDB command-line tool is now installed!"###);
     }
-    println!("\nTo install the server locally run:\n  \
+    println!("\nTo install the EdgeDB server component locally run:\n  \
                 edgedb server install");
 }
 

--- a/src/server/methods.rs
+++ b/src/server/methods.rs
@@ -79,11 +79,23 @@ impl InstallationMethods {
             buf.push_str("No installation method found:\n");
             self.package.format_error(&mut buf);
             self.docker.format_error(&mut buf);
-            buf.push_str("Consider installing docker: \
-                https://docs.docker.com/get-docker/");
-            buf.push_str("Or ask for native support at \
-                https://github.com/edgedb/edgedb-cli/issues/new\
-                ?template=install-unsupported.md");
+            if cfg!(windows) {
+                buf.push_str("EdgeDB server installation on Windows \
+                    requires Docker Desktop to be installed and running. \
+                    You can download Docker Desktop for Windows here: \
+                    https://hub.docker.com/editions/community/docker-ce-desktop-windows/ \
+                    Once Docker Desktop is installed and running, restart the \
+                    EdgeDB server installation by running \
+                    `edgedb server install --method=docker`");
+            } else {
+                buf.push_str("It looks like there are no native EdgeDB server \
+                    packages for your OS yet.  However, it is possible to \
+                    install and run EdgeDB server in a Docker container. \
+                    Please install Docker by following the instructions at \
+                    https://docs.docker.com/get-docker/.  Once Docker is \
+                    installed, restart the EdgeDB server installation by \
+                    running `edgedb server install --method=docker`");
+            }
         } else {
             buf.push_str("No installation method supported for the platform:");
             self.package.format_error(&mut buf);

--- a/tests/github-actions/install.rs
+++ b/tests/github-actions/install.rs
@@ -68,7 +68,7 @@ fn github_action_install() -> anyhow::Result<()> {
             .assert()
             .success()
             .stdout(predicates::str::contains(
-                "EdgeDB command-line tool is installed now"));
+                "The EdgeDB command-line tool is now installed"));
     }
 
     shut_tx.send(()).ok();


### PR DESCRIPTION
Update the wording of messages produced in the `edgedb-init` flow.