### PR TITLE
Fix minor version exact match

### DIFF
--- a/src/portable/info.rs
+++ b/src/portable/info.rs
@@ -22,7 +22,9 @@ pub fn info(options: &Info) -> anyhow::Result<()> {
     // note this assumes that latest is set if no nightly and version
     let query = Query::from_options(options.nightly, &options.version)?;
     let all = local::get_installed()?;
-    let inst = all.into_iter().filter(|item| query.matches(&item.version))
+    let inst = all
+        .into_iter()
+        .filter(|item| query.matches(&item.version, true))
         .max_by_key(|item| item.version.specific())
         .context("cannot find installed packages maching your criteria")?;
     if options.bin_path {

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -836,7 +836,7 @@ impl Handle {
     }
     fn check_version(&self, ver_query: &Query) {
         match self.get_version() {
-            Ok(inst_ver) if ver_query.matches(&inst_ver) => {}
+            Ok(inst_ver) if ver_query.matches(&inst_ver, false) => {}
             Ok(inst_ver) => {
                 print::warn(format!(
                     "WARNING: existing instance has version {}, \
@@ -1255,7 +1255,8 @@ pub fn update_toml(options: &Upgrade) -> anyhow::Result<()> {
             }
             print_other_project_warning(&name, &root, &query)?;
         } else {
-            echo!("Latest version found", pkg.version.to_string() + ",",
+            echo!("Latest or requested version found",
+                  pkg.version.to_string() + ",",
                   "current instance version is",
                   inst.get_version()?.emphasize().to_string() + ".",
                   "Already up to date.");

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -362,7 +362,11 @@ fn get_platform_server_package(query: &Query, platform: &str)
     let filter = query.version.as_ref();
     let pkg = get_platform_server_packages(query.channel, platform)?
         .into_iter()
-        .filter(|pkg| filter.map(|q| q.matches(&pkg.version)).unwrap_or(true))
+        .filter(|pkg| {
+            filter
+                .map(|q| q.matches(&pkg.version, true))
+                .unwrap_or(true)
+        })
         .max_by_key(|pkg| pkg.version.specific());
     Ok(pkg)
 }
@@ -532,9 +536,9 @@ impl Query {
             }
         }
     }
-    pub fn matches(&self, ver: &ver::Build) -> bool {
+    pub fn matches(&self, ver: &ver::Build, exact: bool) -> bool {
         match &self.version {
-            Some(query_ver) => query_ver.matches(ver),
+            Some(query_ver) => query_ver.matches(ver, exact),
             None => {
                 Channel::from_version(&ver.specific())
                     .map(|channel| self.channel == channel)

--- a/src/portable/uninstall.rs
+++ b/src/portable/uninstall.rs
@@ -19,7 +19,7 @@ pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
     }
     if let Some(ver) = &options.version {
         if let Ok(ver) = ver.parse::<ver::Filter>() {
-            candidates.retain(|cand| ver.matches(&cand.version));
+            candidates.retain(|cand| ver.matches(&cand.version, false));
         } else if let Ok(ver) = ver.parse::<ver::Specific>() {
             candidates.retain(|cand| ver == cand.version.specific());
         } else if let Ok(ver) = ver.parse::<ver::Build>() {

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -161,7 +161,7 @@ impl Build {
 }
 
 impl Filter {
-    pub fn matches(&self, bld: &Build) -> bool {
+    pub fn matches(&self, bld: &Build, exact: bool) -> bool {
         use MinorVersion as M;
         use FilterMinor as Q;
 
@@ -173,6 +173,7 @@ impl Filter {
         match (spec.minor, self.minor.unwrap_or(Q::Minor(0))) {
             // dev releases can't be matched
             (M::Dev(_), _) => false,
+            (M::Minor(v), Q::Minor(q)) if exact => v == q,
             // minor releases are upgradeable
             (M::Minor(v), Q::Minor(q)) => v >= q,
             // Special-case before 1.0, to treat all prereleases as major


### PR DESCRIPTION
The following cases will now use exact minor version match:

* edgedb server info --version
* edgedb server install --version
* edgedb instance upgrade --to-version
* edgedb project init --server-version
* edgedb project init with version in edgedb.toml
* edgedb porject init with interactively-collected version
* edgedb project upgrade --to-version (--force to downgrade)
* edgedb project upgrade with new version in edgedb.toml

Fixes #687 