### PR TITLE
Fix error reporting

### DIFF
--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -360,7 +360,7 @@ pub fn error(line: impl fmt::Display) {
         eprintln!(
             "{}: {}",
             "edgedb error".bold().light_red(),
-            line.to_string().bold().white(),
+            format!("{:#}", line).bold().white(),
         );
     } else {
         eprintln!("edgedb error: {}", line);


### PR DESCRIPTION
Previously it only printed top-level error, i.e.
`ClientConnectionError`, with this patch it also prints causes:
`ClientConnectionError: connection reset by peer`.