### PR TITLE
migrate: initial implementation of `--dev-mode`

### DIFF
--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -587,6 +587,13 @@ pub struct Migrate {
     /// revisions are applied on top.
     #[clap(long)]
     pub to_revision: Option<String>,
+
+    /// Apply current schema changes on top of what's in the migration history
+    ///
+    /// This is commonly used to apply schema temporarily before doing
+    /// `migration create` for testing purposes.
+    #[clap(long, hide=true)]
+    pub dev_mode: bool,
 }
 
 #[derive(EdbClap, Clone, Debug)]

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -585,7 +585,7 @@ pub struct Migrate {
     /// If this revision is applied, the command is no-op. The command
     /// ensures that this revision present, but it's not an error if more
     /// revisions are applied on top.
-    #[clap(long)]
+    #[clap(long, conflicts_with="dev_mode")]
     pub to_revision: Option<String>,
 
     /// Apply current schema changes on top of what's in the migration history

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -105,7 +105,7 @@ struct Refused;
 #[error("split migration")]
 struct SplitMigration;
 
-async fn execute(cli: &mut Connection, text: impl AsRef<str>)
+pub async fn execute(cli: &mut Connection, text: impl AsRef<str>)
     -> Result<(), Error>
 {
     if !cli.is_consistent() {
@@ -118,7 +118,7 @@ async fn execute(cli: &mut Connection, text: impl AsRef<str>)
     Ok(())
 }
 
-async fn query_row<R>(cli: &mut Connection, text: &str)
+pub async fn query_row<R>(cli: &mut Connection, text: &str)
     -> Result<R, Error>
     where R: Queryable
 {

--- a/src/migrations/dev_mode.rs
+++ b/src/migrations/dev_mode.rs
@@ -13,57 +13,78 @@ use crate::migrations::migrate::{apply_migrations, apply_migrations_inner};
 use crate::migrations::migration::{self, MigrationFile};
 use crate::migrations::timeout;
 
+enum Mode {
+    Normal { skip: usize },
+    Rebase,
+}
+
 pub async fn migrate(cli: &mut Connection, ctx: Context, migrate: &Migrate)
     -> anyhow::Result<()>
 {
-    apply_fs(cli, &ctx, migrate).await?;
-    migrate_to_schema(cli, &ctx).await?;
-    Ok(())
-}
-
-async fn skip_and_check_revisions(cli: &mut Connection,
-    migrations: &mut LinkedHashMap<String, MigrationFile>,
-    db_migration: &str)
-    -> anyhow::Result<()>
-{
-    let last_fs_migration = migrations.back().map(|(id, _)| id.clone());
-    while let Some((key, _)) = migrations.pop_front() {
-        if key == db_migration {
-            return Ok(())
-        }
-    }
-    if let Some(id) = last_fs_migration {
-        let contains_last_fs_migration: bool = cli.query_row(r###"
-                select exists(
-                    select schema::Migration filter .name = <str>$0
-                )
-            "###, &(id,)).await?;
-        if !contains_last_fs_migration {
-            // TODO(tailhook) do the rebase
-            log::warn!("Migrations in the database and \
-                        the filesystem are diverging.");
-        }
-    }
-    Ok(())
-}
-
-async fn apply_fs(cli: &mut Connection, ctx: &Context, migrate: &Migrate)
-    -> anyhow::Result<()>
-{
     let mut migrations = migration::read_all(&ctx, true).await?;
-    let db_migration: Option<String> = cli.query_row_opt(r###"
+    let db_migration = get_db_migration(cli).await?;
+    match select_mode(cli, &migrations, db_migration.as_deref()).await? {
+        Mode::Normal { skip } => {
+            log::info!("Skipping {} revisions.", skip);
+            for _ in 0..skip {
+                migrations.pop_front();
+            }
+            if !migrations.is_empty() {
+                apply_migrations(cli, &migrations, migrate).await?;
+            }
+            log::info!("Calculating schema diff.");
+            migrate_to_schema(cli, &ctx).await?;
+        }
+        Mode::Rebase => {
+            log::info!("Calculating schema diff.");
+            migrate_to_schema(cli, &ctx).await?;
+            log::info!("Now rebasing on top of filesystem migrations.");
+            rebase_to_schema(cli, &ctx, &migrations).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn select_mode(cli: &mut Connection,
+                     migrations: &LinkedHashMap<String, MigrationFile>,
+                     db_migration: Option<&str>)
+    -> anyhow::Result<Mode>
+{
+    if let Some(db_migration) = &db_migration {
+        for (idx, (key, _)) in migrations.iter().enumerate() {
+            if key == db_migration {
+                return Ok(Mode::Normal { skip: idx+1 });
+            }
+        }
+        let last_fs_migration = migrations.back().map(|(id, _)| id.clone());
+        if let Some(id) = last_fs_migration {
+            let contains_last_fs_migration: bool = cli.query_row(r###"
+                    select exists(
+                        select schema::Migration filter .name = <str>$0
+                    )
+                "###, &(id,)).await?;
+            if contains_last_fs_migration {
+                Ok(Mode::Normal { skip: migrations.len() })
+            } else {
+                Ok(Mode::Rebase)
+            }
+        } else {
+            Ok(Mode::Normal { skip: migrations.len() /* == 0 */ })
+        }
+    } else {
+        Ok(Mode::Normal { skip: 0 })
+    }
+}
+
+async fn get_db_migration(cli: &mut Connection)
+    -> anyhow::Result<Option<String>>
+{
+    let res = cli.query_row_opt(r###"
             WITH Last := (SELECT schema::Migration
                           FILTER NOT EXISTS .<parents[IS schema::Migration])
             SELECT name := Last.name
         "###, &()).await?;
-
-    if let Some(db_migration) = &db_migration {
-        skip_and_check_revisions(cli, &mut migrations, db_migration).await?;
-    }
-    if !migrations.is_empty() {
-        apply_migrations(cli, &migrations, migrate).await?;
-    }
-    Ok(())
+    Ok(res)
 }
 
 async fn migrate_to_schema(cli: &mut Connection, ctx: &Context)
@@ -90,17 +111,57 @@ async fn migrate_to_schema(cli: &mut Connection, ctx: &Context)
     Ok(())
 }
 
+async fn rebase_to_schema(cli: &mut Connection, ctx: &Context,
+                          migrations: &LinkedHashMap<String, MigrationFile>)
+    -> anyhow::Result<()>
+{
+    execute(cli, "START MIGRATION REWRITE").await?;
+
+    let res = async {
+        apply_migrations_inner(cli, migrations, true).await?;
+        execute_start_migration(&ctx, cli).await?;
+        execute(cli, "POPULATE MIGRATION").await?;
+        let descr = query_row::<CurrentMigration>(cli,
+            "DESCRIBE CURRENT MIGRATION AS JSON"
+        ).await?;
+        if !descr.complete {
+            // TODO(tailhook) is `POPULATE MIGRATION` equivalent to `--yolo` or
+            // should we do something manually?
+            anyhow::bail!("Migration cannot be automatically populated");
+        }
+        execute(cli, "ABORT MIGRATION").await?;
+        if !descr.confirmed.is_empty() {
+            execute(cli, format!(
+            "CREATE MIGRATION {{
+                SET generated_by := schema::MigrationGeneratedBy.DevMode;
+                {}
+            }}", descr.confirmed.join("\n"))).await?;
+        }
+        Ok(())
+    }.await;
+
+    match res {
+        Ok(()) => {
+            execute(cli, "COMMIT MIGRATION REWRITE").await
+                .context("commit migration rewrite")?;
+            Ok(())
+        }
+        Err(e) => {
+            execute(cli, "ABORT MIGRATION REWRITE").await
+                .map_err(|e| {
+                    log::warn!("Error aborting migration rewrite: {:#}", e);
+                }).ok();
+            Err(e)
+        }
+    }
+}
+
 async fn create_in_rewrite(ctx: &Context, cli: &mut Connection,
                            migrations: &LinkedHashMap<String, MigrationFile>,
                            create: &CreateMigration)
     -> anyhow::Result<()>
 {
-    apply_migrations_inner(cli, migrations, &Migrate {
-        cfg: create.cfg.clone(),
-        quiet: true,
-        to_revision: None,
-        dev_mode: false,
-    }).await?;
+    apply_migrations_inner(cli, migrations, true).await?;
     normal_migration(cli, ctx, migrations, create).await?;
     Ok(())
 }

--- a/src/migrations/dev_mode.rs
+++ b/src/migrations/dev_mode.rs
@@ -1,0 +1,36 @@
+use edgedb_client::client::Connection;
+
+use crate::commands::parser::Migrate;
+use crate::migrations::context::Context;
+use crate::migrations::create::{execute, query_row, execute_start_migration};
+use crate::migrations::create::{CurrentMigration};
+
+
+pub async fn migrate(cli: &mut Connection, ctx: Context, _migrate: &Migrate)
+    -> anyhow::Result<()>
+{
+    // TODO(tailhook) first apply the whole migration history
+    migrate_to_schema(cli, &ctx).await?;
+    Ok(())
+}
+
+async fn migrate_to_schema(cli: &mut Connection, ctx: &Context)
+    -> anyhow::Result<()>
+{
+    execute_start_migration(&ctx, cli).await?;
+    execute(cli, "POPULATE MIGRATION").await?;
+    let descr = query_row::<CurrentMigration>(cli,
+        "DESCRIBE CURRENT MIGRATION AS JSON"
+    ).await?;
+    if !descr.complete {
+        // TODO(tailhook) is `POPULATE MIGRATION` equivalent to `--yolo` or
+        // should we do something manually?
+        anyhow::bail!("Migration cannot be automatically populated");
+    }
+    if descr.confirmed.is_empty() {
+        execute(cli, "ABORT MIGRATION").await?;
+    } else {
+        execute(cli, "COMMIT MIGRATION").await?;
+    }
+    Ok(())
+}

--- a/src/migrations/dev_mode.rs
+++ b/src/migrations/dev_mode.rs
@@ -1,16 +1,63 @@
 use edgedb_client::client::Connection;
+use linked_hash_map::LinkedHashMap;
 
 use crate::commands::parser::Migrate;
 use crate::migrations::context::Context;
-use crate::migrations::create::{execute, query_row, execute_start_migration};
 use crate::migrations::create::{CurrentMigration};
+use crate::migrations::create::{execute, query_row, execute_start_migration};
+use crate::migrations::migration::{self, MigrationFile};
+use crate::migrations::migrate::apply_migrations;
 
-
-pub async fn migrate(cli: &mut Connection, ctx: Context, _migrate: &Migrate)
+pub async fn migrate(cli: &mut Connection, ctx: Context, migrate: &Migrate)
     -> anyhow::Result<()>
 {
-    // TODO(tailhook) first apply the whole migration history
+    apply_fs(cli, &ctx, migrate).await?;
     migrate_to_schema(cli, &ctx).await?;
+    Ok(())
+}
+
+async fn skip_and_check_revisions(cli: &mut Connection,
+    migrations: &mut LinkedHashMap<String, MigrationFile>,
+    db_migration: &str)
+    -> anyhow::Result<()>
+{
+    let last_fs_migration = migrations.back().map(|(id, _)| id.clone());
+    while let Some((key, _)) = migrations.pop_front() {
+        if key == db_migration {
+            return Ok(())
+        }
+    }
+    if let Some(id) = last_fs_migration {
+        let contains_last_fs_migration: bool = cli.query_row(r###"
+                select exists(
+                    select schema::Migration filter .name = <str>$0
+                )
+            "###, &(id,)).await?;
+        if !contains_last_fs_migration {
+            // TODO(tailhook) do the rebase
+            log::warn!("Migrations in the database and \
+                        the filesystem are diverging.");
+        }
+    }
+    Ok(())
+}
+
+async fn apply_fs(cli: &mut Connection, ctx: &Context, migrate: &Migrate)
+    -> anyhow::Result<()>
+{
+    let mut migrations = migration::read_all(&ctx, true).await?;
+    let db_migration: Option<String> = cli.query_row_opt(r###"
+            WITH Last := (SELECT schema::Migration
+                          FILTER NOT EXISTS .<parents[IS schema::Migration])
+            SELECT name := Last.name
+        "###, &()).await?;
+
+    if let Some(db_migration) = &db_migration {
+        skip_and_check_revisions(cli, &mut migrations, db_migration).await?;
+    }
+    if !migrations.is_empty() {
+        apply_migrations(cli, &migrations, migrate).await?;
+    }
     Ok(())
 }
 

--- a/src/migrations/migrate.rs
+++ b/src/migrations/migrate.rs
@@ -10,6 +10,7 @@ use crate::commands::Options;
 use crate::commands::ExitCode;
 use crate::commands::parser::Migrate;
 use crate::migrations::timeout;
+use crate::migrations::dev_mode;
 use crate::migrations::context::Context;
 use crate::migrations::migration::{self, MigrationFile};
 use crate::print;
@@ -57,6 +58,9 @@ pub async fn migrate(cli: &mut Connection, _options: &Options,
     -> Result<(), anyhow::Error>
 {
     let ctx = Context::from_project_or_config(&migrate.cfg)?;
+    if migrate.dev_mode {
+        return dev_mode::migrate(cli, ctx, migrate).await;
+    }
 
     let mut migrations = migration::read_all(&ctx, true).await?;
     let db_migration: Option<String> = cli.query_row_opt(r###"

--- a/src/migrations/migrate.rs
+++ b/src/migrations/migrate.rs
@@ -166,7 +166,7 @@ pub async fn apply_migrations(cli: &mut Connection,
     let old_timeout = timeout::inhibit_for_transaction(cli).await?;
     let transaction = async {
         cli.execute("START TRANSACTION").await?;
-        match apply_migrations_inner(cli, migrations, migrate).await {
+        match apply_migrations_inner(cli, migrations, migrate.quiet).await {
             Ok(()) => {
                 cli.execute("COMMIT").await?;
                 Ok(())
@@ -189,7 +189,7 @@ pub async fn apply_migrations(cli: &mut Connection,
 }
 
 pub async fn apply_migrations_inner(cli: &mut Connection,
-    migrations: &LinkedHashMap<String, MigrationFile>, migrate: &Migrate)
+    migrations: &LinkedHashMap<String, MigrationFile>, quiet: bool)
     -> anyhow::Result<()>
 {
     for (_, migration) in migrations {
@@ -201,7 +201,7 @@ pub async fn apply_migrations_inner(cli: &mut Connection,
                 Err(err) => err,
             }
         })?;
-        if !migrate.quiet {
+        if !quiet {
             if print::use_color() {
                 eprintln!(
                     "{} {} ({})",

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -1,5 +1,6 @@
 mod context;
 mod create;
+mod dev_mode;
 mod edit;
 mod grammar;
 mod log;

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -934,6 +934,7 @@ async fn migrate(inst: &Handle<'_>, ask_for_running: bool)
             },
             quiet: false,
             to_revision: None,
+            dev_mode: false,
         }).await?;
     Ok(())
 }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -6,3 +6,5 @@
 /migrations/db2/initial/migrations/00001.edgeql
 /migrations/db2/modified1/migrations/00002.edgeql
 /migrations/db3/migrations/00002.edgeql
+/migrations/db4/modified1/00001.edgeql
+/migrations/db4/created1/00002.edgeql

--- a/tests/func/migrations.rs
+++ b/tests/func/migrations.rs
@@ -672,3 +672,45 @@ edgedb error: cannot proceed until .esdl files are fixed
 "###));
     Ok(())
 }
+
+#[test]
+fn dev_mode() -> anyhow::Result<()> {
+    fs::remove_file("tests/migrations/db4/modified1/00001.edgeql")
+        .ok();
+    fs::remove_file("tests/migrations/db4/created1/00002.edgeql")
+        .ok();
+    SERVER.admin_cmd()
+        .arg("database").arg("create").arg("db4")
+        .assert().success();
+    SERVER.admin_cmd()
+        .arg("--database=db4")
+        .arg("migrate").arg("--dev-mode")
+        .arg("--schema-dir=tests/migrations/db4/initial")
+        .env("NO_COLOR", "1")
+        .assert().success();
+    SERVER.admin_cmd()
+        .arg("--database=db4")
+        .arg("migrate").arg("--dev-mode")
+        .arg("--schema-dir=tests/migrations/db4/modified1")
+        .env("NO_COLOR", "1")
+        .assert().success();
+    SERVER.admin_cmd()
+        .arg("--database=db4")
+        .arg("migration").arg("create").arg("--non-interactive")
+        .arg("--schema-dir=tests/migrations/db4/modified1")
+        .env("NO_COLOR", "1")
+        .assert().success();
+    SERVER.admin_cmd()
+        .arg("--database=db4")
+        .arg("migrate").arg("--dev-mode")
+        .arg("--schema-dir=tests/migrations/db4/created1")
+        .env("NO_COLOR", "1")
+        .assert().success();
+    SERVER.admin_cmd()
+        .arg("--database=db4")
+        .arg("migration").arg("create").arg("--non-interactive")
+        .arg("--schema-dir=tests/migrations/db4/created1")
+        .env("NO_COLOR", "1")
+        .assert().success();
+    Ok(())
+}

--- a/tests/migrations/db4/created1/default.esdl
+++ b/tests/migrations/db4/created1/default.esdl
@@ -1,0 +1,13 @@
+module default {
+    type A {
+        property a -> str;
+    }
+
+    type B {
+        property b -> int32;
+    }
+
+    type C {
+        property c -> int64;
+    }
+}

--- a/tests/migrations/db4/created1/migrations/00001.edgeql
+++ b/tests/migrations/db4/created1/migrations/00001.edgeql
@@ -1,0 +1,10 @@
+CREATE MIGRATION m16ez5xxhkq3eiv6ebyi32igvokf2eiu4ks5wpr3emrweebmgqjqgq
+    ONTO initial
+{
+  CREATE TYPE default::A {
+      CREATE PROPERTY a -> std::str;
+  };
+  CREATE TYPE default::B {
+      CREATE PROPERTY b -> std::int32;
+  };
+};

--- a/tests/migrations/db4/initial/default.esdl
+++ b/tests/migrations/db4/initial/default.esdl
@@ -1,0 +1,3 @@
+module default {
+    type A;
+}

--- a/tests/migrations/db4/modified1/default.esdl
+++ b/tests/migrations/db4/modified1/default.esdl
@@ -1,0 +1,9 @@
+module default {
+    type A {
+        property a -> str;
+    }
+
+    type B {
+        property b -> int32;
+    }
+}


### PR DESCRIPTION
To Do:
* [x] apply migration history beforehands
* [x] implement `migration create` after dev mode (on a temporary database)
* [x] use rebase

(`watch` is probably a different PR)