### PR TITLE
Accept StateDataDescription on restore

### DIFF
--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -230,6 +230,9 @@ async fn wait_response(reader: &mut Reader<'_>, start: Instant)
     loop {
         let msg = reader.message().await?;
         match msg {
+            ServerMessage::StateDataDescription(_) => {
+                // TODO: handle state desc here
+            }
             ServerMessage::CommandComplete0(_) => {
                 log::info!(target: "edgedb::restore",
                     "Complete in {:?}", start.elapsed());


### PR DESCRIPTION
Restore message may also have StateDataDescription message in its response if the state schema is changed.