### PR TITLE
Refactor color highlighting of REPL output

### DIFF
--- a/src/print/json.rs
+++ b/src/print/json.rs
@@ -1,6 +1,5 @@
 use serde_json::Value;
 
-use colorful::Colorful;
 use crate::print::{FormatExt, Formatter};
 use crate::print::buffer::Result;
 
@@ -9,9 +8,10 @@ impl FormatExt for Value {
     fn format<F: Formatter>(&self, prn: &mut F) -> Result<F::Error> {
         use Value as V;
         match self {
-            V::Null => prn.const_scalar("null"),
-            V::Bool(v) => prn.const_scalar(v),
-            s@V::String(_)|s@V::Number(_) => prn.const_scalar(s),
+            V::Null => prn.const_bool("null"),
+            V::Bool(v) => prn.const_bool(v),
+            s@V::String(_) => prn.const_string(s),
+            s@V::Number(_) => prn.const_number(s),
             V::Array(items) => {
                 prn.array(|prn| {
                     for item in items {
@@ -25,13 +25,17 @@ impl FormatExt for Value {
                 prn.json_object(|prn| {
                     for (key, value) in dict {
                         if key.starts_with('@') {
-                            prn.object_field(serde_json::to_string(key)
-                                             .expect("cannot serialize string")
-                                             .rgb(0, 0xa5, 0xcb).bold())?;
+                            prn.object_field(
+                                serde_json::to_string(key)
+                                .expect("cannot serialize string")
+                                .as_ref(),
+                            false)?;
                         } else {
-                            prn.object_field(serde_json::to_string(key)
-                                             .expect("cannot serialize string")
-                                             .light_blue().bold())?;
+                            prn.object_field(
+                                serde_json::to_string(key)
+                                .expect("cannot serialize string")
+                                .as_ref(),
+                                false)?;
                         }
                         value.format(prn)?;
                         prn.comma()?;

--- a/src/print/native.rs
+++ b/src/print/native.rs
@@ -1,7 +1,6 @@
 use std::cmp::min;
 
 use bigdecimal::BigDecimal;
-use colorful::Colorful;
 use num_bigint::BigInt;
 
 use edgedb_protocol::value::Value;
@@ -94,20 +93,20 @@ impl FormatExt for Value {
     fn format<F: Formatter>(&self, prn: &mut F) -> Result<F::Error> {
         use Value as V;
         match self {
-            V::Nothing => prn.const_scalar("Nothing"),
-            V::Uuid(u) => prn.const_scalar(u),
+            V::Nothing => prn.const_uuid("Nothing"),
+            V::Uuid(u) => prn.const_uuid(u),
             V::Str(s) => {
-                prn.const_scalar(format_string(s, prn.expand_strings()))
+                prn.const_string(format_string(s, prn.expand_strings()))
             }
-            V::Bytes(b) => prn.const_scalar(format_bytes(b)),
-            V::Int16(v) => prn.const_scalar(v),
-            V::Int32(v) => prn.const_scalar(v),
-            V::Int64(v) => prn.const_scalar(v),
-            V::Float32(v) => prn.const_scalar(v),
-            V::Float64(v) => prn.const_scalar(v),
-            V::BigInt(v) => prn.const_scalar(format_bigint(v.into())),
-            V::Decimal(v) => prn.const_scalar(format_decimal(v.into())),
-            V::Bool(v) => prn.const_scalar(v),
+            V::Bytes(b) => prn.const_string(format_bytes(b)),
+            V::Int16(v) => prn.const_number(v),
+            V::Int32(v) => prn.const_number(v),
+            V::Int64(v) => prn.const_number(v),
+            V::Float32(v) => prn.const_number(v),
+            V::Float64(v) => prn.const_number(v),
+            V::BigInt(v) => prn.const_number(format_bigint(v.into())),
+            V::Decimal(v) => prn.const_number(format_decimal(v.into())),
+            V::Bool(v) => prn.const_bool(v),
             V::Datetime(t) => prn.typed("datetime", format!("{:?}", t)),
             V::LocalDatetime(t)
             => prn.typed("cal::local_datetime", format!("{:?}", t)),
@@ -119,7 +118,7 @@ impl FormatExt for Value {
             V::RelativeDuration(d) => {
                 prn.typed("cal::relative_duration", d.to_string())
             }
-            V::Json(d) => prn.const_scalar(format!("{:?}", d)),
+            V::Json(d) => prn.const_string(format!("{:?}", d)),
             V::Set(items) => {
                 prn.set(|prn| {
                     if let Some(limit) = prn.max_items() {
@@ -156,12 +155,11 @@ impl FormatExt for Value {
                         if !fld.flag_implicit || prn.implicit_properties() {
                             if fld.flag_link_property {
                                 prn.object_field(
-                                    ("@".to_owned() + &fld.name)
-                                    .rgb(0, 0xa5, 0xcb).bold()
+                                    &("@".to_owned() + &fld.name),
+                                    true
                                 )?;
                             } else {
-                                prn.object_field(
-                                    fld.name.clone().light_blue().bold())?;
+                                prn.object_field(&fld.name, false)?;
                             };
                             value.format(prn)?;
                             prn.comma()?;
@@ -173,8 +171,7 @@ impl FormatExt for Value {
                             .iter().zip(fields)
                             .find(|(f, _) | f.name == "id")
                         {
-                            prn.object_field(
-                                fld.name.clone().light_blue().bold())?;
+                            prn.object_field(&fld.name, false)?;
                             value.format(prn)?;
                             prn.comma()?;
                         }
@@ -220,7 +217,7 @@ impl FormatExt for Value {
                     Ok(())
                 })
             }
-            V::Enum(v) => prn.const_scalar(&**v),
+            V::Enum(v) => prn.const_enum(&**v),
         }
     }
 }

--- a/src/print/tests.rs
+++ b/src/print/tests.rs
@@ -12,6 +12,7 @@ use edgedb_protocol::model::Datetime;
 use edgedb_protocol::codec::{ObjectShape, ShapeElement};
 use crate::print::{self, _native_format, Config};
 use crate::print::native::FormatExt;
+use crate::print::style::Styler;
 
 struct UnfusedStream<'a, I>(Option<&'a [I]>);
 
@@ -58,6 +59,7 @@ fn test_format<I: FormatExt + Clone + Send + Sync>(items: &[I])
         max_width: Some(80),
         implicit_properties: false,
         max_items: None,
+        styler: Styler::dark_256(),
     })
 }
 

--- a/tests/func/interactive.rs
+++ b/tests/func/interactive.rs
@@ -6,11 +6,11 @@ use crate::SERVER;
 fn simple_query() -> Result<(), Box<dyn Error>> {
     let mut cmd = SERVER.admin_interactive();
     cmd.exp_string("edgedb>")?;
-    cmd.send_line("SELECT 1+2;\n")?;
-    cmd.exp_string("{\u{1b}[38;5;2m3\u{1b}[0m}\r\n")?;
+    cmd.send_line("SELECT 'abc'++'def';\n")?;
+    cmd.exp_string("abcdef")?;
     cmd.exp_string("edgedb>")?;
-    cmd.send_line(" SELECT 2+3;\n")?;
-    cmd.exp_string("{\u{1b}[38;5;2m5\u{1b}[0m}\r\n")?;
+    cmd.send_line(" SELECT 'xy'++'z';\n")?;
+    cmd.exp_string("xyz")?;
     Ok(())
 }
 
@@ -18,9 +18,9 @@ fn simple_query() -> Result<(), Box<dyn Error>> {
 fn two_queries() -> Result<(), Box<dyn Error>> {
     let mut cmd = SERVER.admin_interactive();
     cmd.exp_string("edgedb>")?;
-    cmd.send_line("SELECT 1+2; SELECT 2+3;\n")?;
-    cmd.exp_string("{\u{1b}[38;5;2m3\u{1b}[0m}\r\n")?;
-    cmd.exp_string("{\u{1b}[38;5;2m5\u{1b}[0m}\r\n")?;
+    cmd.send_line("SELECT 'AB'++'C'; SELECT 'XY'++'Z';\n")?;
+    cmd.exp_string("ABC")?;
+    cmd.exp_string("XYZ")?;
     Ok(())
 }
 


### PR DESCRIPTION
Refactor output highlighting; implement Tomorrow Night color scheme

* Refactor output highlighting to use the the same abstraction
    (`print::style::Styler`) that we use to highlight EdgeQL in input;
  This makes the input and output styling consistent.

* Cleanup and and new enum members to `print::style::Style`;

* Switch Styler to use xterm256 palette (non-RGB) for better
    compatibility (apparently macOS' default Terminal.app still doesn't
    support RGB);

* Implement the Tomorrow Night color scheme. It's not too bright and not
    too dark, should cater well to the majority of the users. It's also
    one of the most popular themes programmers use;

* Drop some dead code and unused `Style` enum members;

* Hide object name when it is "std::VirtualObject" -- that's
    anonumous shapes and showing a name there is confusing.


## Before


![Screenshot from 2021-08-01 18-13-31](https://user-images.githubusercontent.com/239003/127797643-ceccc531-d3cd-4dc7-a812-b3d6c2607090.png)


## After

![Screenshot from 2021-08-01 18-14-10](https://user-images.githubusercontent.com/239003/127797652-a5f42380-66eb-4ac1-89c3-6e8a98b41a6d.png)
