### PR TITLE
Initial implementation of the "testing" repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.16"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
@@ -601,23 +601,23 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.2.3"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
+checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.15"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1176,7 +1176,7 @@ dependencies = [
  "termcolor",
  "termimad",
  "test-case",
- "textwrap",
+ "textwrap 0.15.0",
  "thiserror",
  "tokio",
  "toml",
@@ -3799,6 +3799,12 @@ dependencies = [
  "unicode-linebreak",
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ bytes = "1.0.1"
 blake2b_simd = "1.0.0"
 blake3 = "1.1.0"
 rustyline = { git="https://github.com/tailhook/rustyline", branch="edgedb_20210403"}
-clap = {version="3.1.5", features=["derive", "cargo"]}
-clap_complete = "3.1.1"
+clap = {version="3.2.23", features=["derive", "cargo"]}
+clap_complete = "3.2.5"
 strsim = "0.10.0"
 whoami = "1.1"
 atty = "0.2.13"

--- a/edgedb-cli-derive/Cargo.toml
+++ b/edgedb-cli-derive/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["EdgeDB Inc. <hello@edgedb.com>"]
 edition = "2018"
 
 [dependencies]
-clap = "3.1.5"
+clap = "3.2.23"
 clap_generate = "3.0.3"
 termimad = "0.20.1"
 syn = {version="1.0.72", features=["extra-traits"]}

--- a/edgedb-cli-derive/src/attrib.rs
+++ b/edgedb-cli-derive/src/attrib.rs
@@ -83,6 +83,7 @@ pub enum ParserKind {
     TryFromOsStr,
     FromOccurrences,
     FromFlag,
+    ValueEnum,
 }
 
 #[derive(Debug, Clone)]
@@ -219,6 +220,13 @@ impl Parse for FieldAttr {
         } else if lookahead.peek(kw::inheritable) {
             let _kw: kw::inheritable = input.parse()?;
             Ok(Inheritable)
+        } else if lookahead.peek(kw::value_enum) {
+            let _kw: kw::value_enum = input.parse()?;
+            Ok(Parse(CliParse {
+                kind: ParserKind::ValueEnum,
+                parser: None,
+                span: input.span(),
+            }))
         } else if lookahead.peek(syn::Ident) {
             let name: syn::Ident = input.parse()?;
             let lookahead = input.lookahead1();

--- a/edgedb-cli-derive/src/kw.rs
+++ b/edgedb-cli-derive/src/kw.rs
@@ -14,3 +14,4 @@ syn::custom_keyword!(from_os_str);
 syn::custom_keyword!(from_str);
 syn::custom_keyword!(try_from_os_str);
 syn::custom_keyword!(try_from_str);
+syn::custom_keyword!(value_enum);

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -17,7 +17,7 @@ use crate::portable::local::{Paths, InstanceInfo};
 use crate::portable::local::{write_json, allocate_port};
 use crate::portable::options::{Create, InstanceName, Start};
 use crate::portable::platform::optional_docker_check;
-use crate::portable::repository::{Query};
+use crate::portable::repository::{Query, QueryOptions};
 use crate::portable::reset_password::{password_hash, generate_password};
 use crate::portable::{windows, linux, macos};
 use crate::print::{self, echo, err_marker, Highlight};
@@ -130,7 +130,16 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
             port,
         }
     } else {
-        let query = Query::from_options(cmd.nightly, &cmd.version)?;
+        let (query, _) = Query::from_options(
+            QueryOptions {
+                nightly: cmd.nightly,
+                testing: false,
+                channel: cmd.channel,
+                version: cmd.version.as_ref(),
+                stable: false,
+            },
+            || anyhow::Ok(Query::stable()),
+        )?;
         let inst = install::version(&query).context("error installing EdgeDB")?;
         let info = InstanceInfo {
             name: name.clone(),

--- a/src/portable/install.rs
+++ b/src/portable/install.rs
@@ -14,6 +14,7 @@ use crate::portable::local::{InstallInfo, write_json};
 use crate::portable::options::Install;
 use crate::portable::platform::optional_docker_check;
 use crate::portable::repository::{PackageInfo, PackageHash, Query, download};
+use crate::portable::repository::{QueryOptions};
 use crate::portable::repository::{get_server_package, get_specific_package};
 use crate::portable::ver;
 use crate::print::{self, echo, Highlight};
@@ -154,7 +155,15 @@ pub fn install(options: &Install) -> anyhow::Result<()> {
         );
         return Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
     }
-    let query = Query::from_options(options.nightly, &options.version)?;
+    let (query, _) = Query::from_options(QueryOptions {
+            nightly: options.nightly,
+            stable: false,
+            testing: false,
+            channel: options.channel,
+            version: options.version.as_ref(),
+        },
+        || Ok(Query::stable()),
+    )?;
     version(&query)?;
     Ok(())
 }

--- a/src/portable/uninstall.rs
+++ b/src/portable/uninstall.rs
@@ -7,6 +7,7 @@ use crate::portable::exit_codes;
 use crate::portable::local::{InstanceInfo};
 use crate::portable::local;
 use crate::portable::options::Uninstall;
+use crate::portable::repository::Query;
 use crate::portable::status;
 use crate::portable::ver;
 use crate::print::{self, echo, Highlight};
@@ -16,6 +17,10 @@ pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
     let mut candidates = local::get_installed()?;
     if options.nightly {
         candidates.retain(|cand| cand.version.is_nightly());
+    }
+    if let Some(channel) = options.channel {
+        let query = Query::from(channel);
+        candidates.retain(|cand| query.matches(&cand.version));
     }
     if let Some(ver) = &options.version {
         if let Ok(ver) = ver.parse::<ver::Filter>() {

--- a/src/process.rs
+++ b/src/process.rs
@@ -125,6 +125,12 @@ impl IntoArg for &String {
     }
 }
 
+impl IntoArg for &str {
+    fn add_arg(self, process: &mut Native) {
+        process.arg(self);
+    }
+}
+
 impl IntoArg for &u16 {
     fn add_arg(self, process: &mut Native) {
         process.arg(self.to_string());


### PR DESCRIPTION
Includes:
* `--to-testing` for upgrades
* `--channel=*` and `--to-channel=*` options (including `testing`)
* `3.0-alpha.1` in `edgedb.toml` eventually upgrades to `3.x` stable