### PR TITLE
Store password in remote instances

### DIFF
--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -195,6 +195,7 @@ pub fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
 
             let mut builder = builder.clone();
             builder.password(&password);
+            creds.password = Some(password);
             if let Some(cert) = &*verifier.cert_out.lock().unwrap() {
                 let pem = pem::encode(&pem::Pem {
                     tag: "CERTIFICATE".into(),


### PR DESCRIPTION
`edgedb instance link` was not storing password in the generated credential files, this PR fixes that.

Q: was it intentional that password is not stored for remote instances, so that the user must specify `--password` option and type in the password everytime? Or it was just lost in the refactors?