### PR TITLE
Fix aarch64 linux support

### DIFF
--- a/edgedb-init.sh
+++ b/edgedb-init.sh
@@ -177,7 +177,7 @@ get_architecture() {
     esac
 
     if [ "$_cputype" = "aarch64" ]; then
-        if [ "$_ostype" != "apple-darwin" && "$_ostype" != "unknown-linux-musl" ]; then
+        if [ "$_ostype" != "apple-darwin" ] && [ "$_ostype" != "unknown-linux-musl" ]; then
             err "unsupported CPU architecture: $_cputype"
         fi
     fi

--- a/edgedb-init.sh
+++ b/edgedb-init.sh
@@ -177,7 +177,7 @@ get_architecture() {
     esac
 
     if [ "$_cputype" = "aarch64" ]; then
-        if [ "$_ostype" != "apple-darwin" ]; then
+        if [ "$_ostype" != "apple-darwin" || "$_ostype" != "unknown-linux-musl" ]; then
             err "unsupported CPU architecture: $_cputype"
         fi
     fi

--- a/edgedb-init.sh
+++ b/edgedb-init.sh
@@ -177,7 +177,7 @@ get_architecture() {
     esac
 
     if [ "$_cputype" = "aarch64" ]; then
-        if [ "$_ostype" != "apple-darwin" || "$_ostype" != "unknown-linux-musl" ]; then
+        if [ "$_ostype" != "apple-darwin" && "$_ostype" != "unknown-linux-musl" ]; then
             err "unsupported CPU architecture: $_cputype"
         fi
     fi

--- a/src/portable/platform.rs
+++ b/src/portable/platform.rs
@@ -17,6 +17,8 @@ pub fn get_cli() -> anyhow::Result<&'static str> {
     } else if cfg!(target_arch="aarch64") {
         if cfg!(target_os="macos") {
             return Ok("aarch64-apple-darwin");
+        } else if cfg!(target_os="linux") {
+            return Ok("aarch64-unknown-linux-musl");
         } else {
             anyhow::bail!("unsupported OS on aarch64")
         }
@@ -41,6 +43,8 @@ pub fn get_server() -> anyhow::Result<&'static str> {
     } else if cfg!(target_arch="aarch64") {
         if cfg!(target_os="macos") {
             return Ok("aarch64-apple-darwin");
+        } else if cfg!(target_os="linux") {
+            return Ok("aarch64-unknown-linux-musl");
         } else {
             anyhow::bail!("unsupported OS on aarch64")
         }


### PR DESCRIPTION
Currently even with aarch64 build out there that seem to start and run fine, the CLI did not support them because they were not added as possible targets in platform checks.
This PR aims to fix that issue so the CLI can be used to install and manage EdgeDB on linux on the aarch64 architecture.