### PR TITLE
Error out upgrading linked instance

### DIFF
--- a/src/server/destroy.rs
+++ b/src/server/destroy.rs
@@ -45,7 +45,7 @@ fn read_path(path: &Path) -> anyhow::Result<PathBuf> {
     Ok(bytes_to_path(&bytes)?.to_path_buf())
 }
 
-pub fn print_warning(name: &str, project_dirs: &[PathBuf]) {
+pub fn print_instance_in_use_warning(name: &str, project_dirs: &[PathBuf]) {
     eprintln!("Instance {:?} is used by the following projects:",
               name);
     for dir in project_dirs {
@@ -59,6 +59,10 @@ pub fn print_warning(name: &str, project_dirs: &[PathBuf]) {
         };
         eprintln!("  {}", dest.display());
     }
+}
+
+pub fn print_warning(name: &str, project_dirs: &[PathBuf]) {
+    print_instance_in_use_warning(name, project_dirs);
     eprintln!("If you really want to destroy the instance, run:");
     eprintln!("  edgedb instance destroy {:?} --force", name);
 }

--- a/src/server/destroy.rs
+++ b/src/server/destroy.rs
@@ -39,18 +39,17 @@ pub fn find_project_dirs(name: &str) -> anyhow::Result<Vec<PathBuf>> {
     Ok(res)
 }
 
-#[context("cannot read {:?}", path)]
-fn read_path(path: &Path) -> anyhow::Result<PathBuf> {
-    let bytes = fs::read(&path)?;
+#[context("cannot read {:?}", project_dir)]
+pub fn read_project_real_path(project_dir: &Path) -> anyhow::Result<PathBuf> {
+    let bytes = fs::read(&project_dir.join("project-path"))?;
     Ok(bytes_to_path(&bytes)?.to_path_buf())
 }
 
 pub fn print_instance_in_use_warning(name: &str, project_dirs: &[PathBuf]) {
-    eprintln!("Instance {:?} is used by the following projects:",
-              name);
+    eprintln!("Instance {:?} is used by the following project{}:",
+              name, if project_dirs.len() > 1 { "s" } else { "" });
     for dir in project_dirs {
-        let path_path = dir.join("project-path");
-        let dest = match read_path(&path_path) {
+        let dest = match read_project_real_path(dir) {
             Ok(path) => path,
             Err(e) => {
                 eprintln!("edgedb error: {}", e);
@@ -75,8 +74,7 @@ pub fn destroy(options: &Destroy) -> anyhow::Result<()> {
     }
     do_destroy(options)?;
     for dir in project_dirs {
-        let path_path = dir.join("project-path");
-        match read_path(&path_path) {
+        match read_project_real_path(&dir) {
             Ok(path) => eprintln!("Unlinking {}", path.display()),
             Err(_) => eprintln!("Cleaning {}", dir.display()),
         };

--- a/src/server/upgrade.rs
+++ b/src/server/upgrade.rs
@@ -95,7 +95,14 @@ pub fn upgrade(options: &Upgrade) -> anyhow::Result<()> {
         if !project_dirs.is_empty() {
             destroy::print_instance_in_use_warning(name, &project_dirs);
             let current_project = project::project_dir_opt(None)?;
-            eprintln!("To continue with the upgrade, run:");
+            if options.force {
+                eprintln!(
+                    "To update the project{} after the instance upgrade, run:",
+                    if project_dirs.len() > 1 { "s" } else { "" }
+                );
+            } else {
+                eprintln!("To continue with the upgrade, run:");
+            }
             for pd in project_dirs {
                 let pd = destroy::read_project_real_path(&pd)?;
                 eprintln!(


### PR DESCRIPTION
A few sample errors:

```
/tmp $ edgedb instance upgrade ccc --to-version 1-beta2
Instance "ccc" is used by the following project:
  /Users/fantix/workspace/test
To continue with the upgrade, run:
  edgedb project upgrade --to-version 1-beta2 --project-dir '/Users/fantix/workspace/test'
edgedb error: Upgrade aborted.
```

```
~/workspace/test $ edgedb instance upgrade ccc --to-version 1-beta2
Instance "ccc" is used by the following project:
  /Users/fantix/workspace/test
To continue with the upgrade, run:
  edgedb project upgrade --to-version 1-beta2
edgedb error: Upgrade aborted.
```

```
~/workspace/test $ edgedb instance upgrade ccc --to-version 1-beta2
Instance "ccc" is used by the following projects:
  /Users/fantix/workspace/test
  /Users/fantix/workspace/test2
To continue with the upgrade, run:
  edgedb project upgrade --to-version 1-beta2
  edgedb project upgrade --to-version 1-beta2 --project-dir '/Users/fantix/workspace/test2'
edgedb error: Upgrade aborted.
```

I know @vpetrovykh convinced the team that `--force` should not override the behavior, but `--force` is essentially the same thing when you have multiple projects linking to the same instance, and the user should be warned to upgrade other projects too when upgrading from one of the projects.