### PR TITLE
Consistently check major_version for compare

### DIFF
--- a/src/server/distribution.rs
+++ b/src/server/distribution.rs
@@ -98,3 +98,33 @@ impl DistributionRef {
         self.0.downcast_ref()
     }
 }
+
+#[test]
+fn test_major_version_cmp() {
+    assert!(
+        MajorVersion::Nightly >
+        MajorVersion::Stable(Version("1-beta2".into()))
+    );
+    assert!(
+        MajorVersion::Stable(Version("1-beta3".into())) >
+        MajorVersion::Stable(Version("1-beta2".into()))
+    );
+    assert!(
+        MajorVersion::Stable(Version("1-rc".into())) >
+        MajorVersion::Stable(Version("1-beta2".into()))
+    );
+    assert!(
+        MajorVersion::Stable(Version("1-rc2".into())) >
+        MajorVersion::Stable(Version("1-beta2".into()))
+    );
+    assert!(
+        !(
+            MajorVersion::Stable(Version("1-beta2".into())) >
+            MajorVersion::Stable(Version("1-beta2".into()))
+        )
+    );
+    assert!(
+        MajorVersion::Stable(Version("1".into())) >
+        MajorVersion::Stable(Version("1-beta2".into()))
+    );
+}

--- a/src/server/docker.rs
+++ b/src/server/docker.rs
@@ -772,11 +772,9 @@ impl<'os, O: CurrentOs + ?Sized> DockerMethod<'os, O> {
         let tmp_role = format!("tmp_upgrade_{}", timestamp());
         let tmp_password = generate_password();
 
-        let cert_generated = match &new_image.major_version {
-            MajorVersion::Stable(ver) => ver > &Version("1-beta2".into()),
-            MajorVersion::Nightly => true,
-        };
-
+        let cert_generated = new_image.major_version > MajorVersion::Stable(
+            Version("1-beta2".into())
+        );
         let mut cmd = Command::new(&inst.method.cli);
         cmd.arg("run");
         cmd.arg("--rm");
@@ -1036,9 +1034,9 @@ impl<'os, O: CurrentOs + ?Sized> Method for DockerMethod<'os, O> {
             .arg("-c")
             .arg(format!("chown -R 999:999 /mnt")))?;
 
-        let cert_generated = settings.nightly ||
-            settings.version > Version("1-beta2".into());
-
+        let cert_generated = image.major_version > MajorVersion::Stable(
+            Version("1-beta2".into())
+        );
         let password = generate_password();
         let mut cmd = Command::new(&self.cli);
         cmd.arg("run");

--- a/src/server/unix.rs
+++ b/src/server/unix.rs
@@ -121,8 +121,9 @@ pub fn bootstrap(method: &dyn Method, settings: &init::Settings)
     cmd.arg("--log-level=warn");
     cmd.arg("--data-dir").arg(&dir);
 
-    let cert_generated = settings.nightly ||
-        settings.version > Version("1.0b2".into());
+    let cert_generated = pkg.major_version > MajorVersion::Stable(
+        Version("1-beta2".into())
+    );
     if cert_generated {
         cmd.arg("--generate-self-signed-cert");
     }
@@ -561,10 +562,7 @@ fn _reinit_and_restore(instance_dir: &Path, inst: &dyn Instance,
     let cert_generated = if instance_dir.join("edbtlscert.pem").exists() {
         false
     } else {
-        match &new_meta.version {
-            MajorVersion::Nightly => true,
-            MajorVersion::Stable(ver) => ver > &Version("1-beta2".into()),
-        }
+        new_meta.version > MajorVersion::Stable(Version("1-beta2".into()))
     };
     if cert_generated {
         cmd.arg("--generate-self-signed-cert");

--- a/src/server/version.rs
+++ b/src/server/version.rs
@@ -136,12 +136,14 @@ impl<T: AsRef<str>> Ord for Version<T> {
                 (None, Some(Numeric(_))) => Less,
                 (None, Some(String(x)))
                 if matches!(x, "a"|"b"|"c"|"rc"|"pre"|"dev"|"dirty")
+                || x.starts_with("beta") || x.starts_with("rc")
                 => Greater,
                 (None, Some(String(_))) => Less,
                 (Some(String(x)), None)
                 // git revision starts with g
                 if matches!(x, "a"|"b"|"c"|"rc"|"pre"|"dev"|"dirty")
                 || x.starts_with("g")
+                || x.starts_with("beta") || x.starts_with("rc")
                 => Less,
                 (Some(String(_)), None) => Greater,
                 (None, None) => return Equal,
@@ -204,5 +206,14 @@ mod test {
     #[test]
     fn edgedb_test() {
         assert!(Version("1-alpha2") < Version("1-alpha3"));
+        assert!(!(Version("1-beta2") < Version("1-beta2")));
+        assert!(Version("1-beta2") < Version("1-rc1"));
+        assert!(Version("1-beta2") < Version("1"));
+        assert!(Version("1-rc1") < Version("1"));
+        assert!(Version("1-rc2") < Version("1"));
+        assert!(Version("1") > Version("1-beta2"));
+        assert!(Version("1") > Version("1-rc1"));
+        assert!(Version("1") > Version("1-rc2"));
+        assert!(Version("3") < Version("12"));
     }
 }


### PR DESCRIPTION
Also:
* Added `edgedb authenticate` successful message
* Fixed `1-beta*`/`1-rc*`/`1` major_version compare issue