### PR TITLE
repl: Add print for used configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use fn_error_context::context;
 
@@ -10,6 +10,8 @@ use crate::repl;
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 #[serde(rename_all="kebab-case")]
 pub struct Config {
+    #[serde(skip, default)]
+    pub file_name: Option<PathBuf>,
     pub shell: ShellConfig,
 }
 
@@ -47,6 +49,7 @@ pub fn get_config() -> anyhow::Result<Config> {
 fn read_config(path: impl AsRef<Path>) -> anyhow::Result<Config> {
     let text = fs::read_to_string(&path)?;
     let mut toml = toml::de::Deserializer::new(&text);
-    let val: Config = serde_path_to_error::deserialize(&mut toml)?;
+    let mut val: Config = serde_path_to_error::deserialize(&mut toml)?;
+    val.file_name = Some(path.as_ref().to_path_buf());
     Ok(val)
 }

--- a/src/print/color.rs
+++ b/src/print/color.rs
@@ -1,0 +1,73 @@
+use std::fmt;
+
+use colorful::Color;
+use colorful::core::ColorInterface;
+
+static THEME: once_cell::sync::Lazy<Theme> = once_cell::sync::Lazy::new(|| {
+    if clicolors_control::colors_enabled() {
+        Theme {
+            fade: Some(Color::Grey37),
+        }
+    } else {
+        Theme {
+            fade: None,
+        }
+    }
+});
+
+struct Theme {
+    fade: Option<Color>,
+}
+
+pub struct Colored<T> {
+    color: Option<Color>,
+    value: T,
+}
+
+
+pub trait Highlight: fmt::Display + Sized {
+    fn fade(self) -> Colored<Self> {
+        Colored {
+            color: theme().fade,
+            value: self,
+        }
+    }
+}
+
+fn theme() -> &'static Theme {
+    &*THEME
+}
+
+impl<T: fmt::Display> Highlight for T {
+}
+
+impl<T: fmt::Display> fmt::Display for Colored<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(col) = self.color {
+            write!(f, "\x1B[38;5;{}m{}\x1B[0m", col.to_color_str(), self.value)
+        } else {
+            self.value.fmt(f)
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! echo {
+    ($word1:expr $(,$word:expr )* $(,)?) => {
+        // Buffer the whole output so mutliple processes do not interfere
+        // each other
+        {
+            use ::std::fmt::Write;
+            let mut buf = ::std::string::String::with_capacity(4096);
+            write!(&mut buf, "{}", $word1)
+                .expect("buffering of echo succeeds");
+            $(
+                buf.push(' ');
+                write!(&mut buf, "{}", $word)
+                    .expect("buffering of echo succeeds");
+            )*
+            buf.push('\n');
+            print!("{}", buf);
+        };
+    }
+}

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -7,6 +7,7 @@ use async_std::stream::{Stream, StreamExt};
 use colorful::{Color, Colorful};
 use snafu::{Snafu, ResultExt, AsErrorSource};
 
+mod color;
 mod native;
 mod json;
 mod buffer;
@@ -17,6 +18,7 @@ pub mod style;
 
 pub(in crate::print) use native::FormatExt;
 pub(in crate::print) use formatter::Formatter;
+pub use color::Highlight;
 use formatter::ColorfulExt;
 use buffer::{Exception, WrapErr, UnwrapExc, Delim};
 use stream::Output;


### PR DESCRIPTION
This also introduces a new way for color printing:
1. Styles are semantic, no colors thorough code
2. Don't need intermediate strings (`x.to_string().light_blue()`)
3. Disabling colors works even when formatting to a string
4. Themes can be used later

Also introduces new print macro `echo` which:
1. Doesn't require format pattern (patterns have little use with colors)
2. Buffers the whole line before printing (friendlier to other
   processes, faster)

This unfortunately introduces another way for color printing thorought
code, but we eventually have to convert colors to semantic names for
theme support anyway.

Other than that, this color priting is mostly in proof of concept state
as more styles should be added to make it useful.