### PR TITLE
Allow running nightly tests on macOS

### DIFF
--- a/tests/docker.rs
+++ b/tests/docker.rs
@@ -147,20 +147,19 @@ pub fn run(tagname: &str, script: &str) -> assert_cmd::assert::Assert {
 pub fn run_docker(tagname: &str, script: &str)
     -> assert_cmd::assert::Assert
 {
-    let path = if let Ok(path) = env::var("DOCKER_VOLUME_PATH") {
-        path.to_string()
-    } else {
-        "/var/run/docker.sock".to_string()
-    };
     let script = format!(r###"
         export EDGEDB_SKIP_DOCKER_CHECK=yes
-        sudo chmod 777 {path}
         docker ps -q -f 'name=edgedb_test' | xargs -r docker container kill
         docker system prune --all --force
         docker volume list -q -f 'name=edgedb_test' | xargs -r docker volume rm
 
         {script}
-    "###, path=path, script=script);
+    "###, script=script);
+    let path = if let Ok(path) = env::var("DOCKER_VOLUME_PATH") {
+        path.to_string()
+    } else {
+        "/var/run/docker.sock".to_string()
+    };
     Command::new("docker")
         .arg("run")
         .arg("--rm")


### PR DESCRIPTION
This makes it easier to run the nightly tests on macOS:

```console
$ brew install FiloSottile/musl-cross/musl-cross
```

**WARNING** The script below will set permission `/var/run/docker.sock` to 777 permenantly, which may affect the security of your Docker environment.

```bash
#!/usr/bin/env bash

docker run --rm -v /var/run/docker.sock:/var/run/docker.sock bash chmod 777 /var/run/docker.sock
MUSL_PREFIX=$(brew --prefix FiloSottile/musl-cross/musl-cross)
CC_x86_64_unknown_linux_musl=$MUSL_PREFIX/bin/x86_64-linux-musl-gcc \
  CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc \
  RUSTFLAGS='-C link-arg=-Wl,-undefined,dynamic_lookup' \
  cargo build --target x86_64-unknown-linux-musl --bins
EDGEDB_TEST_BIN_EXE=target/x86_64-unknown-linux-musl/debug/edgedb \
  cargo test --test=github-nightly --features=github_nightly -- $@
```