### PR TITLE
Use user session domain instead of GUI domain on macOS for instances

### DIFF
--- a/src/portable/control.rs
+++ b/src/portable/control.rs
@@ -112,7 +112,7 @@ pub fn detect_supervisor(name: &str) -> bool {
     if cfg!(windows) {
         false
     } else if cfg!(target_os="macos") {
-        macos::detect_gui_session()
+        macos::detect_launchd()
     } else if cfg!(target_os="linux") {
         linux::detect_systemd(name)
     } else {


### PR DESCRIPTION
The `gui/<uid>` domain requires an active GUI login session, which
might not be the case if one logs in to a machine via SSH.
The `user/<uid>` works in both scenarios.  An caveat is that, unlike
`gui/`, the `user/` domain does not terminate when a user logs out.