### PR TITLE
add support for custom schema directory

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -379,8 +379,7 @@ fn try_project_init(new_layout: bool) -> anyhow::Result<InitResult> {
 
     let base_dir = env::current_dir()
         .context("failed to get current directory")?;
-    let dir = project::search_dir(&base_dir)?;
-    if let Some(dir) = dir {
+    if let Some(dir) = project::search_dir(&base_dir) {
         if project::stash_path(&base_dir)?.exists() {
             log::info!("Project is already initialized. Skipping...");
             return Ok(Already);

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -514,9 +514,10 @@ pub struct AuthParameter {
 
 #[derive(EdbClap, Clone, Debug)]
 pub struct MigrationConfig {
-    /// Directory where `*.esdl` and `*.edgeql` files are located
-    #[clap(long, default_value="./dbschema", value_hint=ValueHint::DirPath)]
-    pub schema_dir: PathBuf,
+    /// Directory where `*.esdl` and `*.edgeql` files are located.
+    /// Default is `./dbschema`
+    #[clap(long, value_hint=ValueHint::DirPath)]
+    pub schema_dir: Option<PathBuf>,
 }
 
 #[derive(EdbClap, Clone, Debug)]

--- a/src/migrations/context.rs
+++ b/src/migrations/context.rs
@@ -16,7 +16,7 @@ impl Context {
         } else if let Some(config_dir_path) = project::search_dir(Path::new(".").as_ref()) {
             let config_path = config_dir_path.join("edgedb.toml");
             let config = config::read(&config_path)?;
-            config.project.schema_dir.unwrap_or("./dbschema".into())
+            config.project.schema_dir
         } else {
             "./dbschema".into()
         };

--- a/src/migrations/context.rs
+++ b/src/migrations/context.rs
@@ -1,6 +1,7 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::commands::parser::MigrationConfig;
+use crate::portable::config;
 
 
 pub struct Context {
@@ -8,9 +9,39 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn from_config(cfg: &MigrationConfig) -> Context {
-        Context {
-            schema_dir: cfg.schema_dir.clone(),
-        }
+    pub fn from_project_or_config(cfg: &MigrationConfig) -> anyhow::Result<Context> {
+        let schema_dir = if let Some(schema_dir) = &cfg.schema_dir {
+            schema_dir.clone()
+        } else if let Some(config_path) = search_project_config_path(&Path::new(".")) {
+            let config = config::read(&config_path)?;
+            config.edgedb.schema_dir
+        } else {
+            "./dbschema".into()
+        };
+
+        Ok(Context {
+            schema_dir,
+        })
     }
+}
+
+
+fn search_project_config_path(base_path: &Path) -> Option<PathBuf>
+{
+    let mut path = base_path;
+
+    let config_path = path.join("edgedb.toml");
+    if config_path.exists() {
+        return Some(config_path);
+    }
+
+    while let Some(parent) = path.parent() {
+        let config_path = parent.join("edgedb.toml");
+        if config_path.exists() {
+            return Some(config_path);
+        }
+        path = parent;
+    }
+
+    None
 }

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -518,7 +518,7 @@ pub async fn create(cli: &mut Connection, _options: &Options,
     create: &CreateMigration)
     -> Result<(), anyhow::Error>
 {
-    let ctx = Context::from_config(&create.cfg);
+    let ctx = Context::from_project_or_config(&create.cfg)?;
     let migrations = migration::read_all(&ctx, true).await?;
 
     let old_timeout = timeout::inhibit_for_transaction(cli).await?;

--- a/src/migrations/log.rs
+++ b/src/migrations/log.rs
@@ -88,7 +88,7 @@ pub async fn log_fs(_common: &Options, options: &MigrationLog)
 {
     assert!(options.from_fs);
 
-    let ctx = Context::from_config(&options.cfg);
+    let ctx = Context::from_project_or_config(&options.cfg)?;
     let migrations = migration::read_all(&ctx, true).await?;
     let limit = options.limit.unwrap_or(migrations.len());
     if options.newest_first {
@@ -102,4 +102,3 @@ pub async fn log_fs(_common: &Options, options: &MigrationLog)
     }
     Ok(())
 }
-

--- a/src/migrations/migrate.rs
+++ b/src/migrations/migrate.rs
@@ -56,7 +56,7 @@ pub async fn migrate(cli: &mut Connection, _options: &Options,
     migrate: &Migrate)
     -> Result<(), anyhow::Error>
 {
-    let ctx = Context::from_config(&migrate.cfg);
+    let ctx = Context::from_project_or_config(&migrate.cfg)?;
 
     let mut migrations = migration::read_all(&ctx, true).await?;
     let db_migration: Option<String> = cli.query_row_opt(r###"

--- a/src/migrations/status.rs
+++ b/src/migrations/status.rs
@@ -46,7 +46,7 @@ pub async fn status(cli: &mut Connection, _options: &Options,
     status: &ShowStatus)
     -> Result<(), anyhow::Error>
 {
-    let ctx = Context::from_config(&status.cfg);
+    let ctx = Context::from_project_or_config(&status.cfg)?;
     let migrations = migration::read_all(&ctx, true).await?;
     let db_migration: Option<String> = cli.query_row_opt(r###"
             WITH Last := (SELECT schema::Migration

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -10,11 +10,13 @@ use crate::portable::repository::{Channel, Query};
 use crate::platform::tmp_file_path;
 use crate::print::{self, echo, Highlight};
 
+static DEFAULT_SCHEMA_DIR: &str = "dbschema";
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all="kebab-case")]
 pub struct SrcConfig {
     pub edgedb: SrcEdgedb,
+    pub project: Option<toml::Spanned<SrcProject>>,
     #[serde(flatten)]
     pub extra: BTreeMap<String, toml::Value>,
 }
@@ -24,21 +26,34 @@ pub struct SrcConfig {
 pub struct SrcEdgedb {
     #[serde(default)]
     pub server_version: Option<toml::Spanned<Query>>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, toml::Value>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all="kebab-case")]
+pub struct SrcProject {
     #[serde(default)]
     pub schema_dir: Option<toml::Spanned<String>>,
     #[serde(flatten)]
     pub extra: BTreeMap<String, toml::Value>,
 }
 
+
 #[derive(Debug)]
 pub struct Config {
     pub edgedb: Edgedb,
+    pub project: Project,
 }
 
 #[derive(Debug)]
 pub struct Edgedb {
     pub server_version: Query,
-    pub schema_dir: PathBuf
+}
+
+#[derive(Debug)]
+pub struct Project {
+    pub schema_dir: Option<PathBuf>
 }
 
 fn warn_extra(extra: &BTreeMap<String, toml::Value>, prefix: &str) {
@@ -48,14 +63,21 @@ fn warn_extra(extra: &BTreeMap<String, toml::Value>, prefix: &str) {
     }
 }
 
-pub fn format_config(version: &Query, schema_dir: &Path) -> String {
-    return format!("\
+pub fn format_config(version: &Query, schema_dir: Option<&Path>) -> String {
+    let config = format!("\
         [edgedb]\n\
         server-version = {:?}\n\
-        schema-dir = {:?}\n\
-    ", version.as_config_value(), schema_dir)
-}
+    ", version.as_config_value());
 
+    if let Some(schema_dir) = schema_dir {
+        return format!("{}\n
+            [project]\n\
+            schema-directory = {:?}\n\
+        ", config, schema_dir)
+    } else {
+        return config
+    }
+}
 
 #[context("error reading project config `{}`", path.display())]
 pub fn read(path: &Path) -> anyhow::Result<Config> {
@@ -64,6 +86,7 @@ pub fn read(path: &Path) -> anyhow::Result<Config> {
     let val: SrcConfig = serde_path_to_error::deserialize(&mut toml)?;
     warn_extra(&val.extra, "");
     warn_extra(&val.edgedb.extra, "edgedb.");
+
     return Ok(Config {
         edgedb: Edgedb {
             server_version: val.edgedb.server_version
@@ -72,41 +95,88 @@ pub fn read(path: &Path) -> anyhow::Result<Config> {
                     channel: Channel::Stable,
                     version: None,
                 }),
-            schema_dir: val.edgedb.schema_dir
-                .map(|x| x.into_inner())
-                .unwrap_or("dbschema".into())
-                .into()
-        }
+        },
+        project: Project{
+            schema_dir: val.project
+                .map(|p| p.into_inner().schema_dir)
+                .map(|p| p)
+                .flatten()
+                .map(|s| s.into_inner().into())
+        },
     })
 }
 
-fn toml_modify_config(data: &str, version: &Query, schema_dir: &Path)
+fn toml_modify_config(data: &str, version: &Query, schema_dir: Option<&Path>)
     -> anyhow::Result<Option<String>>
 {
     use std::fmt::Write;
 
     let mut toml = toml::de::Deserializer::new(&data);
     let parsed: SrcConfig = serde_path_to_error::deserialize(&mut toml)?;
+    let schema_dir_length = schema_dir.map_or(0, |x| x.display().to_string().len());
+    let mut out = String::with_capacity(data.len() + 5 + schema_dir_length);
+
+    let mut config_updated = false;
+
     if let Some(ver_position) = &parsed.edgedb.server_version {
-        if let Some(schema_dir_position) = &parsed.edgedb.schema_dir {
-            if ver_position.get_ref() == version {
-                return Ok(None);
+        if ver_position.get_ref() != version {
+            config_updated = true;
+        }
+
+        let project_start = parsed.project.as_ref().map_or(data.len(), |s| s.start());
+
+        write!(&mut out, "{}{:?}{}",
+            &data[..ver_position.start()],
+            version.as_config_value(),
+            &data[ver_position.end()..project_start],
+        ).unwrap();
+
+        let mut keep_project_unchanged = true;
+        if let Some(project_source) = parsed.project {
+            if let Some(ref schema_dir_source) = project_source.get_ref().schema_dir {
+                if let Some(schema_dir) = schema_dir {
+                    if schema_dir != Path::new(DEFAULT_SCHEMA_DIR) && schema_dir != Path::new(schema_dir_source.get_ref()) {
+                        keep_project_unchanged = false;
+                        config_updated = true;
+
+                        write!(&mut out, "{}{:?}{}",
+                            &data[project_start..schema_dir_source.start()],
+                            schema_dir,
+                            &data[schema_dir_source.end()..],
+                        ).unwrap();
+                    }
+                }
+            } else if let Some(schema_dir) = schema_dir {
+                if schema_dir != Path::new(DEFAULT_SCHEMA_DIR) {
+                    keep_project_unchanged = false;
+                    config_updated = true;
+
+                    write!(&mut out, "{}\nschema-dir = {:?}\n{}",
+                        &data[project_start..project_source.end()],
+                        schema_dir,
+                        &data[project_source.end()..],
+                    ).unwrap();
+                }
             }
+        } else if let Some(schema_dir) = schema_dir {
+            keep_project_unchanged = false;
+            config_updated = true;
 
-            let schema_dir_length = schema_dir.display().to_string().len();
-            let mut out = String::with_capacity(data.len() + 5 + schema_dir_length);
-            write!(&mut out, "{}{:?}{}{:?}{}",
-                &data[..ver_position.start()],
-                version.as_config_value(),
-                &data[ver_position.end()..schema_dir_position.start()],
+            write!(&mut out, "[project]\nschema-dir = {:?}",
                 schema_dir,
-                &data[schema_dir_position.end()..],
             ).unwrap();
+        }
 
+        if keep_project_unchanged {
+            write!(&mut out, "{}", &data[project_start..]).unwrap();
+        }
+
+        if config_updated {
             return Ok(Some(out));
         } else {
-            print::error("No schema-dir found in `edgedb.toml`.");
+            return Ok(None);
         }
+
     } else {
         print::error("No server-version found in `edgedb.toml`.");
     }
@@ -121,13 +191,11 @@ fn toml_modify_config(data: &str, version: &Query, schema_dir: &Path)
 }
 
 #[context("cannot modify `{}`", config.display())]
-pub fn modify(config: &Path, ver: &Query, schema_dir: &Path) -> anyhow::Result<bool> {
+pub fn modify(config: &Path, ver: &Query, schema_dir: Option<&Path>) -> anyhow::Result<bool> {
     let input = fs::read_to_string(&config)?;
     if let Some(output) = toml_modify_config(&input, ver, schema_dir)? {
         echo!("Setting `server-version = ",
                format_args!("{:?}", ver.as_config_value()).emphasize(),
-               "and `schema-direcorty = ",
-               format_args!("{:?}", schema_dir).emphasize(),
                " in `edgedb.toml`");
         let tmp = tmp_file_path(config);
         fs::remove_file(&tmp).ok();
@@ -148,21 +216,19 @@ mod test {
     const TOML_BETA1: &str = "\
         [edgedb]\n\
         server-version = \"1.0-beta.1\"\n\
-        schema-dir = \"dbschema\"\n\
     ";
     const TOML_BETA2: &str = "\
         [edgedb]\n\
         server-version = \"1.0-beta.2\"\n\
-        schema-dir = \"dbschema\"\n\
     ";
     const TOML_NIGHTLY: &str = "\
         [edgedb]\n\
         server-version = \"nightly\"\n\
-        schema-dir = \"dbschema\"\n\
     ";
     const TOML_NIGHTLY_CUSTOM_SCHEMA_DIR: &str = "\
         [edgedb]\n\
         server-version = \"nightly\"\n\
+        [project]
         schema-dir = \"custom-dir\"\n\
     ";
 
@@ -170,78 +236,79 @@ mod test {
         [edgedb]\n\
         # some comment\n\
         server-version = \"1.0-beta.1\" #and here\n\
-        schema-dir = \"dbschema\"\n\
         other-setting = true\n\
     ";
     const TOML2_BETA2: &str = "\
         [edgedb]\n\
         # some comment\n\
         server-version = \"1.0-beta.2\" #and here\n\
-        schema-dir = \"dbschema\"\n\
         other-setting = true\n\
     ";
     const TOML2_NIGHTLY: &str = "\
         [edgedb]\n\
         # some comment\n\
         server-version = \"nightly\" #and here\n\
-        schema-dir = \"dbschema\"\n\
         other-setting = true\n\
     ";
     const TOML2_NIGHTLY_CUSTOM_SCHEMA_DIR: &str = "\
         [edgedb]\n\
         # some comment\n\
         server-version = \"nightly\" #and here\n\
-        schema-dir = \"custom-dir\"\n\
         other-setting = true\n\
+        [project]
+        schema-dir = \"custom-dir\"\n\
     ";
 
     const TOMLI_BETA1: &str = "\
-        edgedb = {server-version = \"1.0-beta.1\", schema-dir = \"dbschema\"}\n\
+        edgedb = {server-version = \"1.0-beta.1\"}\n\
     ";
     const TOMLI_BETA2: &str = "\
-        edgedb = {server-version = \"1.0-beta.2\", schema-dir = \"dbschema\"}\n\
+        edgedb = {server-version = \"1.0-beta.2\"}\n\
     ";
     const TOMLI_NIGHTLY: &str = "\
-        edgedb = {server-version = \"nightly\", schema-dir = \"dbschema\"}\n\
+        edgedb = {server-version = \"nightly\"}\n\
     ";
     const TOMLI_NIGHTLY_CUSTOM_SCHEMA_DIR: &str = "\
-        edgedb = {server-version = \"nightly\", schema-dir = \"custom-dir\"}\n\
+        edgedb = {server-version = \"nightly\"}\n\
+        project = {schema-dir = \"custom-dir\"}\n\
     ";
+    #[test_case(TOML_BETA1, "1.0-beta.2", None => Some(TOML_BETA2.into()))]
+    #[test_case(TOML_BETA2, "1.0-beta.2", None => None)]
+    #[test_case(TOML_NIGHTLY, "1.0-beta.2", None => Some(TOML_BETA2.into()))]
+    #[test_case(TOML_BETA1, "1.0-beta.1", None => None)]
+    #[test_case(TOML_BETA2, "1.0-beta.1", None => Some(TOML_BETA1.into()))]
+    #[test_case(TOML_NIGHTLY, "1.0-beta.1", None => Some(TOML_BETA1.into()))]
+    #[test_case(TOML_BETA1, "nightly", None => Some(TOML_NIGHTLY.into()))]
+    #[test_case(TOML_BETA2, "nightly", None => Some(TOML_NIGHTLY.into()))]
+    #[test_case(TOML_BETA2, "nightly", Some("custom-dir") => Some(TOML_NIGHTLY_CUSTOM_SCHEMA_DIR.into()))]
+    #[test_case(TOML_NIGHTLY_CUSTOM_SCHEMA_DIR, "nightly", Some("custom-dir") => None)]
+    #[test_case(TOML_NIGHTLY, "nightly", None => None)]
 
-    #[test_case(TOML_BETA1, "1.0-beta.2", "dbschema" => Some(TOML_BETA2.into()))]
-    #[test_case(TOML_BETA2, "1.0-beta.2", "dbschema" => None)]
-    #[test_case(TOML_NIGHTLY, "1.0-beta.2", "dbschema" => Some(TOML_BETA2.into()))]
-    #[test_case(TOML_BETA1, "1.0-beta.1", "dbschema" => None)]
-    #[test_case(TOML_BETA2, "1.0-beta.1", "dbschema" => Some(TOML_BETA1.into()))]
-    #[test_case(TOML_NIGHTLY, "1.0-beta.1", "dbschema" => Some(TOML_BETA1.into()))]
-    #[test_case(TOML_BETA1, "nightly", "dbschema" => Some(TOML_NIGHTLY.into()))]
-    #[test_case(TOML_BETA2, "nightly", "dbschema" => Some(TOML_NIGHTLY.into()))]
-    #[test_case(TOML_BETA2, "nightly", "custom-dir" => Some(TOML_NIGHTLY_CUSTOM_SCHEMA_DIR.into()))]
-    #[test_case(TOML_NIGHTLY, "nightly", "dbschema" => None)]
+    #[test_case(TOML2_BETA1, "1.0-beta.2", None => Some(TOML2_BETA2.into()))]
+    #[test_case(TOML2_BETA2, "1.0-beta.2", None => None)]
+    #[test_case(TOML2_NIGHTLY, "1.0-beta.2", None => Some(TOML2_BETA2.into()))]
+    #[test_case(TOML2_BETA1, "1.0-beta.1", None => None)]
+    #[test_case(TOML2_BETA2, "1.0-beta.1", None => Some(TOML2_BETA1.into()))]
+    #[test_case(TOML2_NIGHTLY, "1.0-beta.1", None => Some(TOML2_BETA1.into()))]
+    #[test_case(TOML2_BETA1, "nightly", None => Some(TOML2_NIGHTLY.into()))]
+    #[test_case(TOML2_BETA2, "nightly", None => Some(TOML2_NIGHTLY.into()))]
+    #[test_case(TOML2_BETA2, "nightly", Some("custom-dir") => Some(TOML2_NIGHTLY_CUSTOM_SCHEMA_DIR.into()))]
+    #[test_case(TOML2_NIGHTLY_CUSTOM_SCHEMA_DIR, "nightly", Some("custom-dir") => None)]
+    #[test_case(TOML2_NIGHTLY, "nightly", None => None)]
 
-    #[test_case(TOML2_BETA1, "1.0-beta.2", "dbschema" => Some(TOML2_BETA2.into()))]
-    #[test_case(TOML2_BETA2, "1.0-beta.2", "dbschema" => None)]
-    #[test_case(TOML2_NIGHTLY, "1.0-beta.2", "dbschema" => Some(TOML2_BETA2.into()))]
-    #[test_case(TOML2_BETA1, "1.0-beta.1", "dbschema" => None)]
-    #[test_case(TOML2_BETA2, "1.0-beta.1", "dbschema" => Some(TOML2_BETA1.into()))]
-    #[test_case(TOML2_NIGHTLY, "1.0-beta.1", "dbschema" => Some(TOML2_BETA1.into()))]
-    #[test_case(TOML2_BETA1, "nightly", "dbschema" => Some(TOML2_NIGHTLY.into()))]
-    #[test_case(TOML2_BETA2, "nightly", "dbschema" => Some(TOML2_NIGHTLY.into()))]
-    #[test_case(TOML2_BETA2, "nightly", "custom-dir" => Some(TOML2_NIGHTLY_CUSTOM_SCHEMA_DIR.into()))]
-    #[test_case(TOML2_NIGHTLY, "nightly", "dbschema" => None)]
-
-    #[test_case(TOMLI_BETA1, "1.0-beta.2", "dbschema" => Some(TOMLI_BETA2.into()))]
-    #[test_case(TOMLI_BETA2, "1.0-beta.2", "dbschema" => None)]
-    #[test_case(TOMLI_NIGHTLY, "1.0-beta.2", "dbschema" => Some(TOMLI_BETA2.into()))]
-    #[test_case(TOMLI_BETA1, "1.0-beta.1", "dbschema" => None)]
-    #[test_case(TOMLI_BETA2, "1.0-beta.1", "dbschema" => Some(TOMLI_BETA1.into()))]
-    #[test_case(TOMLI_NIGHTLY, "1.0-beta.1", "dbschema" => Some(TOMLI_BETA1.into()))]
-    #[test_case(TOMLI_BETA1, "nightly", "dbschema" => Some(TOMLI_NIGHTLY.into()))]
-    #[test_case(TOMLI_BETA2, "nightly", "dbschema" => Some(TOMLI_NIGHTLY.into()))]
-    #[test_case(TOMLI_BETA2, "nightly", "custom-dir" => Some(TOMLI_NIGHTLY_CUSTOM_SCHEMA_DIR.into()))]
-    #[test_case(TOMLI_NIGHTLY, "nightly", "dbschema" => None)]
-    fn modify(src: &str, ver: &str, schema_dir: &str) -> Option<String> {
-        toml_modify_config(src, &ver.parse().unwrap(), Path::new(schema_dir)).unwrap()
+    #[test_case(TOMLI_BETA1, "1.0-beta.2", None => Some(TOMLI_BETA2.into()))]
+    #[test_case(TOMLI_BETA2, "1.0-beta.2", None => None)]
+    #[test_case(TOMLI_NIGHTLY, "1.0-beta.2", None => Some(TOMLI_BETA2.into()))]
+    #[test_case(TOMLI_BETA1, "1.0-beta.1", None => None)]
+    #[test_case(TOMLI_BETA2, "1.0-beta.1", None => Some(TOMLI_BETA1.into()))]
+    #[test_case(TOMLI_NIGHTLY, "1.0-beta.1", None => Some(TOMLI_BETA1.into()))]
+    #[test_case(TOMLI_BETA1, "nightly", None => Some(TOMLI_NIGHTLY.into()))]
+    #[test_case(TOMLI_BETA2, "nightly", None => Some(TOMLI_NIGHTLY.into()))]
+    #[test_case(TOMLI_BETA2, "nightly", Some("custom-dir") => Some(TOMLI_NIGHTLY_CUSTOM_SCHEMA_DIR.into()))]
+    #[test_case(TOMLI_NIGHTLY_CUSTOM_SCHEMA_DIR, "nightly", Some("custom-dir") => None)]
+    #[test_case(TOMLI_NIGHTLY, "nightly", None => None)]
+    fn modify(src: &str, ver: &str, schema_dir: Option<&str>) -> Option<String> {
+        toml_modify_config(src, &ver.parse().unwrap(), schema_dir.map(|s| Path::new(s))).unwrap()
     }
 
 }

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -63,9 +63,9 @@ fn warn_extra(extra: &BTreeMap<String, toml::Value>, prefix: &str) {
 
 pub fn format_config(version: &Query) -> String {
     return format!("\
-            [edgedb]\n\
-            server-version = {:?}\n\
-        ", version.as_config_value());
+        [edgedb]\n\
+        server-version = {:?}\n\
+    ", version.as_config_value())
 }
 
 #[context("error reading project config `{}`", path.display())]

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -25,7 +25,7 @@ pub struct SrcEdgedb {
     #[serde(default)]
     pub server_version: Option<toml::Spanned<Query>>,
     #[serde(default)]
-    pub schema_directory: Option<toml::Spanned<String>>,
+    pub schema_dir: Option<toml::Spanned<String>>,
     #[serde(flatten)]
     pub extra: BTreeMap<String, toml::Value>,
 }
@@ -38,7 +38,7 @@ pub struct Config {
 #[derive(Debug)]
 pub struct Edgedb {
     pub server_version: Query,
-    pub schema_directory: PathBuf
+    pub schema_dir: PathBuf
 }
 
 fn warn_extra(extra: &BTreeMap<String, toml::Value>, prefix: &str) {
@@ -52,7 +52,7 @@ pub fn format_config(version: &Query, schema_dir: &Path) -> String {
     return format!("\
         [edgedb]\n\
         server-version = {:?}\n\
-        schema-directory = {:?}\n\
+        schema-dir = {:?}\n\
     ", version.as_config_value(), schema_dir)
 }
 
@@ -72,7 +72,7 @@ pub fn read(path: &Path) -> anyhow::Result<Config> {
                     channel: Channel::Stable,
                     version: None,
                 }),
-            schema_directory: val.edgedb.schema_directory
+            schema_dir: val.edgedb.schema_dir
                 .map(|x| x.into_inner())
                 .unwrap_or("dbschema".into())
                 .into()
@@ -88,7 +88,7 @@ fn toml_modify_config(data: &str, version: &Query, schema_dir: &Path)
     let mut toml = toml::de::Deserializer::new(&data);
     let parsed: SrcConfig = serde_path_to_error::deserialize(&mut toml)?;
     if let Some(ver_position) = &parsed.edgedb.server_version {
-        if let Some(schema_dir_position) = &parsed.edgedb.schema_directory {
+        if let Some(schema_dir_position) = &parsed.edgedb.schema_dir {
             if ver_position.get_ref() == version {
                 return Ok(None);
             }
@@ -105,7 +105,7 @@ fn toml_modify_config(data: &str, version: &Query, schema_dir: &Path)
 
             return Ok(Some(out));
         } else {
-            print::error("No schema-directory found in `edgedb.toml`.");
+            print::error("No schema-dir found in `edgedb.toml`.");
         }
     } else {
         print::error("No server-version found in `edgedb.toml`.");
@@ -148,64 +148,64 @@ mod test {
     const TOML_BETA1: &str = "\
         [edgedb]\n\
         server-version = \"1.0-beta.1\"\n\
-        schema-directory = \"dbschema\"\n\
+        schema-dir = \"dbschema\"\n\
     ";
     const TOML_BETA2: &str = "\
         [edgedb]\n\
         server-version = \"1.0-beta.2\"\n\
-        schema-directory = \"dbschema\"\n\
+        schema-dir = \"dbschema\"\n\
     ";
     const TOML_NIGHTLY: &str = "\
         [edgedb]\n\
         server-version = \"nightly\"\n\
-        schema-directory = \"dbschema\"\n\
+        schema-dir = \"dbschema\"\n\
     ";
     const TOML_NIGHTLY_CUSTOM_SCHEMA_DIR: &str = "\
         [edgedb]\n\
         server-version = \"nightly\"\n\
-        schema-directory = \"custom-dir\"\n\
+        schema-dir = \"custom-dir\"\n\
     ";
 
     const TOML2_BETA1: &str = "\
         [edgedb]\n\
         # some comment\n\
         server-version = \"1.0-beta.1\" #and here\n\
-        schema-directory = \"dbschema\"\n\
+        schema-dir = \"dbschema\"\n\
         other-setting = true\n\
     ";
     const TOML2_BETA2: &str = "\
         [edgedb]\n\
         # some comment\n\
         server-version = \"1.0-beta.2\" #and here\n\
-        schema-directory = \"dbschema\"\n\
+        schema-dir = \"dbschema\"\n\
         other-setting = true\n\
     ";
     const TOML2_NIGHTLY: &str = "\
         [edgedb]\n\
         # some comment\n\
         server-version = \"nightly\" #and here\n\
-        schema-directory = \"dbschema\"\n\
+        schema-dir = \"dbschema\"\n\
         other-setting = true\n\
     ";
     const TOML2_NIGHTLY_CUSTOM_SCHEMA_DIR: &str = "\
         [edgedb]\n\
         # some comment\n\
         server-version = \"nightly\" #and here\n\
-        schema-directory = \"custom-dir\"\n\
+        schema-dir = \"custom-dir\"\n\
         other-setting = true\n\
     ";
 
     const TOMLI_BETA1: &str = "\
-        edgedb = {server-version = \"1.0-beta.1\", schema-directory = \"dbschema\"}\n\
+        edgedb = {server-version = \"1.0-beta.1\", schema-dir = \"dbschema\"}\n\
     ";
     const TOMLI_BETA2: &str = "\
-        edgedb = {server-version = \"1.0-beta.2\", schema-directory = \"dbschema\"}\n\
+        edgedb = {server-version = \"1.0-beta.2\", schema-dir = \"dbschema\"}\n\
     ";
     const TOMLI_NIGHTLY: &str = "\
-        edgedb = {server-version = \"nightly\", schema-directory = \"dbschema\"}\n\
+        edgedb = {server-version = \"nightly\", schema-dir = \"dbschema\"}\n\
     ";
     const TOMLI_NIGHTLY_CUSTOM_SCHEMA_DIR: &str = "\
-        edgedb = {server-version = \"nightly\", schema-directory = \"custom-dir\"}\n\
+        edgedb = {server-version = \"nightly\", schema-dir = \"custom-dir\"}\n\
     ";
 
     #[test_case(TOML_BETA1, "1.0-beta.2", "dbschema" => Some(TOML_BETA2.into()))]

--- a/src/portable/mod.rs
+++ b/src/portable/mod.rs
@@ -1,7 +1,7 @@
-mod config;
 mod exit_codes;
 mod main;
 mod platform;
+pub mod config;
 pub mod local;
 pub mod options;
 pub mod repository;

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -193,7 +193,7 @@ pub struct Handle {
     name: String,
     instance: InstanceKind,
     project_dir: PathBuf,
-    schema_dir: Option<PathBuf>,
+    schema_dir: PathBuf,
 }
 
 pub struct WslInfo {
@@ -319,7 +319,7 @@ fn link(options: &Init, project_dir: &Path, opts: &crate::options::Options)
     let inst = Handle::probe(
         &name,
         project_dir,
-        config.project.schema_dir.as_ref().map(|p| p.as_path()),
+        &config.project.schema_dir,
     )?;
     inst.check_version(&ver_query);
     do_link(&inst, options, &stash_dir)
@@ -465,8 +465,13 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
 
     let config_path = project_dir.join("edgedb.toml");
     let config = config::read(&config_path)?;
-    let schema_dir = config.project.schema_dir.unwrap_or("dbschema".into());
+    let schema_dir = config.project.schema_dir;
     let schema_dir_path = project_dir.join(&schema_dir);
+    let schema_dir_path =
+        fs::canonicalize(&schema_dir_path)
+            .with_context(|| {
+                format!("failed to canonicalize dir {:?}", schema_dir_path)
+            })?;
     let schema_files = find_schema_files(&schema_dir_path)?;
 
     let ver_query = if let Some(sver) = &options.server_version {
@@ -481,12 +486,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
             log::warn!("Linking to existing instance. \
                 `--server-start-conf` is ignored.");
         }
-        let inst =
-            Handle::probe(
-                &name,
-                project_dir,
-                Some(&schema_dir),
-            )?;
+        let inst = Handle::probe(&name, project_dir, &schema_dir)?;
         inst.check_version(&ver_query);
         return do_link(&inst, options, &stash_dir);
     } else if options.cloud {
@@ -519,12 +519,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
         ))? {
             ask_link_cloud_instance(options, &name)?;
             task::block_on(crate::cloud::ops::link_existing_cloud_instance(&client, &name))?;
-            let inst =
-                Handle::probe(
-                    &name,
-                    project_dir,
-                    Some(&schema_dir),
-                )?;
+            let inst = Handle::probe(&name, project_dir, &schema_dir)?;
             inst.check_version(&ver_query);
             return do_link(&inst, options, &stash_dir);
         }
@@ -533,7 +528,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
             ("Project config", &config_path.display().to_string()),
             (&format!("Schema dir {}",
                       if schema_files { "(non-empty)" } else { "(empty)" }),
-             &schema_dir.display().to_string()),
+             &schema_dir_path.display().to_string()),
             // ("Version", &format!("{:?}", version)),
             ("Instance name", &name),
         ]);
@@ -557,7 +552,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
             ("Project config", &config_path.display().to_string()),
             (&format!("Schema dir {}",
                       if schema_files { "(non-empty)" } else { "(empty)" }),
-             &schema_dir.display().to_string()),
+             &schema_dir_path.display().to_string()),
             ("Installation method", meth),
             ("Start configuration", start_conf.as_str()),
             ("Version", &pkg.version.to_string()),
@@ -618,7 +613,7 @@ fn do_init(name: &str, pkg: &PackageInfo,
     let handle = Handle {
         name: name.into(),
         project_dir: project_dir.into(),
-        schema_dir: Some(schema_dir.into()),
+        schema_dir: schema_dir.into(),
         instance,
     };
     match (svc_result, start_conf) {
@@ -676,7 +671,7 @@ fn do_cloud_init(
     if !options.no_migrations {
         let handle = Handle {
             name: name.clone(),
-            schema_dir: Some(schema_dir.into()),
+            schema_dir: schema_dir.into(),
             instance: InstanceKind::Remote,
             project_dir: project_dir.into(),
         };
@@ -727,9 +722,9 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
             log::warn!("Linking to existing instance. \
                 `--server-start-conf` is ignored.");
         }
-        let inst = Handle::probe(&name, project_dir, Some(&schema_dir))?;
+        let inst = Handle::probe(&name, project_dir, &schema_dir)?;
         write_config(&config_path,
-                     &Query::from_version(&inst.get_version()?.specific())?, Some(&schema_dir))?;
+                     &Query::from_version(&inst.get_version()?.specific())?)?;
         if !schema_files {
             write_schema_default(&schema_dir_path)?;
         }
@@ -760,9 +755,9 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
         ))? {
             ask_link_cloud_instance(options, &name)?;
             task::block_on(crate::cloud::ops::link_existing_cloud_instance(&client, &name))?;
-            let inst = Handle::probe(&name, project_dir, Some(&schema_dir))?;
+            let inst = Handle::probe(&name, project_dir, &schema_dir)?;
             write_config(&config_path,
-                         &Query::from_version(&inst.get_version()?.specific())?, Some(&schema_dir))?;
+                         &Query::from_version(&inst.get_version()?.specific())?)?;
             if !schema_files {
                 write_schema_default(&schema_dir_path)?;
             }
@@ -779,7 +774,7 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
             ("Instance name", &name),
         ]);
         let ver_query = Query::from_str(&version)?;
-        write_config(&config_path, &ver_query, Some(&schema_dir))?;
+        write_config(&config_path, &ver_query)?;
         if !schema_files {
             write_schema_default(&schema_dir_path)?;
         }
@@ -807,7 +802,7 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
         ]);
 
         let ver_query = Query::from_version(&pkg.version.specific())?;
-        write_config(&config_path, &ver_query, Some(&schema_dir))?;
+        write_config(&config_path, &ver_query)?;
         if !schema_files {
             write_schema_default(&schema_dir_path)?;
         }
@@ -961,7 +956,7 @@ async fn migrate(inst: &Handle, ask_for_running: bool)
         },
         &Migrate {
             cfg: MigrationConfig {
-                schema_dir: inst.schema_dir.as_ref().map(|s| inst.project_dir.join(s)),
+                schema_dir: Some(inst.project_dir.join(&inst.schema_dir)),
             },
             quiet: false,
             to_revision: None,
@@ -998,20 +993,20 @@ impl InstanceKind {
 }
 
 impl Handle {
-    pub fn probe(name: &str, project_dir: &Path, schema_dir: Option<&Path>) -> anyhow::Result<Handle> {
+    pub fn probe(name: &str, project_dir: &Path, schema_dir: &Path) -> anyhow::Result<Handle> {
         if let Some(info) = InstanceInfo::try_read(name)? {
             return Ok(Handle {
                 name: name.into(),
                 instance: InstanceKind::Portable(info),
                 project_dir: project_dir.into(),
-                schema_dir: schema_dir.map(|s| s.into()),
+                schema_dir: schema_dir.into(),
             });
         };
         Ok(Handle {
             name: name.into(),
             instance: InstanceKind::Remote,
             project_dir: project_dir.into(),
-            schema_dir: schema_dir.map(|s| s.into()),
+            schema_dir: schema_dir.into(),
         })
     }
     pub async fn get_builder(&self) -> anyhow::Result<Builder> {
@@ -1100,8 +1095,8 @@ fn write_schema_default(dir: &Path) -> anyhow::Result<()> {
 }
 
 #[context("cannot write config `{}`", path.display())]
-fn write_config(path: &Path, version: &Query, schema_dir: Option<&Path>) -> anyhow::Result<()> {
-    let text = config::format_config(version, schema_dir);
+fn write_config(path: &Path, version: &Query) -> anyhow::Result<()> {
+    let text = config::format_config(version);
     let tmp = tmp_file_path(path);
     fs::remove_file(&tmp).ok();
     fs::write(&tmp, text)?;
@@ -1427,7 +1422,7 @@ pub fn update_toml(options: &Upgrade) -> anyhow::Result<()> {
     let root = project_dir(options.project_dir.as_ref().map(|x| x.as_path()))?;
     let config_path = root.join("edgedb.toml");
     let config = config::read(&config_path)?;
-    let schema_dir = config.project.schema_dir.as_ref().map(|p| p.as_path());
+    let schema_dir = config.project.schema_dir;
 
     // This assumes to_version.is_some() || to_nightly || to_latest
     let query = Query::from_options(options.to_nightly, &options.to_version)?;
@@ -1439,7 +1434,7 @@ pub fn update_toml(options: &Upgrade) -> anyhow::Result<()> {
     if !stash_dir.exists() {
         log::warn!("No associated instance found.");
 
-        if config::modify(&config_path, &query, schema_dir)? {
+        if config::modify(&config_path, &query)? {
             print::success("Config updated successfully.");
         } else {
             print::success("Config is up to date.");
@@ -1448,7 +1443,7 @@ pub fn update_toml(options: &Upgrade) -> anyhow::Result<()> {
               "to initialize an instance.");
     } else {
         let name = instance_name(&stash_dir)?;
-        let inst = Handle::probe(&name, &root, schema_dir)?;
+        let inst = Handle::probe(&name, &root, &schema_dir)?;
         let inst = match inst.instance {
             InstanceKind::Remote
                 => anyhow::bail!("remote instances cannot be upgraded"),
@@ -1487,7 +1482,7 @@ pub fn update_toml(options: &Upgrade) -> anyhow::Result<()> {
                 Query::from_version(&pkg_ver)?
             };
 
-            if config::modify(&config_path, &config_version, schema_dir)? {
+            if config::modify(&config_path, &config_version)? {
                 echo!("Remember to commit it to version control.");
             }
             print_other_project_warning(&name, &root, &query)?;
@@ -1539,7 +1534,7 @@ pub fn upgrade_instance(options: &Upgrade) -> anyhow::Result<()> {
     let config_path = root.join("edgedb.toml");
     let config = config::read(&config_path)?;
     let cfg_ver = config.edgedb.server_version;
-    let schema_dir = config.project.schema_dir.as_ref().map(|p| p.as_path());
+    let schema_dir = config.project.schema_dir;
 
     let stash_dir = stash_path(&root)?;
     if !stash_dir.exists() {
@@ -1547,7 +1542,7 @@ pub fn upgrade_instance(options: &Upgrade) -> anyhow::Result<()> {
     }
 
     let instance_name = instance_name(&stash_dir)?;
-    let inst = Handle::probe(&instance_name, &root, schema_dir)?;
+    let inst = Handle::probe(&instance_name, &root, &schema_dir)?;
     let inst = match inst.instance {
         InstanceKind::Remote
             => anyhow::bail!("remote instances cannot be upgraded"),

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -316,7 +316,7 @@ fn link(options: &Init, project_dir: &Path, opts: &crate::options::Options)
     } else {
         ask_existing_instance_name()?
     };
-    let inst = Handle::probe(&name, project_dir, &config.edgedb.schema_directory)?;
+    let inst = Handle::probe(&name, project_dir, &config.edgedb.schema_dir)?;
     inst.check_version(&ver_query);
     do_link(&inst, options, &stash_dir)
 }
@@ -461,7 +461,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
 
     let config_path = project_dir.join("edgedb.toml");
     let config = config::read(&config_path)?;
-    let schema_dir = project_dir.join(config.edgedb.schema_directory.clone());
+    let schema_dir = project_dir.join(config.edgedb.schema_dir.clone());
     let schema_files = find_schema_files(&schema_dir)?;
 
     let ver_query = if let Some(sver) = &options.server_version {
@@ -476,7 +476,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
             log::warn!("Linking to existing instance. \
                 `--server-start-conf` is ignored.");
         }
-        let inst = Handle::probe(&name, project_dir, &config.edgedb.schema_directory)?;
+        let inst = Handle::probe(&name, project_dir, &config.edgedb.schema_dir)?;
         inst.check_version(&ver_query);
         return do_link(&inst, options, &stash_dir);
     } else if options.cloud {
@@ -509,7 +509,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
         ))? {
             ask_link_cloud_instance(options, &name)?;
             task::block_on(crate::cloud::ops::link_existing_cloud_instance(&client, &name))?;
-            let inst = Handle::probe(&name, project_dir, &config.edgedb.schema_directory)?;
+            let inst = Handle::probe(&name, project_dir, &config.edgedb.schema_dir)?;
             inst.check_version(&ver_query);
             return do_link(&inst, options, &stash_dir);
         }
@@ -1422,7 +1422,7 @@ pub fn update_toml(options: &Upgrade) -> anyhow::Result<()> {
     if !stash_dir.exists() {
         log::warn!("No associated instance found.");
 
-        if config::modify(&config_path, &query, &config.edgedb.schema_directory)? {
+        if config::modify(&config_path, &query, &config.edgedb.schema_dir)? {
             print::success("Config updated successfully.");
         } else {
             print::success("Config is up to date.");
@@ -1431,7 +1431,7 @@ pub fn update_toml(options: &Upgrade) -> anyhow::Result<()> {
               "to initialize an instance.");
     } else {
         let name = instance_name(&stash_dir)?;
-        let inst = Handle::probe(&name, &root, &config.edgedb.schema_directory)?;
+        let inst = Handle::probe(&name, &root, &config.edgedb.schema_dir)?;
         let inst = match inst.instance {
             InstanceKind::Remote
                 => anyhow::bail!("remote instances cannot be upgraded"),
@@ -1470,7 +1470,7 @@ pub fn update_toml(options: &Upgrade) -> anyhow::Result<()> {
                 Query::from_version(&pkg_ver)?
             };
 
-            if config::modify(&config_path, &config_version, &config.edgedb.schema_directory)? {
+            if config::modify(&config_path, &config_version, &config.edgedb.schema_dir)? {
                 echo!("Remember to commit it to version control.");
             }
             print_other_project_warning(&name, &root, &query)?;
@@ -1529,7 +1529,7 @@ pub fn upgrade_instance(options: &Upgrade) -> anyhow::Result<()> {
     }
 
     let instance_name = instance_name(&stash_dir)?;
-    let inst = Handle::probe(&instance_name, &root, &config.edgedb.schema_directory)?;
+    let inst = Handle::probe(&instance_name, &root, &config.edgedb.schema_dir)?;
     let inst = match inst.instance {
         InstanceKind::Remote
             => anyhow::bail!("remote instances cannot be upgraded"),

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -945,7 +945,7 @@ async fn migrate(inst: &Handle, ask_for_running: bool)
         },
         &Migrate {
             cfg: MigrationConfig {
-                schema_dir: inst.project_dir.join(&inst.schema_dir),
+                schema_dir: Some(inst.project_dir.join(&inst.schema_dir)),
             },
             quiet: false,
             to_revision: None,

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -701,7 +701,7 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
     }
 
     let config_path = project_dir.join("edgedb.toml");
-    let schema_dir = Path::new("dbschema");
+    let schema_dir = project_dir.join("dbschema");
     let schema_files = find_schema_files(&schema_dir)?;
 
     let (name, exists) = ask_name(project_dir, options)?;

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -316,11 +316,7 @@ fn link(options: &Init, project_dir: &Path, opts: &crate::options::Options)
     } else {
         ask_existing_instance_name()?
     };
-    let inst = Handle::probe(
-        &name,
-        project_dir,
-        &config.project.schema_dir,
-    )?;
+    let inst = Handle::probe(&name, project_dir,&config.project.schema_dir)?;
     inst.check_version(&ver_query);
     do_link(&inst, options, &stash_dir)
 }

--- a/tests/func/migrations.rs
+++ b/tests/func/migrations.rs
@@ -175,6 +175,156 @@ fn initial() -> anyhow::Result<()> {
 }
 
 #[test]
+fn project() -> anyhow::Result<()> {
+    fs::remove_file("tests/migrations/db1/project/priv/dbschema/migrations/00002.edgeql")
+        .ok();
+    fs::remove_file("tests/migrations/db1/project/priv/dbschema/migrations/00003.edgeql")
+        .ok();
+    SERVER.admin_cmd()
+        .arg("database").arg("create").arg("project")
+        .assert().success();
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("migration").arg("status")
+        .current_dir("tests/migrations/db1/project")
+        .assert().code(3)
+        .stderr(ends_with(
+            "edgedb error: Database is empty. While there are 1 migrations \
+            on the filesystem.\n  Run `edgedb migrate` to apply.\n"));
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("query").arg("SELECT cfg::DatabaseConfig.allow_bare_ddl")
+        .assert().success()
+        .stdout("\"AlwaysAllow\"\n");
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("migration").arg("create")
+        .arg("--non-interactive")
+        .current_dir("tests/migrations/db1/project")
+        .assert().code(1).stderr(ends_with(
+            "edgedb error: Database must be updated \
+            to the last migration on the filesystem for `migration create`. \
+            Run:\n  \
+              edgedb migrate\n"));
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("migrate")
+        .current_dir("tests/migrations/db1/project")
+        .assert().success()
+        .stderr(contains("Applied \
+            m12bulrbounwj3oj5xsspa7gj676azrog6ndi45iyuwrwzvawkxraa \
+            (00001.edgeql)\n"))
+        .stderr(contains("Note:"));
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("query").arg("SELECT cfg::DatabaseConfig.allow_bare_ddl")
+        .assert().success()
+        .stdout("\"NeverAllow\"\n");
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("migration").arg("status")
+        .current_dir("tests/migrations/db1/project")
+        .assert().success()
+        .stderr(ends_with("Database is up to date. \
+            Last migration: \
+            m12bulrbounwj3oj5xsspa7gj676azrog6ndi45iyuwrwzvawkxraa.\n"));
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("migration").arg("create")
+        .arg("--non-interactive")
+        .current_dir("tests/migrations/db1/project")
+        .assert().code(4).stderr(ends_with("No schema changes detected.\n"));
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("migration").arg("create")
+        .current_dir("tests/migrations/db1/project")
+        .assert().code(4).stderr(ends_with("No schema changes detected.\n"));
+
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("migration").arg("create")
+        .arg("--allow-empty")
+        .current_dir("tests/migrations/db1/project")
+        .assert().code(0)
+        .stderr(ends_with("Created \
+            ./priv/dbschema/migrations/00002.edgeql, \
+            id: m1e5vq3h4oizlsp4a3zge5bqhu7yeoorc27k3yo2aaenfqgfars6uq\n"));
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("migrate")
+        .current_dir("tests/migrations/db1/project")
+        .assert().success()
+        .stderr(ends_with("Applied \
+            m1e5vq3h4oizlsp4a3zge5bqhu7yeoorc27k3yo2aaenfqgfars6uq \
+            (00002.edgeql)\n"));
+
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("migration").arg("create")
+        .arg("--allow-empty")
+        .arg("--non-interactive")
+        .current_dir("tests/migrations/db1/project")
+        .assert().code(0);
+    SERVER.admin_cmd()
+        .arg("--database=project")
+        .arg("migrate")
+        .current_dir("tests/migrations/db1/project")
+        .assert().success()
+        .stderr(ends_with("Applied \
+            m1wrvvw3lycyovtlx4szqm75554g75h5nnbjq3a5qsdncn3oef6nia \
+            (00003.edgeql)\n"));
+
+    // Now test partial migrations
+    SERVER.admin_cmd()
+        .arg("database").arg("create").arg("project_2")
+        .assert().success();
+    SERVER.admin_cmd()
+        .arg("--database=project_2")
+        .arg("migrate")
+        .current_dir("tests/migrations/db1/project")
+        .arg("--to-revision=m1e5vq3h4oizlsp4a3zge5bqh")
+        .assert().success()
+        .stderr(contains("Applied \
+            m12bulrbounwj3oj5xsspa7gj676azrog6ndi45iyuwrwzvawkxraa \
+            (00001.edgeql)\n\
+            Applied \
+            m1e5vq3h4oizlsp4a3zge5bqhu7yeoorc27k3yo2aaenfqgfars6uq \
+            (00002.edgeql)\n"));
+
+    SERVER.admin_cmd()
+        .arg("--database=project_2")
+        .arg("migrate")
+        .current_dir("tests/migrations/db1/project")
+        .arg("--to-revision=m12bulrbo")
+        .assert().success()
+        .stderr(ends_with("Database is up to date. \
+            Revision m12bulrbounwj3oj5xsspa7gj676azrog6ndi45iyuwrwzvawkxraa \
+            is the ancestor of the latest \
+            m1e5vq3h4oizlsp4a3zge5bqhu7yeoorc27k3yo2aaenfqgfars6uq\n"));
+
+    SERVER.admin_cmd()
+        .arg("--database=project_2")
+        .arg("migrate")
+        .current_dir("tests/migrations/db1/project")
+        .arg("--to-revision=m1e5vq3h4oizlsp4a")
+        .assert().success()
+        .stderr(ends_with("Database is up to date. Revision \
+            m1e5vq3h4oizlsp4a3zge5bqhu7yeoorc27k3yo2aaenfqgfars6uq\n"));
+
+    SERVER.admin_cmd()
+        .arg("--database=project_2")
+        .arg("migrate")
+        .current_dir("tests/migrations/db1/project")
+        .arg("--to-revision=m1wrvvw3lycy")
+        .assert().success()
+        .stderr(ends_with("Applied \
+            m1wrvvw3lycyovtlx4szqm75554g75h5nnbjq3a5qsdncn3oef6nia \
+            (00003.edgeql)\n"));
+
+    Ok(())
+}
+
+#[test]
 fn modified1() -> anyhow::Result<()> {
     fs::remove_file("tests/migrations/db1/modified1/migrations/00002.edgeql")
         .ok();

--- a/tests/migrations/db1/project/edgedb.toml
+++ b/tests/migrations/db1/project/edgedb.toml
@@ -1,3 +1,5 @@
 [edgedb]
 server-version = "1.0"
-schema-dir = "./priv/dbschema/"
+
+[project]
+schema-dir = "./priv/dbschema"

--- a/tests/migrations/db1/project/edgedb.toml
+++ b/tests/migrations/db1/project/edgedb.toml
@@ -1,0 +1,3 @@
+[edgedb]
+server-version = "1.0"
+schema-dir = "./priv/dbschema/"

--- a/tests/migrations/db1/project/priv/dbschema/default.esdl
+++ b/tests/migrations/db1/project/priv/dbschema/default.esdl
@@ -1,0 +1,5 @@
+module default {
+    type Type1 {
+        property field1 -> str;
+    };
+};

--- a/tests/migrations/db1/project/priv/dbschema/migrations/00001.edgeql
+++ b/tests/migrations/db1/project/priv/dbschema/migrations/00001.edgeql
@@ -1,0 +1,7 @@
+CREATE MIGRATION m12bulrbounwj3oj5xsspa7gj676azrog6ndi45iyuwrwzvawkxraa
+    ONTO initial
+{
+    CREATE TYPE Type1 {
+        CREATE PROPERTY field1 -> str;
+    };
+};

--- a/tests/migrations/db1/project/priv/dbschema/migrations/00002.edgeql
+++ b/tests/migrations/db1/project/priv/dbschema/migrations/00002.edgeql
@@ -1,0 +1,4 @@
+CREATE MIGRATION m1e5vq3h4oizlsp4a3zge5bqhu7yeoorc27k3yo2aaenfqgfars6uq
+    ONTO m12bulrbounwj3oj5xsspa7gj676azrog6ndi45iyuwrwzvawkxraa
+{
+};

--- a/tests/migrations/db1/project/priv/dbschema/migrations/00003.edgeql
+++ b/tests/migrations/db1/project/priv/dbschema/migrations/00003.edgeql
@@ -1,0 +1,4 @@
+CREATE MIGRATION m1wrvvw3lycyovtlx4szqm75554g75h5nnbjq3a5qsdncn3oef6nia
+    ONTO m1e5vq3h4oizlsp4a3zge5bqhu7yeoorc27k3yo2aaenfqgfars6uq
+{
+};


### PR DESCRIPTION
I marked this one as a draft because it overlaps in some parts with #727, and IMO it is better to wait until the other one is merged.

Tested the new flow locally, but I can also try to add real tests for it.

BTW. 
~Maybe with this change we should also add new commands to handle project migrations? Something like `edgedb project migrate` + `edgedb project migration <action>` which will automatically use `schema-directory` from the project config?~

I suppose this PR should also add support for new config setting for `edgedb migrate`/`edgedb migration <action>` commands, although I'm not quite sure it's necessary in this particular PR.

Closes #732