### PR TITLE
Use `default.target` for systemd units

### DIFF
--- a/src/portable/linux.rs
+++ b/src/portable/linux.rs
@@ -83,7 +83,7 @@ KillMode=mixed
 TimeoutSec=0
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
     "###,
         instance_name=name,
         data_dir=info.data_dir()?.display(),


### PR DESCRIPTION
This fixes start of the units after restart (on next login).