### PR TITLE
Add `edgedb instance list` from status

### DIFF
--- a/src/server/control.rs
+++ b/src/server/control.rs
@@ -47,16 +47,11 @@ pub fn instance_command(cmd: &InstanceCommand) -> anyhow::Result<()> {
         Logs(c) => &c.name,
         Revert(c) => &c.name,
         Unlink(c) => &c.name,
-        Status(c) => {
-            if let Some(name) = &c.name {
-                name
-            } else {
-                return status::print_status_all(c.extended, c.debug, c.json);
-            }
-        }
+        Status(c) => &c.name,
         | Create(_)
         | Destroy(_)
         | Link(_)
+        | List(_)
         | ResetPassword(_) => {
             unreachable!("handled in server::main::instance_main()");
         }
@@ -91,6 +86,7 @@ pub fn instance_command(cmd: &InstanceCommand) -> anyhow::Result<()> {
         | Create(_)
         | Destroy(_)
         | Link(_)
+        | List(_)
         | ResetPassword(_) => {
             unreachable!("handled in server::main::instance_main()");
         }

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -11,6 +11,7 @@ use crate::server::install;
 use crate::server::link;
 use crate::server::list_versions;
 use crate::server::reset_password;
+use crate::server::status;
 use crate::server::uninstall;
 use crate::server::upgrade;
 
@@ -36,6 +37,7 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options) -> Result<(
         Destroy(c) => destroy::destroy(c),
         ResetPassword(c) => reset_password::reset_password(c),
         Link(c) => link::link(c, &options),
+        List(c) => status::print_status_all(c.extended, c.debug, c.json),
         cmd => control::instance_command(cmd)
     }
 }

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -26,7 +26,9 @@ pub struct ServerInstanceCommand {
 pub enum InstanceCommand {
     /// Initialize a new server instance
     Create(Create),
-    /// Show statuses of all or of a matching instance
+    /// Show all instances
+    List(List),
+    /// Show status of a matching instance
     Status(Status),
     /// Start an instance
     Start(Start),
@@ -249,11 +251,26 @@ pub struct Restart {
 }
 
 #[derive(EdbClap, Debug, Clone)]
+pub struct List {
+    /// Output more debug info about each instance
+    #[clap(long)]
+    pub extended: bool,
+
+    /// Output all available debug info about each instance
+    #[clap(long, setting=ArgSettings::Hidden)]
+    pub debug: bool,
+
+    /// Output in JSON format
+    #[clap(long)]
+    pub json: bool,
+}
+
+#[derive(EdbClap, Debug, Clone)]
 pub struct Status {
     /// Database server instance name
     #[clap(validator(instance_name_opt))]
     #[clap(value_hint=ValueHint::Other)]  // TODO complete instance name
-    pub name: Option<String>,
+    pub name: String,
 
     /// Show current systems service info
     #[clap(long)]


### PR DESCRIPTION
Now we'll have:

* `edgedb instance list` works the same as previous `edgedb server status` without positional argument (instance name)
* `edgedb instance status <instance-name>` requires an instance name now.
* All keyword arguments are the same (only that `list` doesn't accept `--service`)