### PR TITLE
EdbClap: Don't add from_str check if has validator

### DIFF
--- a/edgedb-cli-derive/src/into_app.rs
+++ b/edgedb-cli-derive/src/into_app.rs
@@ -237,11 +237,6 @@ fn mk_arg(field: &types::Field, case: &Case) -> TokenStream {
             #arg = #arg.value_name(#name);
         });
     }
-    for (name, value) in &field.attrs.options {
-        modifiers.extend(quote! {
-            #arg = #arg.#name(#value);
-        });
-    }
     match field.parse.kind {
         ParserKind::TryFromStr => {
             let ty = &field.ty;
@@ -270,6 +265,13 @@ fn mk_arg(field: &types::Field, case: &Case) -> TokenStream {
             });
         }
         _ => {}
+    }
+    // The arbitrary options must be added in the end so that e.g. explicit
+    // validator() could overwrite the validators added by default previously
+    for (name, value) in &field.attrs.options {
+        modifiers.extend(quote! {
+            #arg = #arg.#name(#value);
+        });
     }
 
     return quote! {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -52,5 +52,5 @@ pub fn is_valid_name(name: &str) -> bool {
             return false;
         }
     }
-    return name != "_localdev"
+    return true;
 }

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -188,6 +188,8 @@ assign an instance name to simplify future connections.")]
 pub struct Link {
     /// Specify a new instance name for the remote server. If not
     /// present, the name will be interactively asked.
+    #[clap(validator(instance_name_opt))]
+    #[clap(value_hint=ValueHint::Other)]
     pub name: Option<String>,
 
     /// Run in non-interactive mode (accepting all defaults)
@@ -211,6 +213,8 @@ pub struct Link {
 #[clap(long_about = "Unlink from a remote EdgeDB instance.")]
 pub struct Unlink {
     /// Specify the name of the remote instance.
+    #[clap(validator(instance_name_opt))]
+    #[clap(value_hint=ValueHint::Other)]  // TODO complete instance name
     pub name: String,
 }
 


### PR DESCRIPTION
This fixes the issue that invalid instance names can be used in `instance create` etc.

Also fixed _localdev check logic with proper error message.

Refs #356