### PR TITLE
Fix docker registry API URL

### DIFF
--- a/src/server/docker.rs
+++ b/src/server/docker.rs
@@ -370,7 +370,7 @@ impl<'os, O: CurrentOs + ?Sized> DockerMethod<'os, O> {
     fn get_tags(&self) -> anyhow::Result<&[Tag]> {
         self.tags.get_or_try_init(|| {
             task::block_on(async {
-                let mut url = "https://registry.hub.docker.com/\
+                let mut url = "https://hub.docker.com/\
                         v2/repositories/edgedb/edgedb/tags\
                         ?page_size=1000".to_string();
                 let mut tags = Vec::new();


### PR DESCRIPTION
- EdgeDB CLI Version: edgedb-cli 1.0.0-beta.2
- OS Version: macOS 11.4

When I try to execute `edgedb server install -i --method docker` or `edgedb server list-versions`
 it fails with error:

```
edgedb error: failed to fetch JSON at URL: https://registry.hub.docker.com/v2/repositories/edgedb/edgedb/tags?page_size=1000: fetching "failed to fetch tag list from the Docker registry": HTTP failure: 301 Moved Permanently
```