### PR TITLE
Fix dist channel support in PowerShell bootstrap script

### DIFF
--- a/edgedb-init.ps1
+++ b/edgedb-init.ps1
@@ -5,6 +5,8 @@
 # Copyright 2021-present EdgeDB Inc. and the EdgeDB authors.
 # Licensed under the Apache License, Version 2.0 (the "License");
 
+&{
+
 # Bail immediately on any error.
 $ErrorActionPreference = 'Stop'
 # Prevent the pointless progress overlay produced by iwr.
@@ -14,9 +16,12 @@ $ProgressPreference = 'SilentlyContinue'
 
 $BaseUrl = "https://packages.edgedb.com/dist"
 $DistArch = "x86_64"
-$SubDist = ""
-$Suffix = "$SubDist" -replace "\.","_"
-$DownloadUrl = "$BaseUrl/${DistArch}-pc-windows-msvc${SubDist}/edgedb-cli$Suffix.exe"
+If ($Channel -eq $null) {
+  $DistSuf = ""
+} Else {
+  $DistSuf = ".$Channel"
+}
+$DownloadUrl = "$BaseUrl/${DistArch}-pc-windows-msvc${DistSuf}/edgedb-cli.exe"
 
 Write-Output "Downloading installer..."
 
@@ -34,3 +39,5 @@ Start-Process $CliExe -ArgumentList "--no-wait-for-exit-prompt" -NoNewWindow -Wa
 $User = [EnvironmentVariableTarget]::User
 $Path = [Environment]::GetEnvironmentVariable('Path', $User)
 $Env:Path += ";$Path"
+
+}


### PR DESCRIPTION
Also, enclose the script in a block to avoid polluting the enclosing
variable scope.