### PR TITLE
project init: add `--print-project-info`

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -437,6 +437,7 @@ fn try_project_init(new_layout: bool) -> anyhow::Result<InitResult> {
             no_migrations: false,
             link: false,
             server_start_conf: None,
+            print_project_info: false,
         };
         let dir = fs::canonicalize(&dir)
             .with_context(|| format!("failed to canonicalize dir {:?}", dir))?;

--- a/src/print/color.rs
+++ b/src/print/color.rs
@@ -105,7 +105,8 @@ impl<T: fmt::Display> fmt::Display for Colored<&T> {
 
 #[macro_export]
 macro_rules! echo {
-    ($word1:expr $(,$word:expr )* $(,)?) => {
+    ($word1:expr $(; $semi_word1:expr)*
+     $(,$word:expr $(; $semi_word:expr )*)* $(,)?) => {
         // Buffer the whole output so mutliple processes do not interfere
         // each other
         {
@@ -114,9 +115,17 @@ macro_rules! echo {
             write!(&mut buf, "{}", $word1)
                 .expect("buffering of echo succeeds");
             $(
+                write!(&mut buf, "{}", $semi_word1)
+                    .expect("buffering of echo succeeds");
+            )*
+            $(
                 buf.push(' ');
                 write!(&mut buf, "{}", $word)
                     .expect("buffering of echo succeeds");
+                $(
+                    write!(&mut buf, "{}", $semi_word)
+                        .expect("buffering of echo succeeds");
+                )*
             )*
             buf.push('\n');
             eprint!("{}", buf);


### PR DESCRIPTION
Also includes:
1. Project commands don't print to stdout anymore
2. `echo` macro support semicolon char (no-space output)

Note: argument is hidden for now, as this is mostly needed internally for windows/WSL support.