### PR TITLE
Don't panic if Docker set EDGEDB_PORT=tcp://...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "edgedb-client"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb-rust#9d8aeb5e7f0573c6add53b4f9caf75d94a64a1a1"
+source = "git+https://github.com/edgedb/edgedb-rust#a3e4e451261d362ee3b2e34fe052148badc24914"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb-rust#9d8aeb5e7f0573c6add53b4f9caf75d94a64a1a1"
+source = "git+https://github.com/edgedb/edgedb-rust#a3e4e451261d362ee3b2e34fe052148badc24914"
 dependencies = [
  "proc-macro2",
  "quote 1.0.9",
@@ -1079,7 +1079,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb-rust#9d8aeb5e7f0573c6add53b4f9caf75d94a64a1a1"
+source = "git+https://github.com/edgedb/edgedb-rust#a3e4e451261d362ee3b2e34fe052148badc24914"
 dependencies = [
  "bigdecimal",
  "bytes",


### PR DESCRIPTION
Running the sample on https://github.com/edgedb/edgedb-docker will hti an error like:

```
edgedb error: Cannot parse environment variable "EDGEDB_PORT": invalid digit found in string
```

This is because Docker added environment variables like `EDGEDB_PORT=tcp://172.....:5656` when there is a link named `edgedb` like `docker run --link=edgedb edgedb/edgedb-cli`, and our CLI took that value and failed to parse it into an integer. This PR simply identifies the situation and ignores the wrong value.

Also updated edgedb-rust revision.