### PR TITLE
Add a configuration setting to disable typename injection

### DIFF
--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -504,6 +504,9 @@ pub fn get_setting(s: &Setting, prompt: &repl::State) -> Cow<'static, str> {
         OutputFormat(_) => {
             prompt.output_format.as_str().into()
         }
+        DisplayTypenames(_) => {
+            bool_str(prompt.display_typenames).into()
+        }
         ExpandStrings(_) => {
             bool_str(prompt.print.expand_strings).into()
         }
@@ -591,6 +594,9 @@ pub async fn execute(cmd: &BackslashCmd, prompt: &mut repl::State)
                 }
                 OutputFormat(c) => {
                     prompt.output_format = c.value.expect("only writes here");
+                }
+                DisplayTypenames(b) => {
+                    prompt.display_typenames = b.unwrap_value();
                 }
                 ExpandStrings(b) => {
                     prompt.print.expand_strings = b.unwrap_value();

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -156,7 +156,7 @@ pub enum Setting {
     Limit(Limit),
     /// Set output format.
     OutputFormat(OutputFormat),
-    /// Whether to inject typenames in default output mode
+    /// Display typenames in default output mode
     DisplayTypenames(SettingBool),
     /// Stop escaping newlines in quoted strings
     ExpandStrings(SettingBool),

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -156,6 +156,8 @@ pub enum Setting {
     Limit(Limit),
     /// Set output format.
     OutputFormat(OutputFormat),
+    /// Whether to inject typenames in default output mode
+    DisplayTypenames(SettingBool),
     /// Stop escaping newlines in quoted strings
     ExpandStrings(SettingBool),
     /// Set number of entries retained in history

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,8 @@ pub struct ShellConfig {
     pub limit: Option<usize>,
     #[serde(with="serde_str::opt", default)]
     pub output_format: Option<repl::OutputFormat>,
+    #[serde(default)]
+    pub display_typenames: Option<bool>,
     #[serde(with="serde_str::opt", default)]
     pub print_stats: Option<repl::PrintStats>,
     #[serde(default)]

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -116,6 +116,7 @@ pub fn main(options: Options, cfg: Config) -> Result<(), anyhow::Error> {
         output_format: options.output_format
             .or(cfg.shell.output_format)
             .unwrap_or(repl::OutputFormat::Default),
+        display_typenames: cfg.shell.display_typenames.unwrap_or(true),
         input_mode: cfg.shell.input_mode.unwrap_or(repl::InputMode::Emacs),
         print_stats: cfg.shell.print_stats.unwrap_or(repl::PrintStats::Off),
         history_limit: cfg.shell.history_size.unwrap_or(10000),
@@ -266,7 +267,7 @@ async fn execute_query(options: &Options, mut state: &mut repl::State,
     }
     let cli = state.connection.as_mut().expect("connection established");
 
-    if cli.protocol().supports_inline_typenames() {
+    if state.display_typenames && cli.protocol().supports_inline_typenames() {
         headers.insert(QUERY_OPT_INLINE_TYPENAMES,
                        Bytes::from_static(b"true"));
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -55,6 +55,7 @@ pub struct State {
     pub implicit_limit: Option<usize>,
     pub input_mode: InputMode,
     pub output_format: OutputFormat,
+    pub display_typenames: bool,
     pub print_stats: PrintStats,
     pub history_limit: usize,
     pub conn_params: Connector,


### PR DESCRIPTION
This will be useful for me doing development. If there is a way to
make the setting undocumented, it might be worth doing that, since it
seems fairly marginal for normal usage.