### PR TITLE
windows: fix when WSL1 is default and few others

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -131,8 +131,8 @@ fn reset_terminal(sentinel: &TermSentinel) {
 }
 
 #[cfg(windows)]
-fn reset_terminal(sentinel: &TermSentinel) {
-    // TODO
+fn reset_terminal(_sentinel: &TermSentinel) {
+    // On windows it's reset automatically
 }
 
 #[cfg(unix)]

--- a/src/process.rs
+++ b/src/process.rs
@@ -626,10 +626,19 @@ async fn stdout_loop(marker: &str, pipe: Option<impl Read+Unpin>,
             let buf = BufReader::new(pipe);
             let mut lines = buf.lines();
             while let Some(Ok(line)) = lines.next().await {
-                io::stderr().write_all(
-                    format!("[{}] {}\n", marker, line).color(Color::Grey37)
-                    .to_string().as_bytes()
-                ).await.ok();
+                if cfg!(windows) {
+                    io::stderr().write_all(
+                        format!("[{}] {}\r\n", marker, line)
+                        .color(Color::Grey37)
+                        .to_string().as_bytes()
+                    ).await.ok();
+                } else {
+                    io::stderr().write_all(
+                        format!("[{}] {}\n", marker, line)
+                        .color(Color::Grey37)
+                        .to_string().as_bytes()
+                    ).await.ok();
+                }
             }
         }
         (None, Some(_)) => unreachable!(),

--- a/tests/github-actions/install.rs
+++ b/tests/github-actions/install.rs
@@ -68,7 +68,7 @@ fn github_action_install() -> anyhow::Result<()> {
 
     if cfg!(windows) {
         fs::copy(env!("CARGO_BIN_EXE_edgedb"), "edgedb-init.exe")?;
-        Command::new("edgedb-init.exe")
+        Command::new(".\\edgedb-init.exe")
             .arg("-y")
             .assert()
             .context("edgedb-init", "self install by command name")


### PR DESCRIPTION
Includes:
1. Silence `reset_terminal` warning (no need to reset terminal on win)
2. Parses `wsl --list` to find out version of initialized distro and
   coverts if needed (Note: there is no `wsl --status` on some systems,
   no no way to find out which version is default before registering a
   distribution; and also wslapi call returns wrong version)
3. Better newlines on wsl subprocesses (apt output was bad sometimes)
4. `DEBIAN_FRONTEND=noninteractive` for updating packages

Fixes #630