### PR TITLE
Update project upgrade logic

### DIFF
--- a/src/server/centos.rs
+++ b/src/server/centos.rs
@@ -322,7 +322,7 @@ impl<'os> Method for PackageMethod<'os, Centos> {
         linux::get_instance(self, name)
     }
     fn upgrade(&self, todo: &upgrade::ToDo, options: &Upgrade)
-        -> anyhow::Result<()>
+        -> anyhow::Result<bool>
     {
         unix::upgrade(todo, options, self)
     }

--- a/src/server/debian.rs
+++ b/src/server/debian.rs
@@ -121,7 +121,7 @@ impl<'os> Method for PackageMethod<'os, Debian> {
         linux::get_instance(self, name)
     }
     fn upgrade(&self, todo: &upgrade::ToDo, options: &Upgrade)
-        -> anyhow::Result<()>
+        -> anyhow::Result<bool>
     {
         unix::upgrade(todo, options, self)
     }

--- a/src/server/macos.rs
+++ b/src/server/macos.rs
@@ -331,7 +331,7 @@ impl<'os> Method for PackageMethod<'os, Macos> {
         }
     }
     fn upgrade(&self, todo: &upgrade::ToDo, options: &Upgrade)
-        -> anyhow::Result<()>
+        -> anyhow::Result<bool>
     {
         unix::upgrade(todo, options, self)
     }

--- a/src/server/os_trait.rs
+++ b/src/server/os_trait.rs
@@ -104,7 +104,7 @@ pub trait Method: fmt::Debug + Send + Sync {
     fn clean_storage(&self, storage: &Storage) -> anyhow::Result<()>;
     fn bootstrap(&self, settings: &create::Settings) -> anyhow::Result<()>;
     fn upgrade(&self, todo: &upgrade::ToDo, options: &Upgrade)
-        -> anyhow::Result<()>;
+        -> anyhow::Result<bool>;
     fn all_instances<'x>(&'x self) -> anyhow::Result<Vec<InstanceRef<'x>>>;
     fn get_instance<'x>(&'x self, name: &str)
         -> anyhow::Result<InstanceRef<'x>>;

--- a/src/server/ubuntu.rs
+++ b/src/server/ubuntu.rs
@@ -115,7 +115,7 @@ impl<'os> Method for PackageMethod<'os, Ubuntu> {
         linux::get_instance(self, name)
     }
     fn upgrade(&self, todo: &upgrade::ToDo, options: &Upgrade)
-        -> anyhow::Result<()>
+        -> anyhow::Result<bool>
     {
         unix::upgrade(todo, options, self)
     }


### PR DESCRIPTION
* No minor upgrade by default, check and suggest only
* Revamp project upgrade messages

- [x] Depends on #443

Examples:

```
$ edgedb project upgrade
Do you want to upgrade to 1-beta2 per edgedb.toml? [y/n]
> y
......
Instance upgraded to 1.0b2+ga7130d5c7.cv202104290000-202105060205
Warning: the instance ccc is still used by the following projects:
  /Users/fantix/workspace/test2
Run the following commands to update them:
  edgedb project upgrade --to-version 1-beta2 --project-dir '/Users/fantix/workspace/test2'

$ edgedb project upgrade --to-version 1-beta2 --project-dir '/Users/fantix/workspace/test2'
[2021-08-06T12:28:09Z WARN  edgedb::server::unix] Instance has up to date major version 1.0b2+ga7130d5c7.cv202104290000-202105060205. Use `edgedb instance upgrade --local-minor` (without instance name) to upgrade minor versions.
Setting `server-version = "1-beta2"` in `edgedb.toml`
Remember to commit it to the version control.
Instance is up to date.
```

```
$ edgedb project upgrade --to-nightly
......
Setting `server-version = "nightly"` in `edgedb.toml`
Remember to commit it to the version control.
Instance upgraded to 1.0b3.dev5855+d2021080400.ga6ef23eb1.cv202108020000-202108040008~nightly
Warning: the instance ccc is still used by the following projects:
  /Users/fantix/workspace/test2
Run the following commands to update them:
  edgedb project upgrade --to-nightly --project-dir '/Users/fantix/workspace/test2'
$ cd /Users/fantix/workspace/test2
$ edgedb project upgrade --to-nightly
Setting `server-version = "nightly"` in `edgedb.toml`
Remember to commit it to the version control.
Instance is up to date.
```

```
$ edgedb project upgrade
A new nightly version is available: 1.0b3.dev5863+d2021080600.g56a9f479e.cv202108020000-202108060007~nightly. Do you want to upgrade? [y/n]
> y
......
Instance upgraded to 1.0b3.dev5863+d2021080600.g56a9f479e.cv202108020000-202108060007~nightly
```

```
$ edgedb project upgrade
Instance is up to date.
```

```
$ edgedb project upgrade
A new minor version is available: 1.1
  Run `edgedb instance upgrade --local-minor` to update.
```
