### PR TITLE
Init project in self install

### DIFF
--- a/src/print/native.rs
+++ b/src/print/native.rs
@@ -24,6 +24,7 @@ fn format_string(s: &str, expanded: bool) -> String {
             '\u{0080}'..='\u{009F}'
             => buf.push_str(&format!("\\u{:04x}", c as u32)),
             '\'' => buf.push_str("\\'"),
+            '\\' => buf.push_str("\\\\"),
             '\r' if !expanded => buf.push_str("\\r"),
             '\n' if !expanded => buf.push_str("\\n"),
             '\t' if !expanded => buf.push_str("\\t"),
@@ -49,6 +50,7 @@ fn format_bytes(bytes: &[u8]) -> String {
             b'\r' => buf.push_str("\\r"),
             b'\n' => buf.push_str("\\n"),
             b'\t' => buf.push_str("\\t"),
+            b'\\' => buf.push_str("\\\\"),
             _ => buf.push(*b as char),
         }
     }

--- a/src/project/init.rs
+++ b/src/project/init.rs
@@ -284,7 +284,9 @@ fn write_config(path: &Path, distr: &DistributionRef) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn init_existing(options: &Init, project_dir: &Path) -> anyhow::Result<()> {
+pub fn init_existing(options: &Init, project_dir: &Path)
+    -> anyhow::Result<()>
+{
     println!("Found `edgedb.toml` in `{}`", project_dir.display());
 
     let stash_dir = stash_path(project_dir)?;
@@ -471,7 +473,7 @@ pub fn stash_path(project_dir: &Path) -> anyhow::Result<PathBuf> {
     Ok(stash_base()?.join(hname))
 }
 
-fn init_new(options: &Init, project_dir: &Path) -> anyhow::Result<()> {
+pub fn init_new(options: &Init, project_dir: &Path) -> anyhow::Result<()> {
     eprintln!("`edgedb.toml` is not found in `{}` or above",
               project_dir.display());
 


### PR DESCRIPTION
This effectively does `project init` in `curl .. | sh` pipeline.

Note: we don't do project init when using `-y` flag. This latter is for scripting and it's better to use explicit `project init` in scripts.