### PR TITLE
Format errors with hint/context in special cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "edgedb-client"
 version = "0.2.0"
-source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#25a64727b3f27dc5db6b097b600de6d0e0988ef8"
+source = "git+https://github.com/edgedb/edgedb-rust#75c71f844c0ca51cd7329804a6ecce46c3462a75"
 dependencies = [
  "async-std",
  "async-trait",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.2.0"
-source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#25a64727b3f27dc5db6b097b600de6d0e0988ef8"
+source = "git+https://github.com/edgedb/edgedb-rust#75c71f844c0ca51cd7329804a6ecce46c3462a75"
 dependencies = [
  "proc-macro2",
  "quote 1.0.9",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.1.0"
-source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#25a64727b3f27dc5db6b097b600de6d0e0988ef8"
+source = "git+https://github.com/edgedb/edgedb-rust#75c71f844c0ca51cd7329804a6ecce46c3462a75"
 dependencies = [
  "bytes",
 ]
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.2.0"
-source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#25a64727b3f27dc5db6b097b600de6d0e0988ef8"
+source = "git+https://github.com/edgedb/edgedb-rust#75c71f844c0ca51cd7329804a6ecce46c3462a75"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "edgedb-client"
 version = "0.2.0"
-source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#a26ed3cf4cc098ad577a6679602449f0da7581bc"
+source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#25a64727b3f27dc5db6b097b600de6d0e0988ef8"
 dependencies = [
  "async-std",
  "async-trait",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.2.0"
-source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#a26ed3cf4cc098ad577a6679602449f0da7581bc"
+source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#25a64727b3f27dc5db6b097b600de6d0e0988ef8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.9",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.1.0"
-source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#a26ed3cf4cc098ad577a6679602449f0da7581bc"
+source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#25a64727b3f27dc5db6b097b600de6d0e0988ef8"
 dependencies = [
  "bytes",
 ]
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.2.0"
-source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#a26ed3cf4cc098ad577a6679602449f0da7581bc"
+source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#25a64727b3f27dc5db6b097b600de6d0e0988ef8"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "edgedb-client"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust#65f822a2eff6c2e7383b449167b7ade4ab7677f5"
+source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#a26ed3cf4cc098ad577a6679602449f0da7581bc"
 dependencies = [
  "async-std",
  "async-trait",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust#65f822a2eff6c2e7383b449167b7ade4ab7677f5"
+source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#a26ed3cf4cc098ad577a6679602449f0da7581bc"
 dependencies = [
  "proc-macro2",
  "quote 1.0.9",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb-rust#65f822a2eff6c2e7383b449167b7ade4ab7677f5"
+source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#a26ed3cf4cc098ad577a6679602449f0da7581bc"
 dependencies = [
  "bytes",
 ]
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust#65f822a2eff6c2e7383b449167b7ade4ab7677f5"
+source = "git+https://github.com/fantix/edgedb-rust?branch=error-display#a26ed3cf4cc098ad577a6679602449f0da7581bc"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 
 [dependencies]
 edgeql-parser = {git = "https://github.com/edgedb/edgedb"}
-edgedb-protocol = {git = "https://github.com/fantix/edgedb-rust", features=["all-types"], branch="error-display"}
-edgedb-derive = {git = "https://github.com/fantix/edgedb-rust", branch="error-display"}
-edgedb-client = {git = "https://github.com/fantix/edgedb-rust", features=["admin_socket", "unstable"], branch="error-display"}
+edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust", features=["all-types"]}
+edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust"}
+edgedb-client = {git = "https://github.com/edgedb/edgedb-rust", features=["admin_socket", "unstable"]}
 snafu = {version="0.6.0", features=["backtraces"]}
 anyhow = "1.0.23"
 async-std = {version="1.9", features=[

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 
 [dependencies]
 edgeql-parser = {git = "https://github.com/edgedb/edgedb"}
-edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust", features=["all-types"]}
-edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust"}
-edgedb-client = {git = "https://github.com/edgedb/edgedb-rust", features=["admin_socket", "unstable"]}
+edgedb-protocol = {git = "https://github.com/fantix/edgedb-rust", features=["all-types"], branch="error-display"}
+edgedb-derive = {git = "https://github.com/fantix/edgedb-rust", branch="error-display"}
+edgedb-client = {git = "https://github.com/fantix/edgedb-rust", features=["admin_socket", "unstable"], branch="error-display"}
 snafu = {version="0.6.0", features=["backtraces"]}
 anyhow = "1.0.23"
 async-std = {version="1.9", features=[

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -8,9 +8,8 @@ use once_cell::sync::Lazy;
 use prettytable::{Table, Row, Cell};
 use regex::Regex;
 
-use edgedb_client::errors::Error;
+use edgedb_client::errors::{Error, display_error_verbose};
 use edgedb_client::model::Duration;
-use edgedb_protocol::error_response::display_error_verbose;
 
 use crate::commands::Options;
 use crate::repl;

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -7,10 +7,6 @@ use codespan_reporting::term::{emit};
 use termcolor::{StandardStream, ColorChoice};
 
 use edgedb_client::errors::{Error, InternalServerError};
-use edgedb_client::errors::FIELD_POSITION_START;
-use edgedb_client::errors::FIELD_POSITION_END;
-use edgedb_client::errors::{FIELD_HINT, FIELD_DETAILS};
-use edgedb_client::errors::FIELD_SERVER_TRACEBACK;
 
 use crate::print;
 
@@ -18,12 +14,8 @@ use crate::print;
 pub fn print_query_error(err: &Error, query: &str, verbose: bool)
     -> Result<(), anyhow::Error>
 {
-    let pstart = err.headers().get(&FIELD_POSITION_START)
-       .and_then(|x| str::from_utf8(x).ok())
-       .and_then(|x| x.parse::<u32>().ok());
-    let pend = err.headers().get(&FIELD_POSITION_END)
-       .and_then(|x| str::from_utf8(x).ok())
-       .and_then(|x| x.parse::<u32>().ok());
+    let pstart = err.position_start();
+    let pend = err.position_end();
     let (pstart, pend) = match (pstart, pend) {
         (Some(s), Some(e)) => (s, e),
         _ => {
@@ -31,34 +23,30 @@ pub fn print_query_error(err: &Error, query: &str, verbose: bool)
             return Ok(());
         }
     };
-    let hint = err.headers().get(&FIELD_HINT)
-        .and_then(|x| str::from_utf8(x).ok())
-        .unwrap_or("error");
-    let detail = err.headers().get(&FIELD_DETAILS)
-        .and_then(|x| String::from_utf8(x.to_vec()).ok());
+    let hint = err.hint().unwrap_or("error");
+    let detail = err.details().map(|s| s.into());
     let files = SimpleFile::new("query", query);
     let context_error = err
         .contexts()
         .rev()
-        .map(|s| s.as_ref())
         .collect::<Vec<_>>();
     if context_error.len() > 0 {
         print::error(context_error.join(": "));
     }
     let diag = Diagnostic::error()
         .with_message(&format!(
-            "{:#}{:#}",
+            "{}{}",
             err.kind_name(),
             err
                 .initial_message()
-                .map(|s| format!(": {:#}", s))
+                .map(|s| format!(": {}", s))
                 .unwrap_or("".into())
         ))
         .with_labels(vec![
             Label {
                 file_id: (),
                 style: LabelStyle::Primary,
-                range: pstart as usize..pend as usize,
+                range: pstart..pend,
                 message: hint.into(),
             },
         ])
@@ -68,13 +56,10 @@ pub fn print_query_error(err: &Error, query: &str, verbose: bool)
         &Default::default(), &files, &diag)?;
 
     if err.is::<InternalServerError>() || verbose {
-        let tb = err.headers().get(&FIELD_SERVER_TRACEBACK);
-        if let Some(traceback) = tb {
-            if let Ok(traceback) = str::from_utf8(traceback) {
-                eprintln!("  Server traceback:");
-                for line in traceback.lines() {
-                    eprintln!("      {}", line);
-                }
+        if let Some(traceback) = err.server_traceback() {
+            eprintln!("  Server traceback:");
+            for line in traceback.lines() {
+                eprintln!("      {}", line);
             }
         }
     }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -456,7 +456,9 @@ async fn execute_query(options: &Options, mut state: &mut repl::State,
                             source: ref error,
                             ..
                         } => {
-                            eprintln!("{:#}", error);
+                            print_query_error(
+                                error, statement, state.verbose_errors
+                            )?;
                         }
                         _ => eprintln!("{:#?}", e),
                     }
@@ -601,6 +603,10 @@ async fn _interactive_main(options: &Options, state: &mut repl::State)
                         .await?;
                 } else if err.is::<CleanShutdown>() {
                     return Err(err)?;
+                } else if let
+                    Some(e) = err.downcast_ref::<edgedb_client::Error>()
+                {
+                    print::edgedb_error(e, state.verbose_errors);
                 } else if !err.is::<QueryError>() {
                     print::error(err);
                 }

--- a/src/migrations/print_error.rs
+++ b/src/migrations/print_error.rs
@@ -9,11 +9,11 @@ use codespan_reporting::term::{emit};
 use termcolor::{StandardStream, ColorChoice};
 
 use edgedb_client::errors::{Error, InternalServerError};
-use edgedb_protocol::error_response::FIELD_POSITION_END;
-use edgedb_protocol::error_response::FIELD_POSITION_START;
-use edgedb_protocol::error_response::{FIELD_HINT, FIELD_DETAILS};
+use edgedb_client::errors::FIELD_POSITION_END;
+use edgedb_client::errors::FIELD_POSITION_START;
+use edgedb_client::errors::{FIELD_HINT, FIELD_DETAILS};
 use edgeql_parser::tokenizer::TokenStream;
-use edgedb_protocol::error_response::FIELD_SERVER_TRACEBACK;
+use edgedb_client::errors::FIELD_SERVER_TRACEBACK;
 
 use crate::print;
 use crate::migrations::source_map::SourceMap;

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -7,7 +7,7 @@ use async_std::stream::{Stream, StreamExt};
 use colorful::{Color, Colorful};
 use snafu::{Snafu, ResultExt, AsErrorSource};
 
-use edgedb_protocol::error_response::display_error;
+use edgedb_client::errors::display_error;
 
 pub use crate::echo;
 


### PR DESCRIPTION
This PR fixes the missing hint in error output for query `select <datetime>'1234-11-11';` in interactive mode for all output formats.

I have also checked all `print::error` calls to make sure we're not passing server errors to that function. I have also tested both `interactive.rs` and `non_interactive.rs` for all output formats with the two queries mentioned in #559, with or without this server patch:

```patch
diff --git a/edb/edgeql/compiler/func.py b/edb/edgeql/compiler/func.py
index a789505e6..2a3cf73ba 100644
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -498,8 +498,7 @@ def compile_operator(
                 )
             raise errors.InvalidTypeError(
                 msg,
-                hint=hint,
-                context=qlexpr.context)
+                hint=hint)
         elif len(matched) > 1:
             if in_abstract_constraint:
                 matched_call = matched[0]
```

Hint is always printed now.

Fixes #559

(@vpetrovykh however I cannot reproduce the hint-missing issue with this server patch for query `select {'1', 2}; ` with CLI 1.0-rc2, am I missing anything here?)