### PR TITLE
Fix recognition of development servers

### DIFF
--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -45,7 +45,7 @@ pub enum FilterMinor {
 }
 
 static BUILD: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^\d+\.\d+(?:-(?:alpha|beta|rc|dev)\.\d+)?\+[a-f0-9]{7}$"#)
+    Regex::new(r#"^\d+\.\d+(?:-(?:alpha|beta|rc|dev)\.\d+)?\+(?:[a-f0-9]{7}|local)$"#)
         .unwrap()
 });
 
@@ -67,7 +67,7 @@ impl FromStr for Build {
     type Err = anyhow::Error;
     fn from_str(value: &str) -> anyhow::Result<Build> {
         if !BUILD.is_match(value) {
-            anyhow::bail!("unsupported build version format");
+            anyhow::bail!("unsupported build version format: {}", value);
         }
         Ok(Build(value.into()))
     }


### PR DESCRIPTION
Development builds respond with versions like `1.0-dev.6337+local`,
which the current regexp does not match.