### PR TITLE
Upgrade x86_64 install to arm64 on m1

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -474,6 +474,14 @@ fn _main(options: &CliInstall) -> anyhow::Result<()> {
         }
     }
 
+    #[cfg(target_os="macos")]
+    if cfg!(target_arch="x86_64") &&
+        crate::portable::platform::is_arm64_hardware()
+    {
+        echo!("EdgeDB now supports native M1 build. Downloading binary...");
+        return crate::cli::upgrade::upgrade_to_arm64();
+    }
+
     let tmp_path = settings.installation_path.join(".edgedb.tmp");
     let path = if cfg!(windows) {
         settings.installation_path.join("edgedb.exe")

--- a/src/portable/mod.rs
+++ b/src/portable/mod.rs
@@ -1,9 +1,9 @@
 mod exit_codes;
 mod main;
-mod platform;
 pub mod config;
 pub mod local;
 pub mod options;
+pub mod platform;
 pub mod repository;
 pub mod ver;
 

--- a/src/portable/platform.rs
+++ b/src/portable/platform.rs
@@ -91,3 +91,30 @@ pub fn optional_docker_check() -> anyhow::Result<bool> {
     }
     Ok(false)
 }
+
+#[cfg(target_os="macos")]
+pub fn is_arm64_hardware() -> bool {
+    let mut utsname = libc::utsname {
+        sysname: [0; 256],
+        nodename: [0; 256],
+        release: [0; 256],
+        version: [0; 256],
+        machine: [0; 256],
+    };
+    if unsafe { libc::uname(&mut utsname) } == 1 {
+        log::warn!("Cannot get uname: {}", std::io::Error::last_os_error());
+        return false;
+    }
+    let machine: &[u8] = unsafe { std::mem::transmute(&utsname.machine[..]) };
+    let mend: usize = machine.iter().position(|&b| b == 0).unwrap_or(256);
+    match std::str::from_utf8(&machine[..mend]) {
+        Ok(machine) => {
+            log::debug!("Architecture {:?}", machine);
+            return machine == "arm64";
+        }
+        Err(e) => {
+            log::warn!("Cannot decode machine from uname: {}", e);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Since new binary only available after download, we have to redownload the binary in `install --upgrade` hook rather than right away.

*(Not sure how to test this except actually deploying to the nightly repo)*