### PR TITLE
authenticate: Add an option to reduce verbosity

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -231,6 +231,10 @@ pub struct Authenticate {
     /// Run in non-interactive mode (accepting all defaults)
     #[clap(long)]
     pub non_interactive: bool,
+
+    /// Reduce command verbosity.
+    #[clap(long)]
+    pub quiet: bool,
 }
 
 #[derive(EdbClap, Clone, Debug)]


### PR DESCRIPTION
Currently, `edb cli` calls `edgedb authenticate` on a dev instance
unconditionally resulting in a bunch of noise in the terminal.  Add a
`-q` option to `authenticate` to make it less chatty.