### PR TITLE
Don't run tests twice on pull requests and also run them on schedule

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,17 @@
-on: [push, pull_request]
-
 name: Tests
+
+on:
+  push:
+    branches:
+      - master
+      - ci
+      - "releases/*"
+  pull_request:
+    branches:
+      - '*'
+  schedule:
+    - cron: "0 */6 * * *"
+
 env:
   RUST_TEST_THREADS: 2
 


### PR DESCRIPTION
There is no point in running the tests twice on every PR when the
originating branch is in the same repo (which it is most of the time).
Also, run tests on a scheduled interval (6 hours) to shake out anything
intermittent.