### PR TITLE
Better format `--help`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,7 +535,7 @@ dependencies = [
  "os_str_bytes",
  "strsim",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap",
  "vec_map",
 ]
 
@@ -1004,7 +1004,7 @@ dependencies = [
  "termcolor",
  "termimad",
  "test-case",
- "textwrap 0.13.4",
+ "textwrap",
  "thiserror",
  "tokio",
  "toml",
@@ -3208,20 +3208,13 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd05616119e612a8041ef58f2b578906cc2531a6069047ae092cfb86a325d835"
-dependencies = [
- "smawk",
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
+ "smawk",
+ "terminal_size",
+ "unicode-linebreak",
  "unicode-width",
 ]
 
@@ -3530,6 +3523,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
+]
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52dcaab0c48d931f7cc8ef826fa51690a08e1ea55117ef26f89864f532383f"
+dependencies = [
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ termcolor = "1.1.0"
 async-listen = "0.2.0"
 sha1 = "0.6.0"
 hex = "0.4.3"
-textwrap = "0.13.4"
+textwrap = {version="0.14.2", features=["terminal_size"]}
 log = "0.4.8"
 env_logger = "0.8.2"
 os-release = "0.1.0"


### PR DESCRIPTION
Align subcommands help with options help; make rendering consistent
and handle term width correctly.

Before:

![Screenshot from 2021-08-07 11-35-35](https://user-images.githubusercontent.com/239003/128610660-0457c902-8feb-4114-8051-8c7f3a81e419.png)


After:

![Screenshot from 2021-08-07 11-33-21](https://user-images.githubusercontent.com/239003/128610650-0be209dd-fcd5-4615-931d-ee21f2251fab.png)
