### PR TITLE
Add PowerShell install bootstrap script

### DIFF
--- a/edgedb-init.ps1
+++ b/edgedb-init.ps1
@@ -1,0 +1,36 @@
+#!/usr/bin/env pwsh
+
+# A simple Powershell script to download and install the EdgeDB CLI.
+#
+# Copyright 2021-present EdgeDB Inc. and the EdgeDB authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+# Bail immediately on any error.
+$ErrorActionPreference = 'Stop'
+# Prevent the pointless progress overlay produced by iwr.
+$ProgressPreference = 'SilentlyContinue'
+# Ensure proper transport security.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$BaseUrl = "https://packages.edgedb.com/dist"
+$DistArch = "x86_64"
+$SubDist = ".nightly"
+$Suffix = "$SubDist" -replace "\.","_"
+$DownloadUrl = "$BaseUrl/win-${DistArch}${SubDist}/edgedb-cli_latest$Suffix.exe"
+
+Write-Output "Downloading installer..."
+
+$TempRoot = [System.IO.Path]::GetTempPath()
+$TempStem = [System.IO.Path]::GetRandomFileName()
+$TempDir = Join-Path $TempRoot $TempStem
+$CliExe = Join-Path $TempDir "edgedb-init.exe"
+New-Item $TempDir -ItemType Directory | Out-Null
+
+Invoke-WebRequest $DownloadUrl -OutFile $CliExe -UseBasicParsing
+
+Start-Process $CliExe -ArgumentList "--no-wait-for-exit-prompt" -NoNewWindow -Wait
+
+# Make PATH modifications actual in current session.
+$User = [EnvironmentVariableTarget]::User
+$Path = [Environment]::GetEnvironmentVariable('Path', $User)
+$Env:Path += ";$Path"


### PR DESCRIPTION
This is a `edgedb-init.sh` counterpart for Windows intended to be ran
as:

    iwr <url> -useb | iex

Currently installs the nightly build, but once we do a release
run, will switch to downloading the latest stable build.