### PR TITLE
add `project link` command

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -32,7 +32,8 @@ const MAX_TERM_WIDTH: usize = 90;
 const MIN_TERM_WIDTH: usize = 50;
 
 static CONNECTION_ARG_HINT: &str = "\
-    Run `edgedb project init` or use any of `-H`, `-P`, `-I` arguments \
+    Run `edgedb project init`, or `edgedb project link`, \
+    or use any of `-H`, `-P`, `-I` arguments \
     to specify connection parameters. See `--help` for details";
 
 const CONN_OPTIONS_GROUP: &str =

--- a/src/project/init.rs
+++ b/src/project/init.rs
@@ -494,7 +494,7 @@ fn stash_name(path: &Path) -> anyhow::Result<OsString> {
 }
 
 #[context("error writing project dir {:?}", dir)]
-fn write_stash_dir(dir: &Path, project_dir: &Path, instance_name: &str)
+pub fn write_stash_dir(dir: &Path, project_dir: &Path, instance_name: &str)
     -> anyhow::Result<()>
 {
     let tmp = tmp_file_path(&dir);

--- a/src/project/link.rs
+++ b/src/project/link.rs
@@ -1,0 +1,104 @@
+use std::{collections::BTreeSet};
+
+use anyhow::Context;
+
+use crate::print;
+use crate::project::config;
+use crate::project::options::Link;
+use crate::project::{project_dir, stash_path, write_stash_dir};
+use crate::question;
+use crate::server::control::get_instance;
+use crate::server::detect::{self, VersionQuery};
+use crate::server::is_valid_name;
+use crate::server::methods::Methods;
+
+pub fn link(options: &Link) -> anyhow::Result<()> {
+    let project_dir = project_dir(options.project_dir.as_ref().map(|x| x.as_path()))?;
+    let stash_dir = stash_path(&project_dir)?;
+
+    if stash_dir.exists() {
+        anyhow::bail!("Project is already linked");
+    }
+
+    let config_path = project_dir.join("edgedb.toml");
+    let config = config::read(&config_path)?;
+    let ver_query = match config.edgedb.server_version {
+        None => VersionQuery::Stable(None),
+        Some(ver) => ver.to_query(),
+    };
+
+    let os = detect::current_os()?;
+    let avail_methods = os.get_available_methods()?;
+    let methods = avail_methods.instantiate_all(&*os, true)?;
+
+    let name = ask_instance_name(&methods, options)?;
+
+    let instance = get_instance(&methods, &name)?;
+    let version = instance.get_version()?;
+    if !ver_query.matches(version) {
+        print::warn(format!(
+            "WARNING: existing instance has version {}, \
+                but {} is required by `edgedb.toml`",
+            version.title(),
+            ver_query
+        ));
+    }
+
+    write_stash_dir(&stash_dir, &project_dir, &name)?;
+
+    print::success("Project linked");
+    if let Some(dir) = &options.project_dir {
+        println!(
+            "To connect to {}, navigate to {} and run `edgedb`",
+            name,
+            dir.display()
+        );
+    } else {
+        println!("To connect to {}, run `edgedb`", name);
+    }
+
+    Ok(())
+}
+
+
+fn ask_instance_name(methods: &Methods, options: &Link) -> anyhow::Result<String> {
+    let instances = methods
+        .values()
+        .map(|m| m.all_instances())
+        .collect::<Result<Vec<_>, _>>()
+        .context("failed to enumerate existing instances")?
+        .into_iter()
+        .flatten()
+        .map(|inst| inst.name().to_string())
+        .collect::<BTreeSet<_>>();
+
+    if let Some(name) = &options.name {
+        if instances.contains(name) {
+            return Ok(name.clone());
+        }
+
+        print::error(format!("Instance {:?} doesn't exist", name));
+    }
+
+    if options.non_interactive {
+        anyhow::bail!("Existing instance name should be specified")
+    }
+
+    let mut q =
+        question::String::new("Specify the name of EdgeDB instance to link with this project");
+    loop {
+        let target_name = q.ask()?;
+        if !is_valid_name(&target_name) {
+            print::error(
+                "Instance name must be a valid identifier, \
+                         (regex: ^[a-zA-Z_][a-zA-Z_0-9]*$)",
+            );
+            continue;
+        }
+        if instances.contains(&target_name) {
+            return Ok(target_name);
+        } else {
+            print::error(format!("Instance {:?} doesn't exist", target_name));
+        }
+    }
+}

--- a/src/project/main.rs
+++ b/src/project/main.rs
@@ -2,6 +2,7 @@ use crate::project::options::{ProjectCommand, Command};
 
 use crate::project::info;
 use crate::project::init;
+use crate::project::link;
 use crate::project::unlink;
 use crate::project::upgrade;
 
@@ -13,5 +14,6 @@ pub fn main(cmd: &ProjectCommand) -> anyhow::Result<()> {
         Unlink(c) => unlink::unlink(c),
         Info(c) => info::info(c),
         Upgrade(c) => upgrade::upgrade(c),
+        Link(c) => link::link(c),
     }
 }

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -9,12 +9,13 @@ pub mod options;
 mod config;
 mod info;
 mod main;
+mod link;
 mod unlink;
 mod upgrade;
 pub mod init;
 
 pub use main::main;
-pub use init::{stash_path, stash_base};
+pub use init::{stash_path, stash_base, write_stash_dir};
 pub use unlink::unlink;
 
 #[allow(unused)]  // TODO(tailhook) will be used in `project info`

--- a/src/project/options.rs
+++ b/src/project/options.rs
@@ -18,6 +18,8 @@ pub struct ProjectCommand {
 pub enum Command {
     /// Initialize a new or existing project
     Init(Init),
+    /// Link existing server instance with current project
+    Link(Link),
     /// Clean-up the project configuration
     Unlink(Unlink),
     /// Get various metadata about the project
@@ -77,6 +79,22 @@ pub struct Unlink {
     /// `edgedb instance destroy`.
     #[clap(long, short='D')]
     pub destroy_server_instance: bool,
+
+    #[clap(long)]
+    pub non_interactive: bool,
+}
+
+#[derive(EdbClap, Debug, Clone)]
+pub struct Link {
+    /// Specifies a project root directory explicitly.
+    #[clap(long, value_hint=ValueHint::DirPath)]
+    pub project_dir: Option<PathBuf>,
+
+    /// Specifies the EdgeDB server instance to be associated with the project.
+    /// If not present, the name will be interactively asked.
+    #[clap(validator(instance_name_opt))]
+    #[clap(value_hint=ValueHint::Other)]
+    pub name: Option<String>,
 
     #[clap(long)]
     pub non_interactive: bool,


### PR DESCRIPTION
In general, this is a more limited version of the  `edgedb project init` command that only asks for the name of an existing EdgeDB instance and creates project directory for it.

Also I'm not sure where to put tests for this PR. Should I create a separate test for this command, or would it be enough to modify existing tests in [tests/github-nightly/project.rs](https://github.com/edgedb/edgedb-cli/blob/fc67d94e5f12d0f37096640a1b167b82ec04b38c/tests/github-nightly/project.rs)?

Refs #471
Refs https://github.com/edgedb/setup-edgedb/pull/21#issuecomment-909422888
Supersedes (? not sure about that) #475