### PR TITLE
Change fallback socket dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "edgedb-client"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust#75c71f844c0ca51cd7329804a6ecce46c3462a75"
+source = "git+https://github.com/edgedb/edgedb-rust?branch=sock_dir#dc4c98923789fabd940739dad4eacc5eed442dec"
 dependencies = [
  "async-std",
  "async-trait",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust#75c71f844c0ca51cd7329804a6ecce46c3462a75"
+source = "git+https://github.com/edgedb/edgedb-rust?branch=sock_dir#dc4c98923789fabd940739dad4eacc5eed442dec"
 dependencies = [
  "proc-macro2",
  "quote 1.0.9",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb-rust#75c71f844c0ca51cd7329804a6ecce46c3462a75"
+source = "git+https://github.com/edgedb/edgedb-rust?branch=sock_dir#dc4c98923789fabd940739dad4eacc5eed442dec"
 dependencies = [
  "bytes",
 ]
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust#75c71f844c0ca51cd7329804a6ecce46c3462a75"
+source = "git+https://github.com/edgedb/edgedb-rust?branch=sock_dir#dc4c98923789fabd940739dad4eacc5eed442dec"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 
 [dependencies]
 edgeql-parser = {git = "https://github.com/edgedb/edgedb"}
-edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust", features=["all-types"]}
-edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust"}
-edgedb-client = {git = "https://github.com/edgedb/edgedb-rust", features=["admin_socket", "unstable"]}
+edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust", features=["all-types"], branch="sock_dir"}
+edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust", branch="sock_dir"}
+edgedb-client = {git = "https://github.com/edgedb/edgedb-rust", features=["admin_socket", "unstable"], branch="sock_dir"}
 snafu = {version="0.6.0", features=["backtraces"]}
 anyhow = "1.0.23"
 async-std = {version="1.9", features=[

--- a/src/portable/linux.rs
+++ b/src/portable/linux.rs
@@ -1,10 +1,10 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{PathBuf};
 
 use anyhow::Context;
 use fn_error_context::context;
 
-use crate::platform::{home_dir, data_dir, get_current_uid};
+use crate::platform::{home_dir, cache_dir};
 use crate::portable::local::{InstanceInfo};
 use crate::portable::status::Service;
 use crate::process;
@@ -149,13 +149,7 @@ pub fn runstate_dir(name: &str) -> anyhow::Result<PathBuf> {
     if let Some(dir) = dirs::runtime_dir() {
         Ok(dir.join(format!("edgedb-{}", name)))
     } else {
-        let dir = Path::new("/run/user")
-            .join(get_current_uid().to_string());
-        if dir.exists() {
-            Ok(dir.join(format!("edgedb-{}", name)))
-        } else {
-            Ok(data_dir()?.join(name).clone())
-        }
+        Ok(cache_dir()?.join("run").join(name))
     }
 }
 


### PR DESCRIPTION
Previously, on linux if there is no XDG_RUNTIME_DIR, we checked whether `/run/user/<userid>` exists, and used that as a default for XDG_RUNTIME_DIR, otherwise data dir is used.

the above creates an issue for the command-line tool, as now it has to check two locations for the sockets. But unlike for server-side client must poll both locations during `wait-until-available` period, because technically directory can appear at any time.

But generally it makes little sense, since absense of XDG_RUNTIME_DIR always means there is no `systemd --user` daemon (unless environment was cleared out).

Instead of guessing runtime directory this commit uses the same fallback as we use on MacOS: always use `~/.cache/edgedb/run/<name>` as a socket directory if XDG_RUNTIME_DIR is not set (this also means there is no fallback to putting sockets in the data dir, since we assume cache dir is always possible to create).