### PR TITLE
Ignore invalid certs checking UI through HTTPS

### DIFF
--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -123,7 +123,9 @@ pub fn show_ui(options: &Options, args: &UI) -> anyhow::Result<()> {
 
 #[tokio::main]
 async fn open_url(url: &str) -> Result<reqwest::Response, reqwest::Error> {
-    reqwest::Client::new()
+    reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()?
         .get(url)
         .header(reqwest::header::USER_AGENT, USER_AGENT)
         .send()


### PR DESCRIPTION
Do we also want the `.danger_accept_invalid_hostnames(true)`?