### PR TITLE
Use properly cherry-picked rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.19.1"
-source = "git+https://github.com/edgedb/rustls?rev=af7fc66#af7fc66f0a0ba72153491ae2f7c6c460df1f733a"
+source = "git+https://github.com/edgedb/rustls?rev=480345e#480345e83a0da65500951da2407b981aacc94dde"
 dependencies = [
  "base64 0.13.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,4 +126,4 @@ debug = true
 lto = true
 
 [patch.crates-io]
-rustls = { git = "https://github.com/edgedb/rustls", rev = "af7fc66" }
+rustls = { git = "https://github.com/edgedb/rustls", rev = "480345e" }


### PR DESCRIPTION
Removed our own hack in rustls in handling close_notify which was
leading to a timeout in disconnecting from a TLS-enabled server.

Cherry-picked 7 commits from rustls 0.20: https://github.com/edgedb/rustls/commits/main