### PR TITLE
Drop the hidden _ui_token command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -41,4 +41,4 @@ pub use self::restore::{restore, restore_all};
 pub use self::psql::psql;
 pub use self::exit::ExitCode;
 pub use self::info::info;
-pub use self::ui::{show_ui, ui_token};
+pub use self::ui::show_ui;

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -18,9 +18,14 @@ pub fn show_ui(options: &Options) -> anyhow::Result<()> {
     let mut url = format!("http://{}:{}/ui", builder.get_host(), builder.get_port());
     if let Some(instance) = &options.conn_options.instance {
         if instance != "_localdev" {
-            let inst = InstanceInfo::read(instance)?;
-            if inst.get_version()?.specific().major < 2 {
-                print::error("Instance doesn't have UI to open; consider upgrade it.");
+            let ver = InstanceInfo::read(instance)?.get_version()?.specific();
+            if ver.major < 2 {
+                print::error(format!(
+                    "the specified instance runs EdgeDB v{}, which does not \
+                    include the Web UI; consider upgrading the instance to \
+                    EdgeDB 2.x or later",
+                    ver,
+                ));
                 return Err(ExitCode::new(1).into())
             }
         }

--- a/src/portable/main.rs
+++ b/src/portable/main.rs
@@ -1,7 +1,6 @@
 use async_std::task;
 
 use crate::cloud;
-use crate::commands;
 use crate::options::Options;
 use crate::portable::project::ProjectCommand;
 use crate::portable::options::{ServerCommand, ServerInstanceCommand};
@@ -66,8 +65,6 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options)
         Unlink(c) => link::unlink(c),
         Status(c) if cfg!(windows) => windows::status(c),
         Status(c) => status::status(c),
-        UIToken(c) if cfg!(windows) => windows::ui_token(&c.instance),
-        UIToken(c) => commands::ui_token(&c.instance),
     }
 }
 

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -57,9 +57,6 @@ pub enum InstanceCommand {
     Revert(Revert),
     /// Reset password for a user in the instance
     ResetPassword(ResetPassword),
-    #[clap(name="_ui_token")]
-    #[edb(hide=true)]
-    UIToken(UIToken),
 }
 
 #[derive(EdbClap, Clone, Debug)]
@@ -490,15 +487,6 @@ pub struct ResetPassword {
     /// Do not print any messages, only indicate success by exit status
     #[clap(long)]
     pub quiet: bool,
-}
-
-#[derive(EdbClap, IntoArgs, Debug, Clone)]
-pub struct UIToken {
-    /// Name of the instance to generate UI token
-    #[clap(short='I', long)]
-    #[clap(validator(instance_name_opt))]
-    #[clap(value_hint=ValueHint::Other)]  // TODO complete instance name
-    pub instance: String,
 }
 
 #[derive(EdbClap, IntoArgs, Debug, Clone)]


### PR DESCRIPTION
Looks like there is a way to read WSL files directly, so we don't need
the _ui_command command anymore.