### PR TITLE
Fix version formatting in release workflow

### DIFF
--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -5,9 +5,24 @@ on:
     inputs: {}
 
 jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.whichver.outputs.branch }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Determine package version
+      shell: bash
+      run: |
+        branch=${GITHUB_REF#refs/heads/}
+        echo ::set-output name=branch::"${branch}"
+      id: whichver
+
 <% for tgt in targets.linux %>
   build-<< tgt.name >>:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -16,15 +31,11 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/<< tgt.platform >><< "{}".format(tgt.platform_libc) if tgt.platform_libc >><< "-{}".format(tgt.platform_version) if tgt.platform_version >>@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "<< tgt.platform >>"
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
@@ -45,6 +56,7 @@ jobs:
 <% for tgt in targets.macos %>
   build-<< tgt.name >>:
     runs-on: macos-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -66,8 +78,8 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "<< tgt.platform >>"
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
@@ -86,7 +98,7 @@ jobs:
 <% for tgt in targets.win %>
   build-<< tgt.name >>:
     runs-on: windows-latest
-    continue-on-error: true
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -94,10 +106,6 @@ jobs:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-cli/edgedb-pkg
-
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
 
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
@@ -118,7 +126,8 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "<< tgt.platform >>"
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,24 @@ on:
     inputs: {}
 
 jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.whichver.outputs.branch }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Determine package version
+      shell: bash
+      run: |
+        branch=${GITHUB_REF#refs/heads/}
+        echo ::set-output name=branch::"${branch}"
+      id: whichver
+
 
   build-debian-stretch:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -16,15 +31,11 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "stretch"
@@ -40,6 +51,7 @@ jobs:
 
   build-debian-buster:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -48,15 +60,11 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "buster"
@@ -72,6 +80,7 @@ jobs:
 
   build-debian-bullseye:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -80,15 +89,11 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bullseye"
@@ -104,6 +109,7 @@ jobs:
 
   build-ubuntu-xenial:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -112,15 +118,11 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "xenial"
@@ -136,6 +138,7 @@ jobs:
 
   build-ubuntu-bionic:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -144,15 +147,11 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "bionic"
@@ -168,6 +167,7 @@ jobs:
 
   build-ubuntu-focal:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -176,15 +176,11 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "focal"
@@ -200,6 +196,7 @@ jobs:
 
   build-centos-7:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -208,15 +205,11 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-7@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "centos"
         PKG_PLATFORM_VERSION: "7"
@@ -232,6 +225,7 @@ jobs:
 
   build-centos-8:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -240,15 +234,11 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "centos"
         PKG_PLATFORM_VERSION: "8"
@@ -264,6 +254,7 @@ jobs:
 
   build-linux-x86_64:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -272,15 +263,11 @@ jobs:
         ref: master
         path: edgedb-cli/edgedb-pkg
 
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/linuxmusl-x86_64@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "linux"
         PKG_PLATFORM_VERSION: "x86_64"
@@ -301,6 +288,7 @@ jobs:
 
   build-macos-x86_64:
     runs-on: macos-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -322,8 +310,8 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "x86_64"
@@ -342,7 +330,7 @@ jobs:
 
   build-win-x86_64:
     runs-on: windows-latest
-    continue-on-error: true
+    needs: prep
 
     steps:
     - uses: actions/checkout@v1
@@ -350,10 +338,6 @@ jobs:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-cli/edgedb-pkg
-
-    - name: Determine package version
-      run: edgedb-pkg/integration/determine-version.py $GITHUB_REF
-      id: whichver
 
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
@@ -374,7 +358,8 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "win"
         PKG_PLATFORM_VERSION: "x86_64"


### PR DESCRIPTION
Remove the explicit construction of versions from branch names and rely
on Cargo.toml containing the correct version instead.