### PR TITLE
bugfix: conflict message in instance upgrade

### DIFF
--- a/src/server/upgrade.rs
+++ b/src/server/upgrade.rs
@@ -140,10 +140,8 @@ pub fn upgrade(options: &Upgrade) -> anyhow::Result<()> {
     let mut any_upgraded = false;
     for meth in methods.values() {
         match meth.upgrade(&todo, options) {
-            Ok(upgraded) => {
-                if upgraded {
-                    any_upgraded = true;
-                }
+            Ok(upgraded) if upgraded => {
+                any_upgraded = true;
                 if let ToDo::InstanceUpgrade(name, _version) = &todo {
                     let new_inst = meth.get_instance(name)?;
                     let version = new_inst.get_current_version()?.unwrap();
@@ -155,6 +153,7 @@ pub fn upgrade(options: &Upgrade) -> anyhow::Result<()> {
                     break
                 }
             }
+            Ok(_) => {}
             Err(e) if e.is::<InstanceNotFound>() => {
                 errors.push((meth.name(), e));
             }


### PR DESCRIPTION
When upgrading an instance to the latest while it's already the latest,
the CLI shows two conflicting messages.

```console
$ RUST_LOG=info edgedb instance upgrade  new --to-latest
[2021-10-04T21:59:05Z INFO  edgedb::server::unix] Read cached value for MacOS  x86_64: true
[2021-10-04T21:59:06Z INFO  edgedb::server::docker] Error running docker CLI: exit status: 0
[2021-10-04T21:59:06Z INFO  edgedb::server::remote] Fetching optional JSON at https://packages.edgedb.com/archive/.jsonindexes/macos-x86_64.json
[2021-10-04T21:59:06Z WARN  edgedb::server::unix] Instance has up to date major version 1.0rc1+d2021093022.g1d9e3d8c7.cv202109220000-202109302258. Use `edgedb instance upgrade --local-minor` (without instance name) to upgrade minor versions.
Successfully upgraded EdgeDB instance 'new' to version: 1.0rc1+d2021093022.g1d9e3d8c7.cv202109220000-202109302258
Already up to date.
```