### PR TITLE
expand command suggestion when project needs init

### DIFF
--- a/src/project/upgrade.rs
+++ b/src/project/upgrade.rs
@@ -108,7 +108,7 @@ pub fn update_toml(options: &Upgrade) -> anyhow::Result<()> {
         };
         modify_toml(&config_path, &version)?;
         println!("Config updated successfully. \
-            Run `project init` to initialize an instance.")
+            Run `edgedb project init` to initialize an instance.")
     } else {
         let os = detect::current_os()?;
         let methods = os.all_methods()?;


### PR DESCRIPTION
This change makes the suggested command `edgedb project init` instead of
`project init`.