### PR TITLE
Allow manually dispatch nightly event

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -5,8 +5,6 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
     inputs: {}
-  repository_dispatch:
-    types: ["nightly-build"]
   push:
     branches:
       - nightly

--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -3,6 +3,8 @@ name: Build Test and Publish Nightly Packages
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs: {}
   repository_dispatch:
     types: ["nightly-build"]
   push:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,8 +5,6 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
     inputs: {}
-  repository_dispatch:
-    types: ["nightly-build"]
   push:
     branches:
       - nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,8 @@ name: Build Test and Publish Nightly Packages
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs: {}
   repository_dispatch:
     types: ["nightly-build"]
   push:


### PR DESCRIPTION
Although we had `repository_dispatch` with hook `nightly-build`