### PR TITLE
Fix build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ fd-lock = "3.0.2"
 zip = "0.6.2"
 libflate = "1.1.1"
 open = "3.0.2"
-tokio = {version="1.20.1", features=["macros", "rt"]}
+tokio = {version="1.20.1", features=["macros", "rt", "rt-multi-thread"]}
 
 [dev-dependencies]
 assert_cmd = {git="https://github.com/tailhook/assert_cmd", branch="edgedb_20190513"}


### PR DESCRIPTION
Not selecting the "rt-multi-thread" feature of Tokio leads to a build
failure:

    error: The default runtime flavor is `multi_thread`, but the `rt-multi-thread` feature is disabled.
       --> src/portable/repository.rs:333:1
        |
    333 | #[tokio::main]
        | ^^^^^^^^^^^^^^