### PR TITLE
List cloud instances by default

### DIFF
--- a/src/portable/main.rs
+++ b/src/portable/main.rs
@@ -45,7 +45,7 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options)
         ResetPassword(c) if cfg!(windows) => windows::reset_password(c),
         ResetPassword(c) => reset_password::reset_password(c),
         Link(c) => link::link(c, &options),
-        List(c) if cfg!(windows) => windows::list(c),
+        List(c) if cfg!(windows) => windows::list(c, options),
         List(c) => status::list(c, options),
         Upgrade(c) => upgrade::upgrade(c),
         Start(c) if cfg!(windows) => windows::start(c),

--- a/src/portable/mod.rs
+++ b/src/portable/mod.rs
@@ -21,7 +21,7 @@ mod link;
 mod list_versions;
 mod reset_password;
 mod revert;
-mod status;
+pub mod status;
 mod uninstall;
 mod upgrade;
 pub mod project;

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -320,10 +320,6 @@ pub struct List {
     //  Currently needed for WSL
     #[clap(long, hide=true)]
     pub quiet: bool,
-
-    /// List EdgeDB Cloud instances
-    #[clap(long, hide=true)]
-    pub cloud: bool,
 }
 
 #[derive(EdbClap, IntoArgs, Debug, Clone)]

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -796,7 +796,7 @@ pub fn status(options: &options::Status) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn list(options: &options::List) -> anyhow::Result<()> {
+pub fn list(options: &options::List, opts: &crate::Options) -> anyhow::Result<()> {
     if options.debug || options.extended {
         let inner_opts = options::List {
             quiet: true,
@@ -833,7 +833,7 @@ pub fn list(options: &options::List) -> anyhow::Result<()> {
     let remote = if options.no_remote {
         Vec::new()
     } else {
-        status::get_remote(&visited)?
+        status::get_remote(&visited, opts)?
     };
 
     if local.is_empty() && remote.is_empty() {


### PR DESCRIPTION
Drop `--cloud` option in `edgedb instance list`, and list cloud instances in the same table if logged in.