### PR TITLE
instance stop: Fix exit codes on stop

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -227,7 +227,7 @@ impl Interrupt {
     pub fn err_if_occurred(&self) -> anyhow::Result<()> {
         if let Some(sig) = self.event.first.load() {
             self.event.clear();
-            return Err(ExitCode::new(signal_message(sig)).into());
+            return Err(ExitCode::new(128 + signal_message(sig)).into());
         }
         Ok(())
     }


### PR DESCRIPTION
* Generally on unixes we should return 128+signal_num instead of
  signal_num as exit code (that was a bug)
* On macos specifically, we should return exit code 0 to instruct
  launchctl to not restart the instance
* This fixes #663: inability to stop instances on macos