### PR TITLE
Add `edgedb instance credentials` command

### DIFF
--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::fs;
+use std::io::{stdout, Write};
 use std::path::PathBuf;
 
 use ring::rand::SecureRandom;
@@ -39,7 +40,7 @@ pub fn show_ui(options: &Options, args: &UI) -> anyhow::Result<()> {
         }
     }
     if args.print_url {
-        println!("{}", url);
+        stdout().lock().write_all((url + "\n").as_bytes()).expect("stdout write succeeds");
         Ok(())
     } else {
         match open::that(&url) {

--- a/src/portable/credentials.rs
+++ b/src/portable/credentials.rs
@@ -1,0 +1,45 @@
+use url::Url;
+
+use crate::options::Options;
+use crate::portable::options::{ShowCredentials, ShowCredentialsType};
+use crate::print;
+
+pub fn show_credentials(options: &Options, c: &ShowCredentials) -> anyhow::Result<()> {
+    use edgedb_client::credentials::TlsSecurity;
+
+    let connector = options.create_connector()?;
+    let builder = connector.get()?;
+    let mut creds = builder.as_credentials()?;
+    match c._type {
+        Some(ShowCredentialsType::InsecureDSN) => {
+            let mut url = Url::parse(&format!(
+                "edgedb://{}@{}:{}",
+                creds.user,
+                creds.host.unwrap_or("localhost".into()),
+                creds.port,
+            ))?;
+            url.set_password(creds.password.as_deref()).ok();
+            if let Some(database) = creds.database {
+                url = url.join(&database)?;
+            }
+            match creds.tls_security {
+                TlsSecurity::Strict => {
+                    url.set_query(Some(&format!("tls_security=strict")));
+                }
+                TlsSecurity::Insecure => {
+                    url.set_query(Some(&format!("tls_security=insecure")));
+                }
+                TlsSecurity::NoHostVerification => {
+                    url.set_query(Some(&format!("tls_security=no_host_verification")));
+                }
+                _ => {}
+            }
+            print::echo!(url);
+        }
+        _ => {
+            creds.tls_ca = None;
+            print::echo!(serde_json::to_string_pretty(&creds)?);
+        }
+    }
+    Ok(())
+}

--- a/src/portable/credentials.rs
+++ b/src/portable/credentials.rs
@@ -1,44 +1,57 @@
+use std::io::{stdout, Write};
 use url::Url;
 
 use crate::options::Options;
-use crate::portable::options::{ShowCredentials, ShowCredentialsType};
-use crate::print;
+use crate::portable::options::ShowCredentials;
 
 pub fn show_credentials(options: &Options, c: &ShowCredentials) -> anyhow::Result<()> {
     use edgedb_client::credentials::TlsSecurity;
 
     let connector = options.create_connector()?;
     let builder = connector.get()?;
-    let mut creds = builder.as_credentials()?;
-    match c._type {
-        Some(ShowCredentialsType::InsecureDSN) => {
-            let mut url = Url::parse(&format!(
-                "edgedb://{}@{}:{}",
-                creds.user,
-                creds.host.unwrap_or("localhost".into()),
-                creds.port,
-            ))?;
-            url.set_password(creds.password.as_deref()).ok();
-            if let Some(database) = creds.database {
-                url = url.join(&database)?;
-            }
-            match creds.tls_security {
-                TlsSecurity::Strict => {
-                    url.set_query(Some(&format!("tls_security=strict")));
-                }
-                TlsSecurity::Insecure => {
-                    url.set_query(Some(&format!("tls_security=insecure")));
-                }
-                TlsSecurity::NoHostVerification => {
-                    url.set_query(Some(&format!("tls_security=no_host_verification")));
-                }
-                _ => {}
-            }
-            print::echo!(url);
+    let creds = builder.as_credentials()?;
+    let result = if c.json {
+        serde_json::to_string_pretty(&creds)?
+    } else if c.insecure_dsn {
+        let mut url = Url::parse(&format!(
+            "edgedb://{}@{}:{}",
+            creds.user,
+            creds.host.unwrap_or("localhost".into()),
+            creds.port,
+        ))?;
+        url.set_password(creds.password.as_deref()).ok();
+        if let Some(database) = creds.database {
+            url = url.join(&database)?;
         }
-        _ => {
-            print::echo!(serde_json::to_string_pretty(&creds)?);
+        match creds.tls_security {
+            TlsSecurity::Strict => {
+                url.set_query(Some(&format!("tls_security=strict")));
+            }
+            TlsSecurity::Insecure => {
+                url.set_query(Some(&format!("tls_security=insecure")));
+            }
+            TlsSecurity::NoHostVerification => {
+                url.set_query(Some(&format!("tls_security=no_host_verification")));
+            }
+            _ => {}
         }
-    }
+        url.to_string()
+    } else {
+        format!(
+            "Host: {}\n\
+            Port: {}\n\
+            User: {}\n\
+            Password: {}\n\
+            Database: {}\n\
+            TLS Security: {:?}",
+            creds.host.unwrap_or("localhost".into()),
+            creds.port,
+            creds.user,
+            creds.password.map(|_| "<hidden>").unwrap_or("<none>"),
+            creds.database.unwrap_or("<default>".into()),
+            creds.tls_security,
+        )
+    };
+    stdout().lock().write_all((result + "\n").as_bytes()).expect("stdout write succeeds");
     Ok(())
 }

--- a/src/portable/credentials.rs
+++ b/src/portable/credentials.rs
@@ -37,7 +37,6 @@ pub fn show_credentials(options: &Options, c: &ShowCredentials) -> anyhow::Resul
             print::echo!(url);
         }
         _ => {
-            creds.tls_ca = None;
             print::echo!(serde_json::to_string_pretty(&creds)?);
         }
     }

--- a/src/portable/main.rs
+++ b/src/portable/main.rs
@@ -7,6 +7,7 @@ use crate::portable::options::{ServerCommand, ServerInstanceCommand};
 
 use crate::portable::control;
 use crate::portable::create;
+use crate::portable::credentials;
 use crate::portable::destroy;
 use crate::portable::info;
 use crate::portable::install;
@@ -65,6 +66,7 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options)
         Unlink(c) => link::unlink(c),
         Status(c) if cfg!(windows) => windows::status(c),
         Status(c) => status::status(c),
+        Credentials(c) => credentials::show_credentials(&options, &c),
     }
 }
 

--- a/src/portable/mod.rs
+++ b/src/portable/mod.rs
@@ -13,6 +13,7 @@ pub mod windows;
 
 mod control;
 mod create;
+mod credentials;
 mod destroy;
 mod info;
 mod install;

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -509,30 +509,14 @@ pub struct Info {
     pub version: Option<ver::Filter>,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ShowCredentialsType {
-    JSON,
-    InsecureDSN,
-}
-
 #[derive(EdbClap, Clone, Debug)]
 pub struct ShowCredentials {
-    #[clap(long, possible_values=&[
-    "json", "insecure-dsn",
-    ])]
-    pub _type: Option<ShowCredentialsType>
-}
-
-impl FromStr for ShowCredentialsType {
-    type Err = anyhow::Error;
-    fn from_str(v: &str) -> anyhow::Result<ShowCredentialsType> {
-        use ShowCredentialsType::*;
-        match v {
-            "json" => Ok(JSON),
-            "insecure-dsn" => Ok(InsecureDSN),
-            _ => anyhow::bail!("unknown type {:?}", v),
-        }
-    }
+    /// Output in JSON format (password is included in cleartext)
+    #[clap(long)]
+    pub json: bool,
+    /// Output a DSN with password in cleartext
+    #[clap(long)]
+    pub insecure_dsn: bool,
 }
 
 impl FromStr for StartConf {

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -518,7 +518,7 @@ pub enum ShowCredentialsType {
 #[derive(EdbClap, Clone, Debug)]
 pub struct ShowCredentials {
     #[clap(long, possible_values=&[
-    "json", "insecure_dsn",
+    "json", "insecure-dsn",
     ])]
     pub _type: Option<ShowCredentialsType>
 }

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -57,6 +57,9 @@ pub enum InstanceCommand {
     Revert(Revert),
     /// Reset password for a user in the instance
     ResetPassword(ResetPassword),
+    /// Echo credentials to connect to the instance
+    #[edb(inherit(crate::options::ConnectionOptions))]
+    Credentials(ShowCredentials),
 }
 
 #[derive(EdbClap, Clone, Debug)]
@@ -506,6 +509,31 @@ pub struct Info {
     pub version: Option<ver::Filter>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum ShowCredentialsType {
+    JSON,
+    InsecureDSN,
+}
+
+#[derive(EdbClap, Clone, Debug)]
+pub struct ShowCredentials {
+    #[clap(long, possible_values=&[
+    "json", "insecure_dsn",
+    ])]
+    pub _type: Option<ShowCredentialsType>
+}
+
+impl FromStr for ShowCredentialsType {
+    type Err = anyhow::Error;
+    fn from_str(v: &str) -> anyhow::Result<ShowCredentialsType> {
+        use ShowCredentialsType::*;
+        match v {
+            "json" => Ok(JSON),
+            "insecure_dsn" => Ok(InsecureDSN),
+            _ => anyhow::bail!("unknown type {:?}", v),
+        }
+    }
+}
 
 impl FromStr for StartConf {
     type Err = anyhow::Error;

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -529,7 +529,7 @@ impl FromStr for ShowCredentialsType {
         use ShowCredentialsType::*;
         match v {
             "json" => Ok(JSON),
-            "insecure_dsn" => Ok(InsecureDSN),
+            "insecure-dsn" => Ok(InsecureDSN),
             _ => anyhow::bail!("unknown type {:?}", v),
         }
     }


### PR DESCRIPTION
`credentials` subcommand is NOT hidden in the `--help`.

```
edgedb-instance-credentials
Echo credentials to connect to the instance

USAGE:
    edgedb instance credentials [OPTIONS]

OPTIONS:
        --json            Output in JSON format (password is included in cleartext)
        --insecure-dsn    Output a DSN with password in cleartext
    -h, --help            Print help information

CONNECTION OPTIONS (`edgedb --help-connect` to see the full list):
    -I, --instance <instance>
            Local instance name created with edgedb instance create to connect to
            (overrides host and port)

        --dsn <dsn>
            DSN for EdgeDB to connect to (overrides all other options except password)

        --credentials-file <credentials_file>
            Path to JSON file to read credentials from
```