### PR TITLE
Bump the default history-size to 10000

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -100,7 +100,7 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
         output_mode: options.output_mode,
         input_mode: repl::InputMode::Emacs,
         print_stats: repl::PrintStats::Off,
-        history_limit: 100,
+        history_limit: 10000,
         database: options.conn_params.get_database().into(),
         conn_params: options.conn_params.clone(),
         last_version: None,


### PR DESCRIPTION
I find 100 to be much too low, and we don't have a persistent way to
configure it yet.