### PR TITLE
Add `edgedb ui` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
  "nix 0.23.1",
  "num-bigint",
  "once_cell",
+ "open",
  "openssl",
  "os-release",
  "pem 1.0.2",
@@ -2298,6 +2299,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9213e7b66aa06a7722828ee2980c1adff22a3922b582baaa1e62e30ca2a6c018"
+dependencies = [
+ "pathdiff",
+ "winapi",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,6 +2429,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pem"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ blocking = "1.1.0"
 fd-lock = "3.0.2"
 zip = "0.5.0"
 libflate = "1.1.1"
+open = "2.1.1"
 
 [dev-dependencies]
 assert_cmd = {git="https://github.com/tailhook/assert_cmd", branch="edgedb_20190513"}

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -71,5 +71,8 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
         Command::Info => {
             task::block_on(commands::info(&options)).into()
         }
+        Command::UI => {
+            commands::show_ui(&options)
+        }
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub mod backslash;
 pub mod cli;
 pub mod options;
 pub mod parser;
+mod ui;
 
 pub use self::configure::configure;
 pub use self::dump::{dump, dump_all};
@@ -40,3 +41,4 @@ pub use self::restore::{restore, restore_all};
 pub use self::psql::psql;
 pub use self::exit::ExitCode;
 pub use self::info::info;
+pub use self::ui::show_ui;

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -1,0 +1,16 @@
+use crate::options::Options;
+use crate::print;
+use crate::commands::ExitCode;
+
+pub fn show_ui(options: &Options) -> anyhow::Result<()> {
+    let connector = options.create_connector()?;
+    let builder = connector.get()?;
+    let url = format!("http://{}:{}/admin", builder.get_host(), builder.get_port());
+    if open::that(&url).is_ok() {
+        Ok(())
+    } else {
+        print::error("Cannot launch browser, please visit URL:");
+        print::echo!("  {}", url);
+        Err(ExitCode::new(1).into())
+    }
+}

--- a/src/options.rs
+++ b/src/options.rs
@@ -246,6 +246,9 @@ pub enum Command {
     /// Execute EdgeQL queries
     #[edb(inherit(ConnectionOptions))]
     Query(Query),
+    /// Launches the web UI for the EdgeDB instance
+    #[edb(inherit(ConnectionOptions))]
+    UI,
     /// Show information about the EdgeDB installation
     Info,
     /// Manage project installation

--- a/src/options.rs
+++ b/src/options.rs
@@ -247,7 +247,7 @@ pub enum Command {
     #[edb(inherit(ConnectionOptions))]
     Query(Query),
     /// Launches the web UI for the EdgeDB instance
-    #[edb(inherit(ConnectionOptions))]
+    #[edb(inherit(ConnectionOptions), hide=true)]
     UI,
     /// Show information about the EdgeDB installation
     Info,


### PR DESCRIPTION
* If run within a project it should use the project instance; if launched differently, it should require `-I`.
* When an instance is determined, it should open your local browser pointing to `http://$INSTANCE_HOST:$INSTANCE_PORT/admin`.
* Known issue: it's currently not checking if the target server is valid or not. Like `edgedb ui --host 127.0.0.1 --port 8080` will also open `http://127.0.0.1:8080/admin`.
* This command is not hidden in the `--help`.