### PR TITLE
migrations: no transaction timeout on `migrate`

### DIFF
--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -8,6 +8,7 @@ mod print_error;
 mod source_map;
 mod status;
 mod prompt;
+mod timeout;
 
 const NULL_MIGRATION: &str = "initial";
 

--- a/src/migrations/timeout.rs
+++ b/src/migrations/timeout.rs
@@ -1,0 +1,25 @@
+use edgedb_client::client::Connection;
+use edgedb_client::model::Duration;
+use edgeql_parser::helpers::quote_string;
+
+
+pub async fn inhibit_for_transaction(cli: &mut Connection)
+    -> Result<Duration, anyhow::Error>
+{
+    let old_timeout = cli.query_row::<Duration, _>(
+        "SELECT cfg::Config.session_idle_transaction_timeout", &()).await?;
+    cli.execute("CONFIGURE SESSION SET session_idle_transaction_timeout \
+                     := <std::duration>'0'").await?;
+    Ok(old_timeout)
+}
+
+pub async fn restore_for_transaction(cli: &mut Connection, old: Duration)
+    -> Result<(), anyhow::Error>
+{
+    cli.execute(format!(
+       "CONFIGURE SESSION SET session_idle_transaction_timeout \
+           := <std::duration>{}",
+       quote_string(&old.to_string())
+    )).await?;
+    Ok(())
+}


### PR DESCRIPTION
Additionally:
* sets unlimited timeout for `migration create` (previously was set to
  an arbitrary value of "2 hours")
* migration create: fixes few corner cases where `ABORT MIGRATION` and
  timeout reset was not called on error (could only be a problem in
  slash commands)

Supersedes #648
Fixes issue in edgedb/edgedb#3395