### PR TITLE
Skip install if already installed

### DIFF
--- a/src/server/docker.rs
+++ b/src/server/docker.rs
@@ -908,6 +908,21 @@ impl<'os, O: CurrentOs + ?Sized> Method for DockerMethod<'os, O> {
     {
         let image = settings.distribution.downcast_ref::<Image>()
             .context("invalid distribution for Docker")?;
+        if let Ok(tag) = process::get_text(
+            Command::new(&self.cli)
+            .arg("inspect")
+            .arg("--format")
+            .arg("{{index .RepoDigests 0}}")
+            .arg(image.tag.as_image_name())
+        ) {
+            if let Some(tag) = Tag::from_pair(
+                image.major_version.as_str(), &tag
+            ) {
+                if image.tag.eq(&tag) {
+                    return Ok(())
+                }
+            }
+        }
         process::run(Command::new(&self.cli)
             .arg("image")
             .arg("pull")


### PR DESCRIPTION
When running `edgedb instance upgrade`, the CLI was always trying to install the server software, even if the target version is already installed. This PR checks local installation before running install.

Closes #464