### PR TITLE
Rename authenticate to instance link

### DIFF
--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -13,17 +13,17 @@ use crate::print::style::Styler;
 
 
 pub fn main(options: Options) -> Result<(), anyhow::Error> {
-    let cmdopt = commands::Options {
-        command_line: true,
-        styler: if atty::is(atty::Stream::Stdout) {
-            Some(Styler::dark_256())
-        } else {
-            None
-        },
-        conn_params: options.conn_params.clone(),
-    };
     match options.subcommand.as_ref().expect("subcommand is present") {
         Command::Common(cmd) => {
+            let cmdopt = commands::Options {
+                command_line: true,
+                styler: if atty::is(atty::Stream::Stdout) {
+                    Some(Styler::dark_256())
+                } else {
+                    None
+                },
+                conn_params: options.create_connector()?,
+            };
             directory_check::check_and_warn();
             match cmd {
                 Common::Migration(
@@ -35,7 +35,7 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
                 }
                 cmd => {
                     task::block_on(async {
-                        let mut conn = options.conn_params.connect().await?;
+                        let mut conn = cmdopt.conn_params.connect().await?;
                         commands::execute::common(
                             &mut conn, cmd, &cmdopt
                         ).await?;
@@ -59,7 +59,7 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
         Command::Query(q) => {
             directory_check::check_and_warn();
             task::block_on(async {
-                let mut conn = options.conn_params.connect().await?;
+                let mut conn = options.create_connector()?.connect().await?;
                 for query in &q.queries {
                     non_interactive::query(&mut conn, query, &options).await?;
                 }

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -50,7 +50,7 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
         }
         Command::Instance(cmd) => {
             directory_check::check_and_error()?;
-            server::instance_main(cmd)
+            server::instance_main(cmd, &options)
         }
         Command::Project(cmd) => {
             directory_check::check_and_error()?;
@@ -74,12 +74,6 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
         }
         Command::CliCommand(c) => {
             cli::main(c)
-        },
-        Command::Authenticate(cmd) => {
-            task::block_on(async {
-                server::authenticate::authenticate(cmd, &options).await?;
-                Ok(())
-            }).into()
         },
     }
 }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -92,6 +92,7 @@ impl<'a> Iterator for ToDo<'a> {
 pub fn main(options: Options) -> Result<(), anyhow::Error> {
     let (control_wr, control_rd) = channel(1);
     let (repl_wr, repl_rd) = channel(1);
+    let conn = options.create_connector()?;
     let state = repl::State {
         prompt: repl::PromptRpc {
             control: control_wr,
@@ -108,8 +109,8 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
         input_mode: repl::InputMode::Emacs,
         print_stats: repl::PrintStats::Off,
         history_limit: 10000,
-        database: options.conn_params.get()?.get_database().into(),
-        conn_params: options.conn_params.clone(),
+        database: conn.get()?.get_database().into(),
+        conn_params: conn,
         last_version: None,
         connection: None,
         initial_text: "".into(),

--- a/src/non_interactive.rs
+++ b/src/non_interactive.rs
@@ -21,7 +21,7 @@ use crate::outputs::tab_separated;
 pub async fn main(options: Options)
     -> Result<(), anyhow::Error>
 {
-    let mut conn = options.conn_params.connect().await?;
+    let mut conn = options.create_connector()?.connect().await?;
     let mut stdin = stdin();
     let mut inbuf = BytesMut::with_capacity(8192);
     loop {

--- a/src/server/control.rs
+++ b/src/server/control.rs
@@ -50,7 +50,12 @@ pub fn instance_command(cmd: &InstanceCommand) -> anyhow::Result<()> {
                 return status::print_status_all(c.extended, c.debug, c.json);
             }
         }
-        _ => panic!("Should not be here"),
+        | Create(_)
+        | Destroy(_)
+        | Link(_)
+        | ResetPassword(_) => {
+            unreachable!("handled in server::main::instance_main()");
+        }
     };
     let os = detect::current_os()?;
     let methods = os.get_available_methods()?.instantiate_all(&*os, true)?;
@@ -78,6 +83,11 @@ pub fn instance_command(cmd: &InstanceCommand) -> anyhow::Result<()> {
                 }
             }
         }
-        _ => panic!("Should not be here"),
+        | Create(_)
+        | Destroy(_)
+        | Link(_)
+        | ResetPassword(_) => {
+            unreachable!("handled in server::main::instance_main()");
+        }
     }
 }

--- a/src/server/link.rs
+++ b/src/server/link.rs
@@ -1,6 +1,7 @@
 use std::sync::{Mutex, Arc};
 
 use anyhow::Context;
+use async_std::task;
 use edgedb_client::{verify_server_cert, Builder};
 use edgedb_client::errors::PasswordRequired;
 use pem;
@@ -124,7 +125,11 @@ fn gen_default_instance_name(input: &dyn ToString) -> String {
     }).collect::<String>()
 }
 
-pub async fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
+pub fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
+    task::block_on(async_link(cmd, opts))
+}
+
+async fn async_link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
     let builder = opts.conn_params.get()?;
     let mut creds = builder.as_credentials()?;
     let mut verifier = Arc::new(

--- a/src/server/link.rs
+++ b/src/server/link.rs
@@ -9,9 +9,11 @@ use rustls;
 use rustls::{RootCertStore, ServerCertVerifier, ServerCertVerified, TLSError};
 use webpki::DNSNameRef;
 
-use crate::options::{Authenticate, Options, ConnectionOptions};
+use crate::connect::Connector;
+use crate::options::{Options, ConnectionOptions};
 use crate::{question, credentials};
 use crate::server::reset_password::write_credentials;
+use crate::server::options::Link;
 
 struct InteractiveCertVerifier {
     cert_out: Mutex<Option<String>>,
@@ -122,7 +124,7 @@ fn gen_default_instance_name(input: &dyn ToString) -> String {
     }).collect::<String>()
 }
 
-pub async fn authenticate(cmd: &Authenticate, opts: &Options) -> anyhow::Result<()> {
+pub async fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
     let builder = opts.conn_params.get()?;
     let mut creds = builder.as_credentials()?;
     let mut verifier = Arc::new(
@@ -133,8 +135,9 @@ pub async fn authenticate(cmd: &Authenticate, opts: &Options) -> anyhow::Result<
             creds.tls_cert_data.is_none(),
         )
     );
-    let r = builder.connect_with_cert_verifier(verifier.clone()).await;
-    if let Err(e) = r {
+    if let Err(e) = opts.conn_params.connect_with_cert_verifier(
+    verifier.clone()
+    ).await {
         if e.is::<PasswordRequired>() && !cmd.non_interactive {
             let password = rpassword::read_password_from_tty(
                 Some(&format!("Password for '{}': ",
@@ -154,7 +157,9 @@ pub async fn authenticate(cmd: &Authenticate, opts: &Options) -> anyhow::Result<
                     creds.tls_cert_data.is_none(),
                 )
             );
-            builder.connect_with_cert_verifier(verifier.clone()).await?;
+            Connector::new(Ok(builder)).connect_with_cert_verifier(
+                verifier.clone()
+            ).await?;
         } else {
             return Err(e);
         }
@@ -168,7 +173,9 @@ pub async fn authenticate(cmd: &Authenticate, opts: &Options) -> anyhow::Result<
         None => {
             let default = gen_default_instance_name(builder.get_addr());
             if cmd.non_interactive {
-                eprintln!("Using generated instance name: {}", &default);
+                if !cmd.quiet {
+                    eprintln!("Using generated instance name: {}", &default);
+                }
                 (credentials::path(&default)?, default)
             } else {
                 let name = question::String::new(
@@ -197,7 +204,8 @@ pub async fn authenticate(cmd: &Authenticate, opts: &Options) -> anyhow::Result<
     write_credentials(&cred_path, &creds)?;
     if !cmd.quiet {
         eprintln!(
-            "Authentication succeeded. To connect run:\n  edgedb -I {}",
+            "Successfully linked to remote instance. To connect run:\
+            \n  edgedb -I {}",
             instance_name,
         );
     }
@@ -207,24 +215,26 @@ pub async fn authenticate(cmd: &Authenticate, opts: &Options) -> anyhow::Result<
 pub fn prompt_conn_params(
     options: &ConnectionOptions,
     builder: &mut Builder,
-    auth: &Authenticate,
+    link: &Link,
 ) -> anyhow::Result<()> {
-    if auth.non_interactive && options.password {
-        anyhow::bail!("Not both --password and authenticate --non-interactive")
+    if link.non_interactive && options.password {
+        anyhow::bail!(
+            "--password and --non-interactive are mutually exclusive."
+        )
     }
     let (host, port) = builder.get_addr().get_tcp_addr().ok_or_else(|| {
-        anyhow::anyhow!("Cannot authenticate to a UNIX domain socket.")
+        anyhow::anyhow!("Cannot link to a UNIX domain socket.")
     })?;
     let (mut host, mut port) = (host.clone(), *port);
     if options.host.is_none() && host == "127.0.0.1" {
-        // Workaround for the `edgedb authenticate`
+        // Workaround for the `edgedb instance link`
         // https://github.com/briansmith/webpki/issues/54
         builder.tcp_addr("localhost", port);
         host = "localhost".into();
     }
 
-    if auth.non_interactive {
-        if !auth.quiet {
+    if link.non_interactive {
+        if !link.quiet {
             eprintln!(
                 "Authenticating to edgedb://{}@{}/{}",
                 builder.get_user(),

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -1,5 +1,3 @@
-use async_std::task;
-
 use crate::options::Options;
 use crate::server::options::{ServerCommand, Command};
 use crate::server::options::{ServerInstanceCommand, InstanceCommand};
@@ -37,12 +35,7 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options) -> Result<(
         Create(c) => create::create(c),
         Destroy(c) => destroy::destroy(c),
         ResetPassword(c) => reset_password::reset_password(c),
-        Link(c) => {
-            task::block_on(async {
-                link::link(c, &options).await?;
-                Ok(())
-            }).into()
-        }
+        Link(c) => link::link(c, &options),
         cmd => control::instance_command(cmd)
     }
 }

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -1,3 +1,6 @@
+use async_std::task;
+
+use crate::options::Options;
 use crate::server::options::{ServerCommand, Command};
 use crate::server::options::{ServerInstanceCommand, InstanceCommand};
 
@@ -7,6 +10,7 @@ use crate::server::destroy;
 use crate::server::detect;
 use crate::server::info;
 use crate::server::install;
+use crate::server::link;
 use crate::server::list_versions;
 use crate::server::reset_password;
 use crate::server::uninstall;
@@ -26,13 +30,19 @@ pub fn main(cmd: &ServerCommand) -> Result<(), anyhow::Error> {
     }
 }
 
-pub fn instance_main(cmd: &ServerInstanceCommand) -> Result<(), anyhow::Error> {
+pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options) -> Result<(), anyhow::Error> {
     use InstanceCommand::*;
 
     match &cmd.subcommand {
         Create(c) => create::create(c),
         Destroy(c) => destroy::destroy(c),
         ResetPassword(c) => reset_password::reset_password(c),
+        Link(c) => {
+            task::block_on(async {
+                link::link(c, &options).await?;
+                Ok(())
+            }).into()
+        }
         cmd => control::instance_command(cmd)
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -30,13 +30,13 @@ pub mod destroy;
 pub mod errors;
 mod info;
 pub mod install;
+pub mod link;
 mod list_versions;
 pub mod reset_password;
 mod revert;
 mod status;
 mod uninstall;
 pub mod upgrade;
-pub mod authenticate;
 
 pub use main::{main, instance_main};
 

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -36,6 +36,9 @@ pub enum InstanceCommand {
     Restart(Restart),
     /// Destroy an instance and remove the data
     Destroy(Destroy),
+    /// Link to a remote instance
+    #[edb(inherit(crate::options::ConnectionOptions))]
+    Link(Link),
     /// Show logs of an instance
     Logs(Logs),
     /// Revert a major instance upgrade
@@ -175,6 +178,23 @@ pub struct Destroy {
     /// Force destroy even if instance is referred to by a project
     #[clap(long)]
     pub force: bool,
+}
+
+#[derive(EdbClap, Clone, Debug)]
+#[clap(long_about = "Link to a remote EdgeDB instance and
+assign an instance name to simplify future connections.")]
+pub struct Link {
+    /// Specify a new instance name for the remote server. If not
+    /// present, the name will be interactively asked.
+    pub name: Option<String>,
+
+    /// Run in non-interactive mode (accepting all defaults)
+    #[clap(long)]
+    pub non_interactive: bool,
+
+    /// Reduce command verbosity.
+    #[clap(long)]
+    pub quiet: bool,
 }
 
 #[derive(EdbClap, Debug, Clone)]


### PR DESCRIPTION
Also:

* Added connecting hint in link
* CRF #392: follow Rust best practice

TODO:

- [x] unlink
- [x] list links in `instance status`
- [x] update RFC 1006
- [x] update RFC 1008