### PR TITLE
Better error reporting in `edgedb ui` command

### DIFF
--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -1,8 +1,8 @@
 use std::env;
-use std::fs;
 use std::io::{stdout, Write};
 use std::path::PathBuf;
 
+use fs_err as fs;
 use ring::rand::SecureRandom;
 use ring::signature::KeyPair;
 use ring::{aead, agreement, digest, rand, signature};


### PR DESCRIPTION
Old error:
```
Cannot generate authToken: No such file or directory (os error 2)
```

New error:
```
Cannot generate authToken: failed to open file `/work/tmp/.local/share/edgedb/_localdev/edbjwskeys.pem`: No such file or directory (os error 2)
```