### PR TITLE
Restart systemd socket when restarting service

### DIFF
--- a/src/portable/linux.rs
+++ b/src/portable/linux.rs
@@ -318,7 +318,17 @@ pub fn stop_service(name: &str) -> anyhow::Result<()> {
 pub fn restart_service(inst: &InstanceInfo) -> anyhow::Result<()> {
     process::Native::new("restart service", "systemctl", "systemctl")
         .arg("--user")
+        .arg("stop")
+        .arg(unit_name(&inst.name))
+        .run()?;
+    process::Native::new("systemctl", "systemctl", "systemctl")
+        .arg("--user")
         .arg("restart")
+        .arg(socket_name(&inst.name))
+        .run()?;
+    process::Native::new("restart service", "systemctl", "systemctl")
+        .arg("--user")
+        .arg("start")
         .arg(unit_name(&inst.name))
         .run()?;
     Ok(())


### PR DESCRIPTION
Otherwise, if changes were made to the unit file (such as during an
upgrade), systemd will break the socket unit with:

   Socket unit configuration has changed while unit has been running,
   no open socket file descriptor left. The socket unit is not functional
   until restarted.

Fixes: #805