### PR TITLE
Prevent "docker info" from spamming into terminal

### DIFF
--- a/src/server/docker.rs
+++ b/src/server/docker.rs
@@ -2,7 +2,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::fmt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Child};
+use std::process::{Command, Child, Stdio};
 use std::time::{SystemTime, Duration, UNIX_EPOCH};
 
 use anyhow::Context;
@@ -273,6 +273,8 @@ impl DockerCandidate {
         let docker_info_worked = cli.as_ref().map(|cli| {
             Command::new(cli)
             .arg("info")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .status()
             .map_err(|e| {
                 log::info!("Error running docker CLI: {}", e);
@@ -1346,4 +1348,3 @@ impl<O: CurrentOs + ?Sized> fmt::Debug for DockerInstance<'_, O> {
             .finish()
     }
 }
-


### PR DESCRIPTION
A switch, made in #242, to running `docker info` as a method to
check if Docker is operational on a system is currently causing the
output of the aforementioned `docker info` to appear in CLI output.
Prevent that from happening by pointing the std{out,err} handles to
/dev/null.