### PR TITLE
Undeprecate 'edgedb query'; add '--file' option to it.

### DIFF
--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -498,8 +498,8 @@ pub fn get_setting(s: &Setting, prompt: &repl::State) -> Cow<'static, str> {
         HistorySize(_) => {
             prompt.history_limit.to_string().into()
         }
-        OutputMode(_) => {
-            prompt.output_mode.as_str().into()
+        OutputFormat(_) => {
+            prompt.output_format.as_str().into()
         }
         ExpandStrings(_) => {
             bool_str(prompt.print.expand_strings).into()
@@ -586,8 +586,8 @@ pub async fn execute(cmd: &BackslashCmd, prompt: &mut repl::State)
                     let limit = c.value.expect("only set here");
                     prompt.set_history_limit(limit).await?;
                 }
-                OutputMode(c) => {
-                    prompt.output_mode = c.value.expect("only writes here");
+                OutputFormat(c) => {
+                    prompt.output_format = c.value.expect("only writes here");
                 }
                 ExpandStrings(b) => {
                     prompt.print.expand_strings = b.unwrap_value();

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -4,12 +4,12 @@ use crate::cli;
 use crate::cli::directory_check;
 use crate::options::{Options, Command};
 use crate::commands::parser::{Common, MigrationCmd, Migration};
-use crate::non_interactive;
 use crate::commands;
 use crate::migrations;
 use crate::server;
 use crate::project;
 use crate::print::style::Styler;
+use crate::non_interactive;
 
 
 pub fn main(options: Options) -> Result<(), anyhow::Error> {
@@ -58,14 +58,8 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
         }
         Command::Query(q) => {
             directory_check::check_and_warn();
-            task::block_on(async {
-                let mut conn = options.create_connector()?.connect().await?;
-                for query in &q.queries {
-                    non_interactive::query(&mut conn, query, &options).await?;
-                }
-                Ok(())
-            }).into()
-        },
+            task::block_on(non_interactive::main(&q, &options)).into()
+        }
         Command::_SelfInstall(s) => {
             cli::install::main(s)
         }

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -154,8 +154,8 @@ pub enum Setting {
     VerboseErrors(SettingBool),
     /// Set implicit LIMIT. Defaults to 100, specify 0 to disable.
     Limit(Limit),
-    /// Set output mode. One of: json, json-elements, default, tab-separated
-    OutputMode(OutputMode),
+    /// Set output format.
+    OutputFormat(OutputFormat),
     /// Stop escaping newlines in quoted strings
     ExpandStrings(SettingBool),
     /// Set number of entries retained in history
@@ -195,11 +195,11 @@ pub struct Edit {
 }
 
 #[derive(EdbClap, Clone, Debug, Default)]
-pub struct OutputMode {
+pub struct OutputFormat {
     #[clap(name="mode", possible_values=
-        &["json", "json-elements", "default", "tab-separated"][..]
+        &["default", "json-pretty", "json", "json-lines", "tab-separated"][..]
     )]
-    pub value: Option<repl::OutputMode>,
+    pub value: Option<repl::OutputFormat>,
 }
 
 #[derive(EdbClap, Clone, Debug, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn _main() -> anyhow::Result<()> {
         if opt.interactive {
             interactive::main(opt)
         } else {
-            task::block_on(non_interactive::main(opt))
+            task::block_on(non_interactive::interpret_stdin(opt))
         }
     }
 }

--- a/src/non_interactive.rs
+++ b/src/non_interactive.rs
@@ -4,12 +4,16 @@ use anyhow::{self, Context};
 use async_std::prelude::StreamExt;
 use async_std::io::{stdin, stdout};
 use async_std::io::prelude::WriteExt;
+use async_std::fs::{read as async_read};
 
 use bytes::BytesMut;
 use edgeql_parser::preparser;
 use edgedb_protocol::value::Value;
 
+use crate::commands::ExitCode;
 use crate::options::Options;
+use crate::options::Query;
+use crate::repl::OutputMode;
 use crate::print::{self, PrintError};
 use edgedb_client::reader::ReadError;
 use crate::statement::{ReadStatement, EndOfFile};
@@ -17,8 +21,42 @@ use edgedb_client::client::Connection;
 use edgedb_client::errors::NoResultExpected;
 use crate::outputs::tab_separated;
 
+use edgeql_parser::preparser::{full_statement};
 
-pub async fn main(options: Options)
+pub async fn main(q: &Query, options: &Options)
+    -> Result<(), anyhow::Error>
+{
+    let mut query_opts = options.clone();
+    query_opts.output_mode = if q.tab_separated {
+        OutputMode::TabSeparated
+    } else if q.json {
+        OutputMode::Json
+    } else {
+        // Let the top-level --json / --tab-seaparated propagate
+        // (they are deprecated, though.)
+        options.output_mode
+    };
+
+    if let Some(file) = &q.file {
+        if file == "-" {
+            interpret_stdin(query_opts).await?;
+        } else {
+            interpret_file(file.to_string(), query_opts).await?;
+        }
+    } else if let Some(queries) = &q.queries {
+        let mut conn = options.create_connector()?.connect().await?;
+        for query in queries {
+            run_query(&mut conn, query, &query_opts).await?;
+        }
+    } else {
+        eprintln!("error: either a --file option or \
+                  a <queries> positional argument is required.");
+    }
+
+    Ok(())
+}
+
+pub async fn interpret_stdin(options: Options)
     -> Result<(), anyhow::Error>
 {
     let mut conn = options.create_connector()?.connect().await?;
@@ -35,15 +73,14 @@ pub async fn main(options: Options)
         if preparser::is_empty(stmt) {
             continue;
         }
-        query(&mut conn, &stmt, &options).await?;
+        run_query(&mut conn, &stmt, &options).await?;
     }
     Ok(())
 }
 
-pub async fn query(conn: &mut Connection, stmt: &str, options: &Options)
+async fn run_query(conn: &mut Connection, stmt: &str, options: &Options)
     -> Result<(), anyhow::Error>
 {
-    use crate::repl::OutputMode::*;
     let mut cfg = print::Config::new();
     if let Some((w, _h)) = term_size::dimensions_stdout() {
         cfg.max_width(w);
@@ -51,7 +88,7 @@ pub async fn query(conn: &mut Connection, stmt: &str, options: &Options)
     cfg.colors(atty::is(atty::Stream::Stdout));
 
     match options.output_mode {
-        TabSeparated => {
+        OutputMode::TabSeparated => {
             let mut items = match
                 conn.query_dynamic(stmt, &Value::empty_tuple()).await
             {
@@ -71,7 +108,7 @@ pub async fn query(conn: &mut Connection, stmt: &str, options: &Options)
                 stdout().write_all(text.as_bytes()).await?;
             }
         }
-        Default => {
+        OutputMode::Default => {
             let items = match
                 conn.query_dynamic(stmt, &Value::empty_tuple()).await
             {
@@ -102,7 +139,7 @@ pub async fn query(conn: &mut Connection, stmt: &str, options: &Options)
                 }
             }
         }
-        JsonElements => {
+        OutputMode::JsonElements => {
             let mut items = match
                 conn.query_json_els(stmt, &Value::empty_tuple()).await
             {
@@ -124,7 +161,7 @@ pub async fn query(conn: &mut Connection, stmt: &str, options: &Options)
                 stdout().write_all(data.as_bytes()).await?;
             }
         }
-        Json => {
+        OutputMode::Json => {
             let mut items = match
                 conn.query_json(stmt, &Value::empty_tuple()).await
             {
@@ -150,5 +187,57 @@ pub async fn query(conn: &mut Connection, stmt: &str, options: &Options)
             }
         }
     }
+    Ok(())
+}
+
+fn truncated(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        None => s,
+        Some((idx, _)) => &s[..idx],
+    }
+}
+
+async fn interpret_file(file: String, options: Options)
+    -> Result<(), anyhow::Error>
+{
+    let mut contents = async_read(file).await?;
+    contents.push(b';');
+
+    let mut input = vec![];
+
+    loop {
+        match full_statement(&contents, None) {
+            Ok(len) => {
+                let stmt = String::from_utf8((&contents[..len]).to_vec())
+                                .context("can't decode statement")?
+                                .trim().to_string();
+                if stmt != "" && stmt != ";" {
+                    input.push(stmt);
+                }
+
+                contents = (&contents[len..]).to_vec();
+                if contents.len() == 0 {
+                    break
+                }
+            },
+            Err(_) => {
+                let remainder = String::from_utf8(contents)
+                                .context("can't decode statement")?;
+                if remainder.trim().len() != 0 {
+                    eprintln!("The remainder of the file is not \
+                              valid EdgeQL: {}", truncated(&remainder, 100));
+                    return Err(ExitCode::new(1))?;
+                }
+
+                break
+            }
+        }
+    }
+
+    let mut conn = options.create_connector()?.connect().await?;
+    for q in input {
+        run_query(&mut conn, &q, &options).await?;
+    }
+
     Ok(())
 }

--- a/src/non_interactive.rs
+++ b/src/non_interactive.rs
@@ -2,18 +2,17 @@ use std::str;
 
 use anyhow::{self, Context};
 use async_std::prelude::StreamExt;
-use async_std::io::{stdin, stdout};
+use async_std::io::{stdin, stdout, Read as AsyncRead};
 use async_std::io::prelude::WriteExt;
-use async_std::fs::{read as async_read};
+use async_std::fs::{File as AsyncFile};
 
 use bytes::BytesMut;
 use edgeql_parser::preparser;
 use edgedb_protocol::value::Value;
 
-use crate::commands::ExitCode;
 use crate::options::Options;
 use crate::options::Query;
-use crate::repl::OutputMode;
+use crate::repl::OutputFormat;
 use crate::print::{self, PrintError};
 use edgedb_client::reader::ReadError;
 use crate::statement::{ReadStatement, EndOfFile};
@@ -21,27 +20,38 @@ use edgedb_client::client::Connection;
 use edgedb_client::errors::NoResultExpected;
 use crate::outputs::tab_separated;
 
-use edgeql_parser::preparser::{full_statement};
-
 pub async fn main(q: &Query, options: &Options)
     -> Result<(), anyhow::Error>
 {
     let mut query_opts = options.clone();
-    query_opts.output_mode = if q.tab_separated {
-        OutputMode::TabSeparated
-    } else if q.json {
-        OutputMode::Json
+
+    // There's some extra complexity here due to the fact that we
+    // have to support now deprecated top-level `--json` and
+    // `--tab-separated` flags.
+    query_opts.output_format = if let Some(of) = q.output_format {
+        // If the new `--output-format` option was provided - use it.
+        of
     } else {
-        // Let the top-level --json / --tab-seaparated propagate
-        // (they are deprecated, though.)
-        options.output_mode
+        // Or else, check what's coming from the `main::main()`
+        // entrypoint.
+        if options.output_format == OutputFormat::Default {
+            // Means "native" serialization; for `edgedb query`
+            // the default is `json-pretty`.
+            OutputFormat::JsonPretty
+        } else {
+            // If it's not Default, it must either be something set
+            // with `--json` or `--tab-separated`, or it could be
+            // the default `JsonLines` which is fine in this context.
+            options.output_format
+        }
     };
 
-    if let Some(file) = &q.file {
-        if file == "-" {
+    if let Some(filename) = &q.file {
+        if filename == "-" {
             interpret_stdin(query_opts).await?;
         } else {
-            interpret_file(file.to_string(), query_opts).await?;
+            let mut file = AsyncFile::open(filename).await?;
+            interpret_file(&mut file, query_opts).await?;
         }
     } else if let Some(queries) = &q.queries {
         let mut conn = options.create_connector()?.connect().await?;
@@ -59,11 +69,17 @@ pub async fn main(q: &Query, options: &Options)
 pub async fn interpret_stdin(options: Options)
     -> Result<(), anyhow::Error>
 {
+    return interpret_file(&mut stdin(), options).await;
+}
+
+async fn interpret_file<T>(file: &mut T, options: Options)
+    -> Result<(), anyhow::Error>
+    where T: AsyncRead + Unpin
+{
     let mut conn = options.create_connector()?.connect().await?;
-    let mut stdin = stdin();
     let mut inbuf = BytesMut::with_capacity(8192);
     loop {
-        let stmt = match ReadStatement::new(&mut inbuf, &mut stdin).await {
+        let stmt = match ReadStatement::new(&mut inbuf, file).await {
             Ok(chunk) => chunk,
             Err(e) if e.is::<EndOfFile>() => break,
             Err(e) => return Err(e),
@@ -87,8 +103,8 @@ async fn run_query(conn: &mut Connection, stmt: &str, options: &Options)
     }
     cfg.colors(atty::is(atty::Stream::Stdout));
 
-    match options.output_mode {
-        OutputMode::TabSeparated => {
+    match options.output_format {
+        OutputFormat::TabSeparated => {
             let mut items = match
                 conn.query_dynamic(stmt, &Value::empty_tuple()).await
             {
@@ -108,7 +124,7 @@ async fn run_query(conn: &mut Connection, stmt: &str, options: &Options)
                 stdout().write_all(text.as_bytes()).await?;
             }
         }
-        OutputMode::Default => {
+        OutputFormat::Default => {
             let items = match
                 conn.query_dynamic(stmt, &Value::empty_tuple()).await
             {
@@ -139,7 +155,7 @@ async fn run_query(conn: &mut Connection, stmt: &str, options: &Options)
                 }
             }
         }
-        OutputMode::JsonElements => {
+        OutputFormat::JsonPretty | OutputFormat::JsonLines => {
             let mut items = match
                 conn.query_json_els(stmt, &Value::empty_tuple()).await
             {
@@ -152,16 +168,24 @@ async fn run_query(conn: &mut Connection, stmt: &str, options: &Options)
                     Err(e) => Err(e)?,
                 },
             };
-            while let Some(row) = items.next().await.transpose()? {
-                let value: serde_json::Value = serde_json::from_str(&row)
-                    .context("cannot decode json result")?;
-                // trying to make writes atomic if possible
-                let mut data = print::json_item_to_string(&value, &cfg)?;
-                data += "\n";
-                stdout().write_all(data.as_bytes()).await?;
+            if options.output_format == OutputFormat::JsonLines {
+                while let Some(mut row) = items.next().await.transpose()? {
+                    // trying to make writes atomic if possible
+                    row += "\n";
+                    stdout().write_all(row.as_bytes()).await?;
+                }
+            } else {
+                while let Some(row) = items.next().await.transpose()? {
+                    let value: serde_json::Value = serde_json::from_str(&row)
+                        .context("cannot decode json result")?;
+                    // trying to make writes atomic if possible
+                    let mut data = print::json_item_to_string(&value, &cfg)?;
+                    data += "\n";
+                    stdout().write_all(data.as_bytes()).await?;
+                }
             }
         }
-        OutputMode::Json => {
+        OutputFormat::Json => {
             let mut items = match
                 conn.query_json(stmt, &Value::empty_tuple()).await
             {
@@ -187,57 +211,5 @@ async fn run_query(conn: &mut Connection, stmt: &str, options: &Options)
             }
         }
     }
-    Ok(())
-}
-
-fn truncated(s: &str, max_chars: usize) -> &str {
-    match s.char_indices().nth(max_chars) {
-        None => s,
-        Some((idx, _)) => &s[..idx],
-    }
-}
-
-async fn interpret_file(file: String, options: Options)
-    -> Result<(), anyhow::Error>
-{
-    let mut contents = async_read(file).await?;
-    contents.push(b';');
-
-    let mut input = vec![];
-
-    loop {
-        match full_statement(&contents, None) {
-            Ok(len) => {
-                let stmt = String::from_utf8((&contents[..len]).to_vec())
-                                .context("can't decode statement")?
-                                .trim().to_string();
-                if stmt != "" && stmt != ";" {
-                    input.push(stmt);
-                }
-
-                contents = (&contents[len..]).to_vec();
-                if contents.len() == 0 {
-                    break
-                }
-            },
-            Err(_) => {
-                let remainder = String::from_utf8(contents)
-                                .context("can't decode statement")?;
-                if remainder.trim().len() != 0 {
-                    eprintln!("The remainder of the file is not \
-                              valid EdgeQL: {}", truncated(&remainder, 100));
-                    return Err(ExitCode::new(1))?;
-                }
-
-                break
-            }
-        }
-    }
-
-    let mut conn = options.create_connector()?.connect().await?;
-    for q in input {
-        run_query(&mut conn, &q, &options).await?;
-    }
-
     Ok(())
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -144,15 +144,15 @@ pub struct RawOptions {
     pub debug_print_codecs: bool,
 
     /// Tab-separated output of the queries
-    #[clap(short='t', long, overrides_with="json")]
+    #[clap(short='t', long, overrides_with="json",
+           setting=clap::ArgSettings::Hidden)]
     pub tab_separated: bool,
-
     /// JSON output for the queries (single JSON list per query)
-    #[clap(short='j', long, overrides_with="tab_separated")]
+    #[clap(short='j', long, overrides_with="tab_separated",
+           setting=clap::ArgSettings::Hidden)]
     pub json: bool,
-
     /// Execute a query instead of starting REPL
-    #[clap(short='c')]
+    #[clap(short='c', setting=clap::ArgSettings::Hidden)]
     pub query: Option<String>,
 
     /// Show command-line tool version
@@ -174,11 +174,11 @@ pub struct RawOptions {
 pub enum Command {
     #[clap(flatten)]
     Common(Common),
+    /// Execute EdgeQL queries
+    #[edb(inherit(ConnectionOptions))]
+    Query(Query),
     /// Show information about the EdgeDB installation
     Info,
-    /// Execute EdgeQL query
-    #[edb(inherit(ConnectionOptions), hidden)]
-    Query(Query),
     /// Manage project installation
     #[edb(expand_help)]
     Project(project::options::ProjectCommand),
@@ -203,8 +203,20 @@ pub enum Command {
 
 #[derive(EdbClap, Clone, Debug)]
 pub struct Query {
-    #[clap(required=true)]
-    pub queries: Vec<String>,
+    /// Tab-separated output of the queries
+    #[clap(short='t', long, overrides_with="json")]
+    pub tab_separated: bool,
+
+    /// JSON output for the queries (single JSON list per query)
+    #[clap(short='j', long, overrides_with="tab_separated")]
+    pub json: bool,
+
+    /// Filename to execute queries from.
+    /// Pass `--file -` to execute queries from stdin.
+    #[clap(short='f', long)]
+    pub file: Option<String>,
+
+    pub queries: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone)]
@@ -222,6 +234,17 @@ pub struct Options {
 #[derive(Debug, thiserror::Error)]
 #[error("error searching for `edgedb.toml`")]
 pub struct ProjectNotFound(#[source] pub anyhow::Error);
+
+fn say_option_is_deprecated(option_name: &str, suggestion: &str) {
+    let error = "warning:".bold().light_yellow();
+    let instead = suggestion.green();
+    eprintln!("\
+        {error} The '{opt}' option is deprecated.\n\
+        \n         \
+            Use '{instead}' instead.\
+        \n\
+    ", error=error, opt=option_name.green(), instead=instead);
+}
 
 fn make_subcommand_help<T: describe::Describe>() -> String {
     use std::fmt::Write;
@@ -384,9 +407,20 @@ impl Options {
             && tmp.subcommand.is_none()
             && atty::is(atty::Stream::Stdin);
 
+        if tmp.json {
+            say_option_is_deprecated("--json", "edgedb query --json");
+        }
+        if tmp.tab_separated {
+            say_option_is_deprecated(
+                "--tab-separated", "edgedb query --tab-separated");
+        }
         let subcommand = if let Some(query) = tmp.query {
+            say_option_is_deprecated("-c", "edgedb query");
             Some(Command::Query(Query {
-                queries: vec![query],
+                queries: Some(vec![query]),
+                tab_separated: tmp.tab_separated,
+                json: tmp.json,
+                file: None,
             }))
         } else {
             tmp.subcommand

--- a/src/options.rs
+++ b/src/options.rs
@@ -203,13 +203,13 @@ pub enum Command {
 
 #[derive(EdbClap, Clone, Debug)]
 pub struct Query {
-    /// Output format: `json`, `json-lines`, `tab-separated`.
-    /// Default is `json-lines`.
-    // todo: can't use `clap(default='json-lines')` just yet, as we
+    /// Output format: `json`, `json-pretty`, `json-lines`, `tab-separated`.
+    /// Default is `json-pretty`.
+    // todo: can't use `clap(default='json-pretty')` just yet, as we
     // need to see if the user did actually specify some output
     // format or not. We need that to support the now deprecated
     // --json and --tab-separated top-level options.
-    #[clap(long)]
+    #[clap(short='F', long)]
     pub output_format: Option<OutputFormat>,
 
     /// Filename to execute queries from.

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -20,10 +20,11 @@ pub const FAILURE_MARKER: &str = "[tx:failed]";
 
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OutputMode {
+pub enum OutputFormat {
     Default,
     Json,
-    JsonElements,
+    JsonPretty,
+    JsonLines,
     TabSeparated,
 }
 
@@ -53,7 +54,7 @@ pub struct State {
     pub last_error: Option<anyhow::Error>,
     pub implicit_limit: Option<usize>,
     pub input_mode: InputMode,
-    pub output_mode: OutputMode,
+    pub output_format: OutputFormat,
     pub print_stats: PrintStats,
     pub history_limit: usize,
     pub conn_params: Connector,
@@ -227,14 +228,15 @@ impl std::str::FromStr for InputMode {
     }
 }
 
-impl std::str::FromStr for OutputMode {
+impl std::str::FromStr for OutputFormat {
     type Err = anyhow::Error;
-    fn from_str(s: &str) -> Result<OutputMode, anyhow::Error> {
+    fn from_str(s: &str) -> Result<OutputFormat, anyhow::Error> {
         match s {
-            "json" => Ok(OutputMode::Json),
-            "json-elements" => Ok(OutputMode::JsonElements),
-            "tab-separated" => Ok(OutputMode::TabSeparated),
-            "default" => Ok(OutputMode::Default),
+            "json" => Ok(OutputFormat::Json),
+            "json-pretty" => Ok(OutputFormat::JsonPretty),
+            "json-lines" => Ok(OutputFormat::JsonLines),
+            "tab-separated" => Ok(OutputFormat::TabSeparated),
+            "default" => Ok(OutputFormat::Default),
             _ => Err(anyhow::anyhow!("unsupported output mode {:?}", s)),
         }
     }
@@ -263,13 +265,14 @@ impl InputMode {
     }
 }
 
-impl OutputMode {
+impl OutputFormat {
     pub fn as_str(&self) -> &'static str {
-        use OutputMode::*;
+        use OutputFormat::*;
         match self {
             Default => "default",
             Json => "json",
-            JsonElements => "json-elements",
+            JsonPretty => "json-pretty",
+            JsonLines => "json-lines",
             TabSeparated => "tab-separated",
         }
     }

--- a/tests/func/configure.rs
+++ b/tests/func/configure.rs
@@ -45,8 +45,8 @@ fn configure_all_parameters() {
     }
 
     let cmd = SERVER.admin_cmd()
-        .arg("--tab-separated")
         .arg("query")
+        .arg("--output-format=tab-separated")
         .arg(r###"
             WITH Ptr := (SELECT schema::ObjectType
                          FILTER .name = 'cfg::Config'),


### PR DESCRIPTION
In summary:

* 'edgedb query' is back. It has a new option: '--file' to
  execute queries from a file.
* 'edgedb query --file -' executes queries from stdin.
* Top level `edgedb --json`, `edgedb --tab-separated`, and
  `edgedb -c` options are deprecated now.