### PR TITLE
Auto-install gnupg and apt-transport-https on debian-like

### DIFF
--- a/src/server/debian_like.rs
+++ b/src/server/debian_like.rs
@@ -111,6 +111,16 @@ impl Debian {
         let key = task::block_on(remote::get_string(install::KEY_FILE_URL))
             .context("downloading key file")?;
         let mut operations = Vec::new();
+        operations.push(Operation::PrivilegedCmd(
+            Command::new("apt-get")
+                .arg("update")
+        ));
+        operations.push(Operation::PrivilegedCmd(
+            Command::new("apt-get")
+                .arg("install")
+                .arg("-y")
+                .args(&["gnupg", "apt-transport-https"])
+        ));
         operations.push(Operation::FeedPrivilegedCmd {
             input: key.into(),
             cmd: Command::new("apt-key")

--- a/tests/server/debian.rs
+++ b/tests/server/debian.rs
@@ -6,7 +6,7 @@ pub fn dockerfile(codename: &str) -> String {
     format!(r###"
         FROM debian:{codename}
         RUN apt-get update
-        RUN apt-get install -y ca-certificates sudo gnupg2 apt-transport-https
+        RUN apt-get install -y sudo ca-certificates
         RUN adduser --uid 1000 --home /home/user1 \
             --shell /bin/bash --ingroup users --gecos "EdgeDB Test User" \
             user1

--- a/tests/server/ubuntu.rs
+++ b/tests/server/ubuntu.rs
@@ -6,7 +6,7 @@ pub fn dockerfile(codename: &str) -> String {
     format!(r###"
         FROM ubuntu:{codename}
         RUN apt-get update
-        RUN apt-get install -y ca-certificates sudo gnupg2 apt-transport-https
+        RUN apt-get install -y sudo ca-certificates
         RUN adduser --uid 1000 --home /home/user1 \
             --shell /bin/bash --ingroup users --gecos "EdgeDB Test User" \
             user1


### PR DESCRIPTION
Fixes #206