### PR TITLE
instance link --non-interactive default to untrust

### DIFF
--- a/src/server/link.rs
+++ b/src/server/link.rs
@@ -217,10 +217,12 @@ async fn async_link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
         }
     };
     if cred_path.exists() {
-        if cmd.non_interactive {
+        if cmd.overwrite {
             if !cmd.quiet {
                 eprintln!("Overwriting {}", cred_path.display());
             }
+        } else if cmd.non_interactive {
+            anyhow::bail!("File {} exists; abort.", cred_path.display());
         } else {
             let mut q = question::Confirm::new_dangerous(
                 format!("{} exists! Overwrite?", cred_path.display())

--- a/src/server/link.rs
+++ b/src/server/link.rs
@@ -25,7 +25,7 @@ struct InteractiveCertVerifier {
     system_ca_only: bool,
     non_interactive: bool,
     quiet: bool,
-    trust: bool,
+    trust_tls_cert: bool,
 }
 
 impl InteractiveCertVerifier {
@@ -34,7 +34,7 @@ impl InteractiveCertVerifier {
         quiet: bool,
         verify_hostname: Option<bool>,
         system_ca_only: bool,
-        trust: bool,
+        trust_tls_cert: bool,
     ) -> Self {
         Self {
             cert_out: Mutex::new(None),
@@ -42,7 +42,7 @@ impl InteractiveCertVerifier {
             system_ca_only,
             non_interactive,
             quiet,
-            trust,
+            trust_tls_cert,
         }
     }
 }
@@ -85,7 +85,7 @@ impl ServerCertVerifier for InteractiveCertVerifier {
                     &digest::SHA1_FOR_LEGACY_USE_ONLY,
                     &presented_certs[untrusted_index].0
                 );
-                if self.trust {
+                if self.trust_tls_cert {
                     if !self.quiet {
                         eprintln!(
                             "Trusting unknown server certificate: {:?}",
@@ -162,7 +162,7 @@ async fn async_link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
             cmd.quiet,
             creds.tls_verify_hostname,
             creds.tls_cert_data.is_none(),
-            cmd.trust,
+            cmd.trust_tls_cert,
         )
     );
     if let Err(e) = builder.connect_with_cert_verifier(

--- a/src/server/link.rs
+++ b/src/server/link.rs
@@ -25,6 +25,7 @@ struct InteractiveCertVerifier {
     system_ca_only: bool,
     non_interactive: bool,
     quiet: bool,
+    trust: bool,
 }
 
 impl InteractiveCertVerifier {
@@ -33,6 +34,7 @@ impl InteractiveCertVerifier {
         quiet: bool,
         verify_hostname: Option<bool>,
         system_ca_only: bool,
+        trust: bool,
     ) -> Self {
         Self {
             cert_out: Mutex::new(None),
@@ -40,6 +42,7 @@ impl InteractiveCertVerifier {
             system_ca_only,
             non_interactive,
             quiet,
+            trust,
         }
     }
 }
@@ -82,13 +85,15 @@ impl ServerCertVerifier for InteractiveCertVerifier {
                     &digest::SHA1_FOR_LEGACY_USE_ONLY,
                     &presented_certs[untrusted_index].0
                 );
-                if self.non_interactive {
+                if self.trust {
                     if !self.quiet {
                         eprintln!(
                             "Trusting unknown server certificate: {:?}",
                             fingerprint,
                         );
                     }
+                } else if self.non_interactive {
+                    return Err(e);
                 } else {
                     if let Ok(answer) = question::Confirm::new(
                         format!(
@@ -157,6 +162,7 @@ async fn async_link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
             cmd.quiet,
             creds.tls_verify_hostname,
             creds.tls_cert_data.is_none(),
+            cmd.trust,
         )
     );
     if let Err(e) = builder.connect_with_cert_verifier(
@@ -179,6 +185,7 @@ async fn async_link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
                     false,
                     creds.tls_verify_hostname,
                     creds.tls_cert_data.is_none(),
+                    true,
                 )
             );
             Connector::new(Ok(builder)).connect_with_cert_verifier(

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -200,7 +200,7 @@ pub struct Link {
 
     /// Trust peer certificate.
     #[clap(long)]
-    pub trust: bool,
+    pub trust_tls_cert: bool,
 
     /// Overwrite existing credential file if any.
     #[clap(long)]

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -198,9 +198,13 @@ pub struct Link {
     #[clap(long)]
     pub quiet: bool,
 
-    /// Trust peer certificate
+    /// Trust peer certificate.
     #[clap(long)]
     pub trust: bool,
+
+    /// Overwrite existing credential file if any.
+    #[clap(long)]
+    pub overwrite: bool,
 }
 
 #[derive(EdbClap, Clone, Debug)]

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -197,6 +197,10 @@ pub struct Link {
     /// Reduce command verbosity.
     #[clap(long)]
     pub quiet: bool,
+
+    /// Trust peer certificate
+    #[clap(long)]
+    pub trust: bool,
 }
 
 #[derive(EdbClap, Clone, Debug)]


### PR DESCRIPTION
`--non-interactive` will no longer trust the peer certificate by
default. Instead, new option `--trust` option should be used together
with `--non-interactive`. `--trust` can also be used in interactive mode
to avoid the question.

Also added `--overwrite` to manage the existing credential file overwriting.