### PR TITLE
Pass instance name to the server via env var

### DIFF
--- a/src/server/docker.rs
+++ b/src/server/docker.rs
@@ -704,6 +704,8 @@ impl<'os, O: CurrentOs + ?Sized> DockerMethod<'os, O> {
                         options.port));
         cmd.arg(format!("--label=com.edgedb.metadata.start-conf={}",
                         options.start_conf));
+        cmd.env("EDGEDB_SERVER_INSTANCE_NAME", options.name);
+        cmd.arg("--env").arg("EDGEDB_SERVER_INSTANCE_NAME");
         cmd.arg(options.image.tag.as_image_name());
         cmd.arg("edgedb-server");
         cmd.arg("--runstate-dir").arg("/var/lib/edgedb/data/run");

--- a/src/server/docker.rs
+++ b/src/server/docker.rs
@@ -706,6 +706,7 @@ impl<'os, O: CurrentOs + ?Sized> DockerMethod<'os, O> {
                         options.start_conf));
         cmd.env("EDGEDB_SERVER_INSTANCE_NAME", options.name);
         cmd.arg("--env").arg("EDGEDB_SERVER_INSTANCE_NAME");
+        cmd.arg("--env").arg("EDGEDB_SERVER_ALLOW_INSECURE_HTTP_CLIENTS=1");
         cmd.arg(options.image.tag.as_image_name());
         cmd.arg("edgedb-server");
         cmd.arg("--runstate-dir").arg("/var/lib/edgedb/data/run");

--- a/src/server/linux.rs
+++ b/src/server/linux.rs
@@ -155,6 +155,7 @@ impl Instance for LocalInstance<'_> {
         cmd.arg("--data-dir").arg(&self.path);
         cmd.arg("--runstate-dir").arg(&socket_dir);
         cmd.env("EDGEDB_SERVER_INSTANCE_NAME", self.name());
+        cmd.env("EDGEDB_SERVER_ALLOW_INSECURE_HTTP_CLIENTS", "1");
         Ok(cmd)
     }
     fn upgrade<'x>(&'x self, meta: &Metadata)
@@ -292,7 +293,7 @@ After=network.target
 Type=notify
 {userinfo}
 
-Environment="EDGEDATA={directory}" "EDGEDB_SERVER_INSTANCE_NAME={instance_name}"
+Environment="EDGEDATA={directory}" "EDGEDB_SERVER_INSTANCE_NAME={instance_name}" "EDGEDB_SERVER_ALLOW_INSECURE_HTTP_CLIENTS=1"
 RuntimeDirectory=edgedb-{instance_name}
 
 ExecStart={server_path} --data-dir=${{EDGEDATA}} --runstate-dir=%t/edgedb-{instance_name} --port={port}

--- a/src/server/linux.rs
+++ b/src/server/linux.rs
@@ -154,6 +154,7 @@ impl Instance for LocalInstance<'_> {
         cmd.arg("--port").arg(self.get_meta()?.port.to_string());
         cmd.arg("--data-dir").arg(&self.path);
         cmd.arg("--runstate-dir").arg(&socket_dir);
+        cmd.env("EDGEDB_SERVER_INSTANCE_NAME", self.name());
         Ok(cmd)
     }
     fn upgrade<'x>(&'x self, meta: &Metadata)
@@ -291,7 +292,7 @@ After=network.target
 Type=notify
 {userinfo}
 
-Environment=EDGEDATA={directory}
+Environment="EDGEDATA={directory}" "EDGEDB_SERVER_INSTANCE_NAME={instance_name}"
 RuntimeDirectory=edgedb-{instance_name}
 
 ExecStart={server_path} --data-dir=${{EDGEDATA}} --runstate-dir=%t/edgedb-{instance_name} --port={port}

--- a/src/server/macos.rs
+++ b/src/server/macos.rs
@@ -544,6 +544,7 @@ impl<'a> Instance for LocalInstance<'a> {
         cmd.arg("--port").arg(self.get_meta()?.port.to_string());
         cmd.arg("--data-dir").arg(&self.path);
         cmd.arg("--runstate-dir").arg(&socket_dir);
+        cmd.env("EDGEDB_SERVER_INSTANCE_NAME", self.name());
         Ok(cmd)
     }
     fn upgrade(&self, meta: &Metadata)
@@ -627,6 +628,12 @@ fn plist_data(name: &str, meta: &Metadata)
         <string>--runstate-dir={runtime_dir}</string>
         <string>--port={port}</string>
     </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>EDGEDB_SERVER_INSTANCE_NAME</key>
+        <string>{instance_name}</string>
+    </dict>
 
     <key>StandardOutPath</key>
     <string>{log_path}</string>

--- a/src/server/macos.rs
+++ b/src/server/macos.rs
@@ -545,6 +545,7 @@ impl<'a> Instance for LocalInstance<'a> {
         cmd.arg("--data-dir").arg(&self.path);
         cmd.arg("--runstate-dir").arg(&socket_dir);
         cmd.env("EDGEDB_SERVER_INSTANCE_NAME", self.name());
+        cmd.env("EDGEDB_SERVER_ALLOW_INSECURE_HTTP_CLIENTS", "1");
         Ok(cmd)
     }
     fn upgrade(&self, meta: &Metadata)
@@ -633,6 +634,8 @@ fn plist_data(name: &str, meta: &Metadata)
     <dict>
         <key>EDGEDB_SERVER_INSTANCE_NAME</key>
         <string>{instance_name}</string>
+        <key>EDGEDB_SERVER_ALLOW_INSECURE_HTTP_CLIENTS</key>
+        <string>1</string>
     </dict>
 
     <key>StandardOutPath</key>


### PR DESCRIPTION
This way the server instances can render a nice HTML page about
themselves.

Note: I'm not sure that what I'm doing here is correct. Few thoughts:

1. I initially wanted to add a command-line argument to `edgedb-server`, but that would make it harder for us to actually run it from the CLI: we'd have to somehow detect if the `edgedb-server` version we are about to run supports this new argument or not. With an environment variable we don't care; it's up to the server if it wants to use it -- but it's always there.

2. I've updated launchd and systemd entries to include the variable, as well as other places when we run the process, as well as when we create the container with docker.