### PR TITLE
Support opening UI for remote instances

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -322,6 +322,10 @@ pub struct UI {
     /// Print URL in console instead of opening in the browser
     #[clap(long)]
     pub print_url: bool,
+
+    /// Skip checking the instance version, open the UI directly.
+    #[clap(long)]
+    pub skip_version_check: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/options.rs
+++ b/src/options.rs
@@ -323,9 +323,9 @@ pub struct UI {
     #[clap(long)]
     pub print_url: bool,
 
-    /// Skip checking the instance version, open the UI directly.
+    /// Don't check the server version of the instance
     #[clap(long)]
-    pub skip_version_check: bool,
+    pub no_server_check: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/options.rs
+++ b/src/options.rs
@@ -323,7 +323,7 @@ pub struct UI {
     #[clap(long)]
     pub print_url: bool,
 
-    /// Don't check the server version of the instance
+    /// Don't probe the UI endpoint of the server instance
     #[clap(long)]
     pub no_server_check: bool,
 }

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -342,4 +342,4 @@ pub fn is_valid_name(name: &str) -> bool {
 
 #[derive(Debug, thiserror::Error)]
 #[error("Not a local instance")]
-pub struct NonLocalInstance(#[source] pub anyhow::Error);
+pub struct NonLocalInstance;

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -339,3 +339,7 @@ pub fn is_valid_name(name: &str) -> bool {
     }
     return true;
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error("Not a local instance")]
+pub struct NonLocalInstance(#[source] pub anyhow::Error);

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -22,7 +22,7 @@ use crate::platform::{cache_dir, wsl_dir, config_dir, tmp_file_path};
 use crate::portable::control;
 use crate::portable::destroy;
 use crate::portable::exit_codes;
-use crate::portable::local::{InstanceInfo, Paths, write_json};
+use crate::portable::local::{InstanceInfo, Paths, write_json, NonLocalInstance};
 use crate::portable::options::{self, Logs, StartConf, instance_arg};
 use crate::portable::project;
 use crate::portable::repository::{self, download, PackageHash, PackageInfo};
@@ -886,8 +886,12 @@ pub fn read_jose_keys(name: &str) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
     };
 
     Ok((
-        wsl.read_text_file(data_dir.clone() + "edbjwskeys.pem")?.into_bytes(),
-        wsl.read_text_file(data_dir + "edbjwekeys.pem")?.into_bytes(),
+        wsl.read_text_file(data_dir.clone() + "edbjwskeys.pem")
+            .map_err(NonLocalInstance)?
+            .into_bytes(),
+        wsl.read_text_file(data_dir + "edbjwekeys.pem")
+            .map_err(NonLocalInstance)?
+            .into_bytes(),
     ))
 }
 

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -869,7 +869,7 @@ pub fn revert(options: &options::Revert) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn read_jose_keys(name: &str) -> anyhow::Result<(String, String)> {
+pub fn read_jose_keys(name: &str) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
     let wsl = try_get_wsl()?;
 
     let data_dir = if name == "_localdev" {
@@ -886,8 +886,8 @@ pub fn read_jose_keys(name: &str) -> anyhow::Result<(String, String)> {
     };
 
     Ok((
-        wsl.read_text_file(data_dir.clone() + "edbjwskeys.pem")?,
-        wsl.read_text_file(data_dir + "edbjwekeys.pem")?,
+        wsl.read_text_file(data_dir.clone() + "edbjwskeys.pem")?.into_bytes(),
+        wsl.read_text_file(data_dir + "edbjwekeys.pem")?.into_bytes(),
     ))
 }
 


### PR DESCRIPTION
Added `edgedb ui --skip-version-check` because the CLI will now try to connect to the remote instance for version check before opening the browser.

Fixed #807