### PR TITLE
EdgeDB Cloud CLI Support - Prototype Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "edgedb-client"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust?branch=cloud#93809f9f0088d672e1f9ccad43270e60f819df93"
+source = "git+https://github.com/edgedb/edgedb-rust#d30fd20a0b55d4fbe4519f45894de5de6ec46171"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1215,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust?branch=cloud#93809f9f0088d672e1f9ccad43270e60f819df93"
+source = "git+https://github.com/edgedb/edgedb-rust#d30fd20a0b55d4fbe4519f45894de5de6ec46171"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1226,7 +1226,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb-rust?branch=cloud#93809f9f0088d672e1f9ccad43270e60f819df93"
+source = "git+https://github.com/edgedb/edgedb-rust#d30fd20a0b55d4fbe4519f45894de5de6ec46171"
 dependencies = [
  "bytes",
 ]
@@ -1234,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust?branch=cloud#93809f9f0088d672e1f9ccad43270e60f819df93"
+source = "git+https://github.com/edgedb/edgedb-rust#d30fd20a0b55d4fbe4519f45894de5de6ec46171"
 dependencies = [
  "bigdecimal",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "edgedb-client"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust#dfdeb7f2071dc25000521ba994e34d7bc5e4561d"
+source = "git+https://github.com/edgedb/edgedb-rust?branch=cloud#93809f9f0088d672e1f9ccad43270e60f819df93"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1215,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust#dfdeb7f2071dc25000521ba994e34d7bc5e4561d"
+source = "git+https://github.com/edgedb/edgedb-rust?branch=cloud#93809f9f0088d672e1f9ccad43270e60f819df93"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1226,7 +1226,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb-rust#dfdeb7f2071dc25000521ba994e34d7bc5e4561d"
+source = "git+https://github.com/edgedb/edgedb-rust?branch=cloud#93809f9f0088d672e1f9ccad43270e60f819df93"
 dependencies = [
  "bytes",
 ]
@@ -1234,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.2.0"
-source = "git+https://github.com/edgedb/edgedb-rust#dfdeb7f2071dc25000521ba994e34d7bc5e4561d"
+source = "git+https://github.com/edgedb/edgedb-rust?branch=cloud#93809f9f0088d672e1f9ccad43270e60f819df93"
 dependencies = [
  "bigdecimal",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 
 [dependencies]
 edgeql-parser = {git = "https://github.com/edgedb/edgedb"}
-edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust", branch = "cloud", features=["all-types"]}
-edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust", branch = "cloud"}
-edgedb-client = {git = "https://github.com/edgedb/edgedb-rust", branch = "cloud", features=["admin_socket", "unstable"]}
+edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust", features=["all-types"]}
+edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust"}
+edgedb-client = {git = "https://github.com/edgedb/edgedb-rust", features=["admin_socket", "unstable"]}
 snafu = {version="0.7.0", features=["backtraces"]}
 anyhow = "1.0.23"
 async-std = {version="1.10", features=[

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 
 [dependencies]
 edgeql-parser = {git = "https://github.com/edgedb/edgedb"}
-edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust", features=["all-types"]}
-edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust"}
-edgedb-client = {git = "https://github.com/edgedb/edgedb-rust", features=["admin_socket", "unstable"]}
+edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust", branch = "cloud", features=["all-types"]}
+edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust", branch = "cloud"}
+edgedb-client = {git = "https://github.com/edgedb/edgedb-rust", branch = "cloud", features=["admin_socket", "unstable"]}
 snafu = {version="0.7.0", features=["backtraces"]}
 anyhow = "1.0.23"
 async-std = {version="1.10", features=[

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -411,9 +411,13 @@ fn try_project_init(new_layout: bool) -> anyhow::Result<InitResult> {
             server_start_conf: None,
             cloud: false,
         };
+        let options = crate::options::CloudOptions {
+            cloud_base_url: None,
+            cloud_access_token: None,
+        };
         let dir = fs::canonicalize(&dir)
             .with_context(|| format!("failed to canonicalize dir {:?}", dir))?;
-        project::init_existing(&init, &dir)?;
+        project::init_existing(&init, &dir, &options)?;
         Ok(Initialized)
     } else {
         Ok(NotAProject)

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -409,6 +409,7 @@ fn try_project_init(new_layout: bool) -> anyhow::Result<InitResult> {
             no_migrations: false,
             link: false,
             server_start_conf: None,
+            cloud: false,
         };
         let dir = fs::canonicalize(&dir)
             .with_context(|| format!("failed to canonicalize dir {:?}", dir))?;

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use async_std::task;
 
 use crate::cloud::options;
+use crate::options::CloudOptions;
 use crate::platform::config_dir;
 use crate::portable::local::write_json;
 use crate::print;
@@ -37,8 +38,11 @@ fn cloud_config_file() -> anyhow::Result<PathBuf> {
     Ok(config_dir()?.join("cloud.json"))
 }
 
-pub async fn login(c: &options::Login) -> anyhow::Result<()> {
-    let base_url = c.cloud_base_url.as_deref().unwrap_or(EDGEDB_CLOUD_BASE_URL);
+pub async fn login(_c: &options::Login, options: &CloudOptions) -> anyhow::Result<()> {
+    let base_url = options
+        .cloud_base_url
+        .as_deref()
+        .unwrap_or(EDGEDB_CLOUD_BASE_URL);
     let mut resp = surf::post(format!("{}/v1/auth/sessions/", base_url))
         .content_type(surf::http::mime::JSON)
         .body("{\"type\":\"CLI\"}")

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -62,8 +62,7 @@ pub async fn raise_http_error(resp: &mut Response) -> anyhow::Result<()> {
 pub async fn login(_c: &options::Login, options: &CloudOptions) -> anyhow::Result<()> {
     let base_url = get_base_url(options);
     let mut resp = surf::post(format!("{}/v1/auth/sessions/", base_url))
-        .content_type(surf::http::mime::JSON)
-        .body("{\"type\":\"CLI\"}")
+        .body(serde_json::json!({ "type": "CLI" }))
         .await
         .map_err(HttpError)?;
     raise_http_error(&mut resp).await?;

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -8,7 +8,7 @@ use crate::options::CloudOptions;
 use crate::portable::local::write_json;
 use crate::print;
 
-const AUTHENTICATION_WAIT_TIME: i32 = 180;
+const AUTHENTICATION_WAIT_TIME: i32 = 5 * 60;
 
 #[derive(Debug, serde::Deserialize)]
 struct UserSession {

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -1,0 +1,101 @@
+use std::time::Duration;
+
+use async_std::task;
+
+use crate::cloud::options;
+use crate::platform::config_dir;
+use crate::portable::local::write_json;
+use crate::print;
+use std::path::PathBuf;
+
+const EDGEDB_CLOUD_BASE_URL: &str = "http://127.0.0.1:5959";
+const AUTHENTICATION_WAIT_TIME: i32 = 180;
+
+#[derive(Debug, serde::Deserialize)]
+struct ErrorResponse {
+    status: String,
+    error: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct UserSession {
+    id: String,
+    token: Option<String>,
+    auth_url: String,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct CloudConfig {
+    access_token: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("HTTP error: {0}")]
+pub struct HttpError(surf::Error);
+
+fn cloud_config_file() -> anyhow::Result<PathBuf> {
+    Ok(config_dir()?.join("cloud.json"))
+}
+
+pub async fn login(c: &options::Login) -> anyhow::Result<()> {
+    let base_url = c.cloud_base_url.as_deref().unwrap_or(EDGEDB_CLOUD_BASE_URL);
+    let mut resp = surf::post(format!("{}/v1/auth/sessions/", base_url))
+        .content_type(surf::http::mime::JSON)
+        .body("{\"type\":\"CLI\"}")
+        .await
+        .map_err(HttpError)?;
+    if !resp.status().is_success() {
+        let ErrorResponse { status, error } = resp.body_json().await.map_err(HttpError)?;
+        anyhow::bail!(format!(
+            "Failed to create authentication session: {}: {}",
+            status, error
+        ));
+    }
+    let UserSession {
+        id,
+        auth_url,
+        token: _,
+    } = resp.body_json().await.map_err(HttpError)?;
+    let link = format!("{}{}", base_url, auth_url);
+    log::debug!("Opening URL in browser: {}", link);
+    if open::that(&link).is_ok() {
+        print::prompt("Please complete the authentication in the opened browser.");
+    } else {
+        print::prompt("Please open this link in your browser and complete the authentication:");
+        print::success_msg("Link", link);
+    }
+    for _ in 0..AUTHENTICATION_WAIT_TIME {
+        resp = surf::get(format!("{}/v1/auth/sessions/{}", base_url, id))
+            .await
+            .map_err(HttpError)?;
+        let UserSession {
+            id: _,
+            auth_url: _,
+            token,
+        } = resp.body_json().await.map_err(HttpError)?;
+        if let Some(token) = token {
+            write_json(
+                &cloud_config_file()?,
+                "cloud config",
+                &CloudConfig {
+                    access_token: Some(token),
+                },
+            )?;
+            print::success("Successfully authenticated to EdgeDB Cloud.");
+            return Ok(());
+        }
+        task::sleep(Duration::from_secs(1)).await;
+    }
+    print::error("Timed out.");
+    Ok(())
+}
+
+pub async fn logout(_c: &options::Logout) -> anyhow::Result<()> {
+    write_json(
+        &cloud_config_file()?,
+        "cloud config",
+        &CloudConfig { access_token: None },
+    )?;
+    print::success("You're now logged out from EdgeDB Cloud.");
+    Ok(())
+}

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -18,7 +18,7 @@ const AUTHENTICATION_WAIT_TIME: i32 = 180;
 #[derive(Debug, serde::Deserialize)]
 struct ErrorResponse {
     status: String,
-    error: String,
+    error: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -44,10 +44,17 @@ fn cloud_config_file() -> anyhow::Result<PathBuf> {
 pub async fn raise_http_error(resp: &mut Response) -> anyhow::Result<()> {
     if !resp.status().is_success() {
         let ErrorResponse { status, error } = resp.body_json().await.map_err(HttpError)?;
-        anyhow::bail!(format!(
-            "Failed to create authentication session: {}: {}",
-            status, error
-        ));
+        if let Some(error) = error {
+            anyhow::bail!(format!(
+                "Failed to create authentication session: {}: {}",
+                status, error
+            ));
+        } else {
+            anyhow::bail!(format!(
+                "Failed to create authentication session: {}",
+                status
+            ));
+        }
     }
     Ok(())
 }

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -1,4 +1,5 @@
 use std::convert::TryInto;
+use std::env;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
@@ -54,7 +55,11 @@ impl CloudClient {
         let base_url = options
             .cloud_base_url
             .as_deref()
-            .unwrap_or(EDGEDB_CLOUD_BASE_URL)
+            .unwrap_or(
+                env::var("EDGEDB_CLOUD_BASE_URL")
+                    .as_deref()
+                    .unwrap_or(EDGEDB_CLOUD_BASE_URL),
+            )
             .to_string();
         let mut config = surf::Config::new()
             .set_base_url(surf::Url::parse(&base_url)?.join(EDGEDB_CLOUD_API_VERSION)?)

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -7,10 +7,12 @@ use std::time::Duration;
 
 use surf::http::auth::{AuthenticationScheme, Authorization};
 
+use crate::commands::ExitCode;
 use crate::options::CloudOptions;
 use crate::platform::config_dir;
+use crate::print;
 
-const EDGEDB_CLOUD_BASE_URL: &str = "http://127.0.0.1:5959";
+const EDGEDB_CLOUD_BASE_URL: &str = "https://free-tier0.ovh-us-west-2.edgedb.cloud";
 const EDGEDB_CLOUD_API_VERSION: &str = "/v1/";
 const EDGEDB_CLOUD_API_TIMEOUT: u64 = 10;
 
@@ -78,6 +80,17 @@ impl CloudClient {
             is_logged_in,
             base_url,
         })
+    }
+
+    pub fn ensure_authenticated(&self, quiet: bool) -> anyhow::Result<()> {
+        if self.is_logged_in {
+            Ok(())
+        } else {
+            if !quiet {
+                print::error("Run `edgedb cloud login` first.");
+            }
+            Err(ExitCode::new(9).into())
+        }
     }
 
     pub async fn request<T: serde::de::DeserializeOwned>(

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -1,0 +1,125 @@
+use std::convert::TryInto;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use surf::http::auth::{AuthenticationScheme, Authorization};
+
+use crate::options::CloudOptions;
+use crate::platform::config_dir;
+
+const EDGEDB_CLOUD_BASE_URL: &str = "http://127.0.0.1:5959";
+const EDGEDB_CLOUD_API_VERSION: &str = "/v1/";
+const EDGEDB_CLOUD_API_TIMEOUT: u64 = 10;
+
+#[derive(Debug, serde::Deserialize)]
+struct ErrorResponse {
+    status: String,
+    error: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("HTTP error: {0}")]
+pub struct HttpError(surf::Error);
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct CloudConfig {
+    pub access_token: Option<String>,
+}
+
+pub struct CloudClient {
+    client: surf::Client,
+    pub is_logged_in: bool,
+    pub base_url: String,
+}
+
+impl CloudClient {
+    pub fn new(options: &CloudOptions) -> anyhow::Result<Self> {
+        let access_token = if let Some(access_token) = &options.cloud_access_token {
+            Some(access_token.into())
+        } else {
+            match fs::read_to_string(cloud_config_file()?) {
+                Ok(data) if data.is_empty() => None,
+                Ok(data) => {
+                    let config: CloudConfig = serde_json::from_str(&data)?;
+                    config.access_token
+                }
+                Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+                Err(e) => {
+                    return Err(e)?;
+                }
+            }
+        };
+        let base_url = options
+            .cloud_base_url
+            .as_deref()
+            .unwrap_or(EDGEDB_CLOUD_BASE_URL)
+            .to_string();
+        let mut config = surf::Config::new()
+            .set_base_url(surf::Url::parse(&base_url)?.join(EDGEDB_CLOUD_API_VERSION)?)
+            .set_timeout(Some(Duration::from_secs(EDGEDB_CLOUD_API_TIMEOUT)));
+        let is_logged_in = if let Some(access_token) = access_token {
+            let auth = Authorization::new(AuthenticationScheme::Bearer, access_token.into());
+            config = config
+                .add_header(auth.name(), auth.value())
+                .map_err(HttpError)?;
+            true
+        } else {
+            false
+        };
+        Ok(Self {
+            client: config.try_into()?,
+            is_logged_in,
+            base_url,
+        })
+    }
+
+    pub async fn request<T: serde::de::DeserializeOwned>(
+        &self,
+        req: surf::RequestBuilder,
+    ) -> anyhow::Result<T> {
+        let mut resp = req.await.map_err(HttpError)?;
+        if !resp.status().is_success() {
+            let ErrorResponse { status, error } = resp.body_json().await.map_err(HttpError)?;
+            if let Some(error) = error {
+                anyhow::bail!(format!(
+                    "Failed to create authentication session: {}: {}",
+                    status, error
+                ));
+            } else {
+                anyhow::bail!(format!(
+                    "Failed to create authentication session: {}",
+                    status
+                ));
+            }
+        }
+        Ok(resp.body_json().await.map_err(HttpError)?)
+    }
+
+    pub async fn get<T: serde::de::DeserializeOwned>(
+        &self,
+        uri: impl AsRef<str>,
+    ) -> anyhow::Result<T> {
+        self.request(self.client.get(uri)).await
+    }
+
+    pub async fn post<T: serde::de::DeserializeOwned>(
+        &self,
+        uri: impl AsRef<str>,
+        body: impl Into<surf::Body>,
+    ) -> anyhow::Result<T> {
+        self.request(self.client.post(uri).body(body)).await
+    }
+
+    pub async fn delete<T: serde::de::DeserializeOwned>(
+        &self,
+        uri: impl AsRef<str>,
+    ) -> anyhow::Result<T> {
+        self.request(self.client.delete(uri)).await
+    }
+}
+
+pub fn cloud_config_file() -> anyhow::Result<PathBuf> {
+    Ok(config_dir()?.join("cloud.json"))
+}

--- a/src/cloud/main.rs
+++ b/src/cloud/main.rs
@@ -1,15 +1,16 @@
 use async_std::task;
 
+use crate::options::CloudOptions;
 use crate::cloud::options::CloudCommand;
 use crate::cloud::auth;
 
 
-pub fn cloud_main(cmd: &CloudCommand) -> anyhow::Result<()> {
+pub fn cloud_main(cmd: &CloudCommand, options: &CloudOptions) -> anyhow::Result<()> {
     use crate::cloud::options::Command::*;
 
     match &cmd.subcommand {
         Login(c) => {
-            task::block_on(auth::login(c))
+            task::block_on(auth::login(c, options))
         }
         Logout(c) => {
             task::block_on(auth::logout(c))

--- a/src/cloud/main.rs
+++ b/src/cloud/main.rs
@@ -1,0 +1,18 @@
+use async_std::task;
+
+use crate::cloud::options::CloudCommand;
+use crate::cloud::auth;
+
+
+pub fn cloud_main(cmd: &CloudCommand) -> anyhow::Result<()> {
+    use crate::cloud::options::Command::*;
+
+    match &cmd.subcommand {
+        Login(c) => {
+            task::block_on(auth::login(c))
+        }
+        Logout(c) => {
+            task::block_on(auth::logout(c))
+        }
+    }
+}

--- a/src/cloud/mod.rs
+++ b/src/cloud/mod.rs
@@ -1,4 +1,4 @@
-mod auth;
+pub mod auth;
 pub mod ops;
 pub mod main;
 pub mod options;

--- a/src/cloud/mod.rs
+++ b/src/cloud/mod.rs
@@ -1,0 +1,3 @@
+mod auth;
+pub mod main;
+pub mod options;

--- a/src/cloud/mod.rs
+++ b/src/cloud/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
-pub mod ops;
+pub mod client;
 pub mod main;
+pub mod ops;
 pub mod options;

--- a/src/cloud/mod.rs
+++ b/src/cloud/mod.rs
@@ -1,3 +1,4 @@
 mod auth;
+pub mod ops;
 pub mod main;
 pub mod options;

--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -1,0 +1,18 @@
+use crate::cloud::auth;
+
+
+pub fn create(
+    _cmd: &crate::portable::options::Create,
+    opts: &crate::options::Options,
+) -> anyhow::Result<()> {
+    println!("cloud create: {:?}", auth::get_access_token(&opts.cloud_options)?);
+    Ok(())
+}
+
+pub fn link(
+    _cmd: &crate::portable::options::Link,
+    opts: &crate::options::Options,
+) -> anyhow::Result<()> {
+    println!("cloud link: {:?}", auth::get_access_token(&opts.cloud_options)?);
+    Ok(())
+}

--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -26,6 +26,8 @@ pub struct CloudInstance {
     name: String,
     dsn: String,
     status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tls_ca: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -131,6 +133,7 @@ async fn write_credentials(cred_path: &PathBuf, instance: CloudInstance) -> anyh
     if env::var("EDGEDB_TEST_INSECURE_CLOUD").unwrap_or("".into()) == "1" {
         creds.tls_security = TlsSecurity::Insecure;
     }
+    creds.tls_ca = instance.tls_ca;
     creds.cloud_instance_id = Some(instance.id);
     creds.cloud_original_dsn = Some(instance.dsn);
     credentials::write(&cred_path, &creds).await

--- a/src/cloud/options.rs
+++ b/src/cloud/options.rs
@@ -1,0 +1,27 @@
+use edgedb_cli_derive::{EdbClap};
+
+
+#[derive(EdbClap, Debug, Clone)]
+pub struct CloudCommand {
+    #[clap(subcommand)]
+    pub subcommand: Command,
+}
+
+#[derive(EdbClap, Clone, Debug)]
+pub enum Command {
+    /// Authenticate to the EdgeDB Cloud and remember the access token locally
+    Login(Login),
+    /// Forget the stored access token
+    Logout(Logout),
+}
+
+#[derive(EdbClap, Debug, Clone)]
+pub struct Login {
+    #[edb(hide=true)]
+    pub cloud_base_url: Option<String>
+}
+
+#[derive(EdbClap, Debug, Clone)]
+pub struct Logout {
+
+}

--- a/src/cloud/options.rs
+++ b/src/cloud/options.rs
@@ -1,5 +1,7 @@
 use edgedb_cli_derive::{EdbClap};
 
+use crate::options::CloudOptions;
+
 
 #[derive(EdbClap, Debug, Clone)]
 pub struct CloudCommand {
@@ -10,6 +12,7 @@ pub struct CloudCommand {
 #[derive(EdbClap, Clone, Debug)]
 pub enum Command {
     /// Authenticate to the EdgeDB Cloud and remember the access token locally
+    #[edb(inherit(CloudOptions))]
     Login(Login),
     /// Forget the stored access token
     Logout(Logout),
@@ -17,8 +20,6 @@ pub enum Command {
 
 #[derive(EdbClap, Debug, Clone)]
 pub struct Login {
-    #[edb(hide=true)]
-    pub cloud_base_url: Option<String>
 }
 
 #[derive(EdbClap, Debug, Clone)]

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -76,7 +76,7 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
             commands::show_ui(&options)
         }
         Command::Cloud(c) => {
-            cloud_main(c)
+            cloud_main(c, &options.cloud_options)
         }
     }
 }

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -2,6 +2,7 @@ use async_std::task;
 
 use crate::cli;
 use crate::cli::directory_check;
+use crate::cloud::main::cloud_main;
 use crate::options::{Options, Command};
 use crate::commands::parser::{Common, MigrationCmd, Migration};
 use crate::commands;
@@ -73,6 +74,9 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
         }
         Command::UI => {
             commands::show_ui(&options)
+        }
+        Command::Cloud(c) => {
+            cloud_main(c)
         }
     }
 }

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -54,7 +54,7 @@ pub fn main(options: Options) -> Result<(), anyhow::Error> {
         }
         Command::Project(cmd) => {
             directory_check::check_and_error()?;
-            portable::project_main(cmd)
+            portable::project_main(cmd, &options)
         }
         Command::Query(q) => {
             directory_check::check_and_warn();

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod options;
 mod outputs;
 mod platform;
 mod portable;
+mod cloud;
 mod print;
 mod process;
 //mod project;

--- a/src/options.rs
+++ b/src/options.rs
@@ -191,7 +191,7 @@ pub struct ConnectionOptions {
 #[clap(setting=clap::AppSettings::DeriveDisplayOrder)]
 pub struct CloudOptions {
     /// Specify the base URL for EdgeDB Cloud API access, default is
-    /// http://127.0.0.1:5959
+    /// https://free-tier0.ovh-us-west-2.edgedb.cloud
     #[clap(long, name="URL", help_heading=Some(CLOUD_OPTIONS_GROUP))]
     #[clap(hide=true)]
     pub cloud_base_url: Option<String>,

--- a/src/options.rs
+++ b/src/options.rs
@@ -15,6 +15,7 @@ use fs_err as fs;
 
 use crate::cli::options::CliCommand;
 use crate::cli;
+use crate::cloud::options::CloudCommand;
 use crate::commands::ExitCode;
 use crate::commands::parser::Common;
 use crate::connect::Connector;
@@ -271,6 +272,9 @@ pub enum Command {
     #[clap(name="_self_install")]
     #[edb(hide=true)]
     _SelfInstall(cli::install::CliInstall),
+    /// Manage EdgeDB Cloud instances
+    #[edb(hide=true)]
+    Cloud(CloudCommand),
 }
 
 #[derive(EdbClap, Clone, Debug)]

--- a/src/options.rs
+++ b/src/options.rs
@@ -38,6 +38,7 @@ static CONNECTION_ARG_HINT: &str = "\
 
 const CONN_OPTIONS_GROUP: &str =
     "CONNECTION OPTIONS (`edgedb --help-connect` to see the full list)";
+const CLOUD_OPTIONS_GROUP: &str = "CLOUD OPTIONS";
 
 pub trait PropagateArgs {
     fn propagate_args(&self, dest: &mut AnyMap, matches: &clap::ArgMatches)
@@ -186,6 +187,22 @@ pub struct ConnectionOptions {
     pub connect_timeout: Option<Duration>,
 }
 
+#[derive(EdbClap, Clone, Debug)]
+#[clap(setting=clap::AppSettings::DeriveDisplayOrder)]
+pub struct CloudOptions {
+    /// Specify the base URL for EdgeDB Cloud API access, default is
+    /// http://127.0.0.1:5959
+    #[clap(long, name="URL", help_heading=Some(CLOUD_OPTIONS_GROUP))]
+    #[clap(hide=true)]
+    pub cloud_base_url: Option<String>,
+
+    /// Specify the EdgeDB Cloud API access token to use, instead of loading
+    /// the access token from the remembered authentication.
+    #[clap(long, name="URL", help_heading=Some(CLOUD_OPTIONS_GROUP))]
+    #[clap(hide=true)]
+    pub cloud_access_token: Option<String>,
+}
+
 /// Use the `edgedb` command-line tool to spin up local instances,
 /// manage EdgeDB projects, create and apply migrations, and more.
 ///
@@ -236,6 +253,9 @@ pub struct RawOptions {
     #[edb(inheritable)]
     pub conn: ConnectionOptions,
 
+    #[edb(inheritable)]
+    pub cloud: CloudOptions,
+
     #[clap(subcommand)]
     pub subcommand: Option<Command>,
 }
@@ -272,8 +292,8 @@ pub enum Command {
     #[clap(name="_self_install")]
     #[edb(hide=true)]
     _SelfInstall(cli::install::CliInstall),
-    /// Manage EdgeDB Cloud instances
-    #[edb(hide=true)]
+    /// EdgeDB Cloud authentication
+    #[edb(inherit(CloudOptions), hide=true)]
     Cloud(CloudCommand),
 }
 
@@ -299,6 +319,7 @@ pub struct Query {
 #[derive(Debug, Clone)]
 pub struct Options {
     pub conn_options: ConnectionOptions,
+    pub cloud_options: CloudOptions,
     pub subcommand: Option<Command>,
     pub interactive: bool,
     pub debug_print_frames: bool,
@@ -546,6 +567,7 @@ impl Options {
 
         Ok(Options {
             conn_options: tmp.conn,
+            cloud_options: tmp.cloud,
             interactive,
             subcommand,
             debug_print_frames: tmp.debug_print_frames,

--- a/src/portable/destroy.rs
+++ b/src/portable/destroy.rs
@@ -3,6 +3,7 @@ use std::path::{PathBuf};
 use fs_err as fs;
 
 use crate::commands::ExitCode;
+use crate::options::Options;
 use crate::portable::control;
 use crate::portable::exit_codes;
 use crate::portable::local;
@@ -43,7 +44,7 @@ pub fn with_projects<F>(name: &str, force: bool, f: F) -> anyhow::Result<()>
     Ok(())
 }
 
-pub fn destroy(options: &Destroy) -> anyhow::Result<()> {
+pub fn destroy(options: &Destroy, opts: &Options) -> anyhow::Result<()> {
     with_projects(&options.name, options.force, || {
         if !options.force && !options.non_interactive {
             let q = question::Confirm::new_dangerous(
@@ -55,7 +56,7 @@ pub fn destroy(options: &Destroy) -> anyhow::Result<()> {
                 return Err(ExitCode::new(exit_codes::NOT_CONFIRMED).into());
             }
         }
-        match do_destroy(options) {
+        match do_destroy(options, opts) {
             Ok(()) => Ok(()),
             Err(e) if e.is::<InstanceNotFound>() => {
                 print::error(e);
@@ -71,7 +72,7 @@ pub fn destroy(options: &Destroy) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn do_destroy(options: &Destroy) -> anyhow::Result<()> {
+fn do_destroy(options: &Destroy, opts: &Options) -> anyhow::Result<()> {
     if cfg!(windows) {
         return windows::destroy(options);
     }
@@ -100,6 +101,9 @@ fn do_destroy(options: &Destroy) -> anyhow::Result<()> {
     }
     if paths.credentials.exists(){
         found = true;
+        if let Err(e) = crate::cloud::ops::try_to_destroy(&paths.credentials, opts) {
+            print::warn(format!("Failed to destroy EdgeDB Cloud instance: {:#}", e));
+        }
         log::info!("Removing credentials file {:?}", &paths.credentials);
         fs::remove_file(&paths.credentials)?;
     }
@@ -134,12 +138,12 @@ fn do_destroy(options: &Destroy) -> anyhow::Result<()> {
     }
 }
 
-pub fn force_by_name(name: &str) -> anyhow::Result<()> {
+pub fn force_by_name(name: &str, options: &Options) -> anyhow::Result<()> {
     do_destroy(&Destroy {
         name: name.to_string(),
         verbose: false,
         force: true,
         quiet: false,
         non_interactive: true,
-    })
+    }, options)
 }

--- a/src/portable/destroy.rs
+++ b/src/portable/destroy.rs
@@ -102,7 +102,12 @@ fn do_destroy(options: &Destroy, opts: &Options) -> anyhow::Result<()> {
     if paths.credentials.exists(){
         found = true;
         if let Err(e) = crate::cloud::ops::try_to_destroy(&paths.credentials, opts) {
-            print::warn(format!("Failed to destroy EdgeDB Cloud instance: {:#}", e));
+            let msg = format!("Failed to destroy EdgeDB Cloud instance: {:#}", e);
+            if options.force {
+                print::warn(msg);
+            } else {
+                anyhow::bail!(msg);
+            }
         }
         log::info!("Removing credentials file {:?}", &paths.credentials);
         fs::remove_file(&paths.credentials)?;

--- a/src/portable/main.rs
+++ b/src/portable/main.rs
@@ -50,7 +50,7 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options)
         Link(c) if c.cloud => task::block_on(cloud::ops::link(c, options)),
         Link(c) => link::link(c, &options),
         List(c) if cfg!(windows) => windows::list(c),
-        List(c) => status::list(c),
+        List(c) => status::list(c, options),
         Upgrade(c) => upgrade::upgrade(c),
         Start(c) if cfg!(windows) => windows::start(c),
         Start(c) => control::start(c),

--- a/src/portable/main.rs
+++ b/src/portable/main.rs
@@ -1,3 +1,5 @@
+use async_std::task;
+
 use crate::cloud;
 use crate::options::Options;
 use crate::portable::project::ProjectCommand;
@@ -45,7 +47,7 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options)
         Destroy(c) => destroy::destroy(c),
         ResetPassword(c) if cfg!(windows) => windows::reset_password(c),
         ResetPassword(c) => reset_password::reset_password(c),
-        Link(c) if c.cloud => cloud::ops::link(c, &options),
+        Link(c) if c.cloud => task::block_on(cloud::ops::link(c, &options)),
         Link(c) => link::link(c, &options),
         List(c) if cfg!(windows) => windows::list(c),
         List(c) => status::list(c),

--- a/src/portable/main.rs
+++ b/src/portable/main.rs
@@ -42,12 +42,12 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options)
     use crate::portable::options::InstanceCommand::*;
 
     match &cmd.subcommand {
-        Create(c) if c.cloud => cloud::ops::create(c, &options),
+        Create(c) if c.cloud => cloud::ops::create(c, options),
         Create(c) => create::create(c),
-        Destroy(c) => destroy::destroy(c),
+        Destroy(c) => destroy::destroy(c, options),
         ResetPassword(c) if cfg!(windows) => windows::reset_password(c),
         ResetPassword(c) => reset_password::reset_password(c),
-        Link(c) if c.cloud => task::block_on(cloud::ops::link(c, &options)),
+        Link(c) if c.cloud => task::block_on(cloud::ops::link(c, options)),
         Link(c) => link::link(c, &options),
         List(c) if cfg!(windows) => windows::list(c),
         List(c) => status::list(c),
@@ -73,7 +73,7 @@ pub fn project_main(cmd: &ProjectCommand, options: &Options) -> anyhow::Result<(
 
     match &cmd.subcommand {
         Init(c) => project::init(c, &options),
-        Unlink(c) => project::unlink(c),
+        Unlink(c) => project::unlink(c, options),
         Info(c) => project::info(c),
         Upgrade(c) => project::upgrade(c),
     }

--- a/src/portable/main.rs
+++ b/src/portable/main.rs
@@ -66,11 +66,11 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options)
     }
 }
 
-pub fn project_main(cmd: &ProjectCommand) -> anyhow::Result<()> {
+pub fn project_main(cmd: &ProjectCommand, options: &Options) -> anyhow::Result<()> {
     use crate::portable::project::Command::*;
 
     match &cmd.subcommand {
-        Init(c) => project::init(c),
+        Init(c) => project::init(c, &options),
         Unlink(c) => project::unlink(c),
         Info(c) => project::info(c),
         Upgrade(c) => project::upgrade(c),

--- a/src/portable/main.rs
+++ b/src/portable/main.rs
@@ -42,7 +42,7 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options)
     use crate::portable::options::InstanceCommand::*;
 
     match &cmd.subcommand {
-        Create(c) if c.cloud => cloud::ops::create(c, options),
+        Create(c) if c.cloud => task::block_on(cloud::ops::create(c, options)),
         Create(c) => create::create(c),
         Destroy(c) => destroy::destroy(c, options),
         ResetPassword(c) if cfg!(windows) => windows::reset_password(c),

--- a/src/portable/main.rs
+++ b/src/portable/main.rs
@@ -1,3 +1,4 @@
+use crate::cloud;
 use crate::options::Options;
 use crate::portable::project::ProjectCommand;
 use crate::portable::options::{ServerCommand, ServerInstanceCommand};
@@ -39,10 +40,12 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options)
     use crate::portable::options::InstanceCommand::*;
 
     match &cmd.subcommand {
+        Create(c) if c.cloud => cloud::ops::create(c, &options),
         Create(c) => create::create(c),
         Destroy(c) => destroy::destroy(c),
         ResetPassword(c) if cfg!(windows) => windows::reset_password(c),
         ResetPassword(c) => reset_password::reset_password(c),
+        Link(c) if c.cloud => cloud::ops::link(c, &options),
         Link(c) => link::link(c, &options),
         List(c) if cfg!(windows) => windows::list(c),
         List(c) => status::list(c),

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -25,6 +25,7 @@ pub struct ServerInstanceCommand {
 #[derive(EdbClap, Clone, Debug)]
 pub enum InstanceCommand {
     /// Initialize a new EdgeDB instance
+    #[edb(inherit(crate::options::CloudOptions))]
     Create(Create),
     /// Show all instances
     List(List),
@@ -40,6 +41,7 @@ pub enum InstanceCommand {
     Destroy(Destroy),
     /// Link a remote instance
     #[edb(inherit(crate::options::ConnectionOptions))]
+    #[edb(inherit(crate::options::CloudOptions))]
     Link(Link),
     /// Unlink a remote instance
     Unlink(Unlink),
@@ -142,6 +144,10 @@ pub struct Create {
     /// credentials file)
     #[clap(long, default_value="edgedb")]
     pub default_user: String,
+
+    /// Create an EdgeDB Cloud instance rather than a local instance
+    #[clap(long, hide=true)]
+    pub cloud: bool,
 }
 
 #[derive(EdbClap, IntoArgs, Debug, Clone)]
@@ -192,6 +198,10 @@ pub struct Link {
     /// Overwrite existing credential file if any.
     #[clap(long)]
     pub overwrite: bool,
+
+    /// Link to an EdgeDB Cloud instance rather than a regular remote instance
+    #[clap(long, hide=true)]
+    pub cloud: bool,
 }
 
 #[derive(EdbClap, Clone, Debug)]

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -149,6 +149,10 @@ pub struct Create {
     /// Create an EdgeDB Cloud instance rather than a local instance
     #[clap(long, hide=true)]
     pub cloud: bool,
+
+    /// Create the EdgeDB Cloud instance under the given organization
+    #[clap(long, hide=true)]
+    pub cloud_org: Option<String>,
 }
 
 #[derive(EdbClap, IntoArgs, Debug, Clone)]

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -28,6 +28,7 @@ pub enum InstanceCommand {
     #[edb(inherit(crate::options::CloudOptions))]
     Create(Create),
     /// Show all instances
+    #[edb(inherit(crate::options::CloudOptions))]
     List(List),
     /// Show status of a matching instance
     Status(Status),
@@ -286,6 +287,10 @@ pub struct List {
     //  Currently needed for WSL
     #[clap(long, hide=true)]
     pub quiet: bool,
+
+    /// List EdgeDB Cloud instances
+    #[clap(long, hide=true)]
+    pub cloud: bool,
 }
 
 #[derive(EdbClap, IntoArgs, Debug, Clone)]

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -38,6 +38,7 @@ pub enum InstanceCommand {
     /// Restart an instance
     Restart(Restart),
     /// Destroy an instance and remove the data
+    #[edb(inherit(crate::options::CloudOptions))]
     Destroy(Destroy),
     /// Link a remote instance
     #[edb(inherit(crate::options::ConnectionOptions))]

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -447,6 +447,8 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
         let inst = Handle::probe(&name)?;
         inst.check_version(&ver_query);
         return do_link(&inst, options, project_dir, &stash_dir);
+    } else if options.cloud {
+        StartConf::Auto
     } else {
         ask_start_conf(options)?
     };

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -625,8 +625,11 @@ fn do_cloud_init(
     )?;
     write_stash_dir(stash_dir, project_dir, &name)?;
     if !options.no_migrations {
-        // TODO: run migrations
-        // task::block_on(migrate(&handle, false))?;
+        let handle = Handle {
+            name: name.clone(),
+            instance: InstanceKind::Remote,
+        };
+        task::block_on(migrate(&handle, false))?;
     }
     print_initialized(&name, &options.project_dir, StartConf::Auto);
     Ok(ProjectInfo {

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -66,6 +66,7 @@ pub enum Command {
     #[edb(inherit(crate::options::CloudOptions))]
     Init(Init),
     /// Clean-up the project configuration
+    #[edb(inherit(crate::options::CloudOptions))]
     Unlink(Unlink),
     /// Get various metadata about the project
     Info(Info),
@@ -1019,7 +1020,7 @@ fn instance_name(stash_dir: &Path) -> anyhow::Result<String> {
     Ok(inst.trim().into())
 }
 
-pub fn unlink(options: &Unlink) -> anyhow::Result<()> {
+pub fn unlink(options: &Unlink, opts: &crate::options::Options) -> anyhow::Result<()> {
     let stash_path = if let Some(dir) = &options.project_dir {
         let canon = fs::canonicalize(&dir)
             .with_context(|| format!("failed to canonicalize dir {:?}", dir))?;
@@ -1051,7 +1052,7 @@ pub fn unlink(options: &Unlink) -> anyhow::Result<()> {
                 return Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
             }
             if options.destroy_server_instance {
-                destroy::force_by_name(&inst)?;
+                destroy::force_by_name(&inst, opts)?;
             }
         } else {
             match fs::read_to_string(&stash_path.join("instance-name")) {

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -491,6 +491,7 @@ fn do_init(name: &str, pkg: &PackageInfo,
             start_conf,
             default_database: "edgedb".into(),
             default_user: "edgedb".into(),
+            cloud: false,
         }, port, &paths)?;
         let svc_result = create::create_service(&InstanceInfo {
             name: name.into(),

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -504,6 +504,7 @@ fn do_init(name: &str, pkg: &PackageInfo,
             default_database: "edgedb".into(),
             default_user: "edgedb".into(),
             cloud: false,
+            cloud_org: None,
         }, port, &paths)?;
         let svc_result = create::create_service(&InstanceInfo {
             name: name.into(),

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -360,7 +360,11 @@ pub fn get_remote(visited: &BTreeSet<String>)
     Ok(result)
 }
 
-pub fn list(options: &List) -> anyhow::Result<()> {
+pub fn list(options: &List, opts: &crate::options::Options) -> anyhow::Result<()> {
+    if options.cloud {
+        return task::block_on(crate::cloud::ops::list(options, opts));
+    }
+
     let mut visited = BTreeSet::new();
     let mut local = Vec::new();
     let data_dir = data_dir()?;

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -85,8 +85,17 @@ pub enum ConnectionStatus {
 }
 
 #[derive(Debug)]
+pub enum RemoteType {
+    Remote,
+    Cloud {
+        instance_id: String
+    },
+}
+
+#[derive(Debug)]
 pub struct RemoteStatus {
     pub name: String,
+    pub type_: RemoteType,
     pub credentials: Credentials,
     pub version: Option<String>,
     pub connection: ConnectionStatus,
@@ -102,6 +111,8 @@ pub struct JsonStatus {
     pub service_status: Option<String>,
     #[serde(skip_serializing_if="Option::is_none")]
     pub remote_status: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub cloud_instance_id: Option<String>,
 }
 
 
@@ -272,6 +283,11 @@ fn _remote_status(name: &str, quiet: bool) -> anyhow::Result<RemoteStatus> {
     let (version, connection) = try_connect(&credentials);
     return Ok(RemoteStatus {
         name: name.into(),
+        type_: if let Some(instance_id) = &credentials.cloud_instance_id {
+            RemoteType::Cloud { instance_id: instance_id.clone() }
+        } else {
+            RemoteType::Remote
+        },
         credentials,
         version,
         connection,
@@ -424,7 +440,10 @@ pub fn print_table(local: &[JsonStatus], remote: &[RemoteStatus]) {
     }
     for status in remote {
         table.add_row(Row::new(vec![
-            Cell::new("remote"),
+            Cell::new(match status.type_ {
+                RemoteType::Cloud { instance_id: _ } => "cloud",
+                RemoteType::Remote => "remote",
+            }),
             Cell::new(&status.name),
             Cell::new(&format!("{}:{}",
                    status.credentials.host.as_deref().unwrap_or("localhost"),
@@ -557,6 +576,7 @@ impl FullStatus {
                 .map(|v| v.to_string()),
             service_status: Some(status_str(&self.service).to_string()),
             remote_status: None,
+            cloud_instance_id: None,
         }
     }
     pub fn print_json_and_exit<'x>(&'x self) -> ! {
@@ -602,6 +622,9 @@ impl FullStatus {
 impl RemoteStatus {
     pub fn print_extended(&self) {
         println!("{}:", self.name);
+        if let RemoteType::Cloud { instance_id } = &self.type_ {
+            println!("  Cloud Instance ID: {}", instance_id);
+        }
         println!("  Status: {}", self.connection.as_str());
         println!("  Credentials: exist");
         println!("  Version: {}",
@@ -625,6 +648,11 @@ impl RemoteStatus {
             version: self.version.clone(),
             service_status: None,
             remote_status: Some(self.connection.as_str().to_string()),
+            cloud_instance_id: if let RemoteType::Cloud { instance_id } = &self.type_ {
+                Some(instance_id.clone())
+            } else {
+                None
+            },
         }
     }
 


### PR DESCRIPTION
This is basically Option 1 in edgedb/edgedb#3677. All commands and options are hidden from mainline `--help`.

To test, set `EDGEDB_CLOUD_BASE_URL` env var to point to your testing server.