### PR TITLE
project init: Allow linking to exising instances in non-interactive mode

### DIFF
--- a/src/project/init.rs
+++ b/src/project/init.rs
@@ -164,7 +164,7 @@ fn ask_name(methods: &Methods, dir: &Path, options: &Init)
     if options.non_interactive {
         let exists = instances.contains(&default_name);
         if exists {
-            log::warn!("Instance {:?} already exists", default_name);
+            log::warn!("Linking project to the existing tnstance {:?}", default_name);
         }
         return Ok((default_name, exists))
     }

--- a/src/project/init.rs
+++ b/src/project/init.rs
@@ -162,10 +162,11 @@ fn ask_name(methods: &Methods, dir: &Path, options: &Init)
         name
     };
     if options.non_interactive {
-        if instances.contains(&default_name) {
+        let exists = instances.contains(&default_name);
+        if exists {
             log::warn!("Instance {:?} already exists", default_name);
         }
-        return Ok((default_name, false))
+        return Ok((default_name, exists))
     }
     let mut q = question::String::new(
         "Specify the name of EdgeDB instance to use with this project"


### PR DESCRIPTION
Fixes #471

Although it's a simple fix, I'm not sure this is what we want. May be we want an explicit `project link` command? I.e. for interactive mode we do as much as possible by asking questions. But for non-interactive, `project link` would be a simpler and straightforward command with less useless (ignored) arguments.