### PR TITLE
Fix self migrate instance recreation on macOS

### DIFF
--- a/src/self_migrate.rs
+++ b/src/self_migrate.rs
@@ -293,7 +293,6 @@ fn remove_dir_all(path: &Path, dry_run: bool) -> anyhow::Result<()> {
 fn macos_recreate_all_services(dry_run: bool) -> anyhow::Result<()> {
     use crate::server::detect;
     use crate::server::methods::InstallMethod;
-    use crate::server::options::{Start, Stop, StartConf};
     use crate::server::macos;
 
     let os = detect::current_os()?;
@@ -305,22 +304,7 @@ fn macos_recreate_all_services(dry_run: bool) -> anyhow::Result<()> {
             log::info!("Would restart instance {:?}", inst.name());
             continue;
         }
-        log::info!("Stopping instance {:?}", inst.name());
-        inst.stop(&Stop { name: inst.name().into() })?;
-        log::info!("Updating service file for instance {:?}", inst.name());
-        macos::recreate_launchctl_service(inst.name(), inst.get_meta()?)?;
-        if inst.get_start_conf()? == StartConf::Auto {
-            log::info!("Starting instance {:?}", inst.name());
-            inst.start(&Start {
-                name: inst.name().into(),
-                foreground: false,
-            })?;
-        } else {
-            log::warn!(
-                "Service {:?} is not started due to `--start-conf=manual`",
-                inst.name(),
-            );
-        }
+        macos::recreate_launchctl_service(inst)?;
     }
 
     Ok(())

--- a/src/self_migrate.rs
+++ b/src/self_migrate.rs
@@ -227,7 +227,7 @@ pub fn migrate(base: &Path, dry_run: bool) -> anyhow::Result<()> {
     remove_file(&base.join("env"), dry_run)?;
     remove_dir_all(&base.join("bin"), dry_run)?;
 
-    if cfg!(target="macos") {
+    if cfg!(target_os="macos") {
         macos_recreate_all_services(dry_run)?;
     }
 
@@ -308,7 +308,7 @@ fn macos_recreate_all_services(dry_run: bool) -> anyhow::Result<()> {
         log::info!("Stopping instance {:?}", inst.name());
         inst.stop(&Stop { name: inst.name().into() })?;
         log::info!("Updating service file for instance {:?}", inst.name());
-        macos::create_launchctl_service(inst.name(), inst.get_meta()?)?;
+        macos::recreate_launchctl_service(inst.name(), inst.get_meta()?)?;
         if inst.get_start_conf()? == StartConf::Auto {
             log::info!("Starting instance {:?}", inst.name());
             inst.start(&Start {


### PR DESCRIPTION
We need to `bootout` the service first to let launchd reload the new service file, so that it doesn't write to old log files. Also this is needed to run the `bootstrap`.

Also fixed a typo.