### PR TITLE
Add shared test cases

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -5,6 +5,8 @@
       branch: ${{ steps.whichver.outputs.branch }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Determine package version
       shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,8 @@ jobs:
       branch: ${{ steps.whichver.outputs.branch }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Determine package version
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
       branch: ${{ steps.whichver.outputs.branch }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Determine package version
       shell: bash

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,6 +11,8 @@ jobs:
       branch: ${{ steps.whichver.outputs.branch }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Determine package version
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,6 +142,8 @@ jobs:
 
       - run: |
           sudo cp target/debug/edgedb /usr/local/bin/
+          mkdir home_edgedb
+          sudo mv home_edgedb /Users/edgedb
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,8 @@ jobs:
         edgedb-version: ["nightly"]
     steps:
       - uses: actions/checkout@master
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -55,6 +57,8 @@ jobs:
         edgedb-version: ["nightly"]
     steps:
       - uses: actions/checkout@master
+        with:
+          submodules: true
 
       - name: Install musl-tools
         run: "sudo apt-get install musl-tools"
@@ -96,6 +100,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@master
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -117,10 +123,12 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        test: [portable_smoke, portable_project, portable_project_dir]
+        test: [portable_smoke, portable_project, portable_project_dir, portable_shared]
       fail-fast: false
     steps:
       - uses: actions/checkout@master
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -146,13 +154,15 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        test: [portable_smoke, portable_project, portable_project_dir]
+        test: [portable_smoke, portable_project, portable_project_dir, portable_shared]
       fail-fast: false
     env:
       _EDGEDB_WSL_DISTRO: Debian
       _EDGEDB_WSL_LINUX_BINARY: ./linux-binary/edgedb
     steps:
       - uses: actions/checkout@master
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -197,6 +207,8 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@master
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/shared-client-testcases"]
+	path = tests/shared-client-testcases
+	url = git@github.com:edgedb/shared-client-testcases.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,9 @@ openssl = "0.10.30"
 tokio = {version="1.1.0", features=["rt-multi-thread"]}
 warp = {version="0.3.2", default-features=false, features=["tls"]}
 
+[build-dependencies]
+serde_json = "1.0"
+
 [features]
 dev_mode = []
 github_action_install = []

--- a/build.rs
+++ b/build.rs
@@ -55,6 +55,7 @@ fn main() {
         ),
         ("multiple_compound_opts", "(cannot be used with|provided more than once)"),
         ("multiple_compound_env", "multiple compound env vars found"),
+        ("exclusive_options", "provided more than once"),
     ]);
 
     let out_dir = env::var_os("OUT_DIR").unwrap();

--- a/build.rs
+++ b/build.rs
@@ -46,7 +46,7 @@ fn main() {
             "invalid_port",
             "(Invalid value.*for.*port|invalid port|cannot parse env var EDGEDB_PORT)",
         ),
-        ("invalid_dsn_or_instance_name", "invalid DSN"),
+        ("invalid_dsn_or_instance_name", "(invalid DSN|Invalid value.*for.*instance)"),
         ("invalid_user", "invalid user"),
         ("invalid_database", "invalid database"),
         ("invalid_credentials_file", "cannot read credentials file"),
@@ -57,6 +57,8 @@ fn main() {
         ("multiple_compound_opts", "(cannot be used with|provided more than once)"),
         ("multiple_compound_env", "multiple compound env vars found"),
         ("exclusive_options", "provided more than once"),
+        ("credentials_file_not_found", "credentials file.*could not read"),
+        ("project_not_initialised", "error reading project settings")
     ]);
 
     let out_dir = env::var_os("OUT_DIR").unwrap();

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,7 @@ fn main() {
         ("credentialsFile", "--credentials-file"),
         ("credentials", "--credentials-file"),
         ("dsn", "--dsn"),
+        ("instance", "--instance"),
         ("host", "--host"),
         ("port", "--port"),
         ("database", "--database"),

--- a/build.rs
+++ b/build.rs
@@ -37,7 +37,7 @@ fn main() {
         ("env_not_found", "is not set"),
         (
             "invalid_tls_security",
-            "((EDGEDB_CLIENT_TLS_SECURITY|tls_security).*(mutually exclusive|Invalid value)|\
+            "((EDGEDB_CLIENT_TLS_SECURITY|tls_security).*(don't comply|Invalid value)|\
             Unsupported TLS security)"
         ),
         ("file_not_found", "(No such file or directory|cannot find the path)"),

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,252 @@
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::{env, fs};
+
+enum Platform {
+    Linux,
+    Windows,
+    MacOS,
+}
+
+macro_rules! write {
+    ($output:tt, $($arg:tt)*) => {{
+        $output.write_all(format!($($arg)*).as_bytes()).unwrap();
+    }}
+}
+
+fn main() {
+    let opt_key_mapping = HashMap::from([
+        ("credentialsFile", "--credentials-file"),
+        ("credentials", "--credentials-file"),
+        ("dsn", "--dsn"),
+        ("host", "--host"),
+        ("port", "--port"),
+        ("database", "--database"),
+        ("user", "--user"),
+        ("tlsSecurity", "--tls-security"),
+        ("tlsCA", "--tls-ca-file"),
+        ("tlsCAFile", "--tls-ca-file"),
+        ("waitUntilAvailable", "--wait-until-available"),
+        ("secret_key", "--secret-key"),
+    ]);
+    let error_mapping = HashMap::from([
+        ("invalid_dsn", "invalid DSN"),
+    ]);
+
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let out_file = Path::new(&out_dir).join("shared_client_testcases.rs");
+    let out_file = fs::File::create(out_file).unwrap();
+    let mut output = BufWriter::new(out_file);
+
+    let root = env::var_os("CARGO_MANIFEST_DIR").unwrap();
+    let testcases = Path::new(&root)
+        .join("tests")
+        .join("shared-client-testcases");
+    if !testcases.exists() {
+        return;
+    }
+
+    let connection_testcases = testcases.join("connection_testcases.json");
+    println!(
+        "cargo:rerun-if-changed={}",
+        connection_testcases.to_str().unwrap()
+    );
+    let connection_testcases = fs::read_to_string(connection_testcases).unwrap();
+    let connection_testcases: Value = serde_json::from_str(&connection_testcases).unwrap();
+    let empty_map = Map::new();
+    'testcase: for (i, case) in connection_testcases.as_array().unwrap().iter().enumerate() {
+        let mut testcase = Vec::new();
+        let case = case.as_object().unwrap();
+        let opts = case
+            .get("opts")
+            .and_then(|v| v.as_object())
+            .filter(|m| !m.is_empty());
+        let env = case
+            .get("env")
+            .and_then(|v| v.as_object())
+            .filter(|m| !m.is_empty());
+        let fs = case
+            .get("fs")
+            .and_then(|v| v.as_object())
+            .unwrap_or_else(|| &empty_map);
+        let _platform = match case.get("platform").and_then(|p| p.as_str()) {
+            Some("macos") => {
+                write!(testcase, "#[cfg(target_os=\"macos\")]");
+                Some(Platform::MacOS)
+            }
+            Some("windows") => {
+                write!(testcase, "#[cfg(target_os=\"windows\")]");
+                Some(Platform::Windows)
+            }
+            _ if !fs.is_empty() => {
+                write!(testcase, "#[cfg(target_os=\"linux\")]");
+                Some(Platform::Linux)
+            }
+            _ => None,
+        };
+        let result = case.get("result").map(|r| r.to_string());
+        write!(
+            testcase,
+            r#"
+#[cfg(feature="portable_tests")]
+#[test]
+fn connection_{i}() {{
+"#
+        );
+        if let Some(result) = &result {
+            write!(
+                testcase,
+                r#"
+    let result: Value = serde_json::from_str({result:?}).unwrap();"#
+            );
+        }
+
+        let mut buf = Vec::new();
+        if let Some(opts) = opts {
+            for (key, value) in opts {
+                let arg = if let Some(arg) = opt_key_mapping.get(key.as_str()) {
+                    arg
+                } else if key == "serverSettings" {
+                    continue 'testcase;
+                } else if key == "password" {
+                    let argv = value.as_str().unwrap();
+                    write!(
+                        buf,
+                        r#"
+        .write_stdin({argv:?})"#,
+                    );
+                    continue;
+                } else {
+                    panic!("unknown opts key: {}", key);
+                };
+                let argv = if key == "credentials" {
+                    let value = value.as_str().unwrap();
+                    write!(
+                        testcase,
+                        r#"
+    let mut credentials_file = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+    credentials_file.write_all({value:?}.as_bytes()).unwrap();
+    let credentials_file = credentials_file.into_temp_path();
+    "#,
+                    );
+                    "&credentials_file".to_owned()
+                } else if key == "tlsCA" {
+                    let value = value.as_str().unwrap();
+                    write!(
+                        testcase,
+                        r#"
+    let mut tls_ca_file = tempfile::Builder::new().suffix(".pem").tempfile().unwrap();
+    tls_ca_file.write_all({value:?}.as_bytes()).unwrap();
+    let tls_ca_file = tls_ca_file.into_temp_path();
+    "#,
+                    );
+                    "&tls_ca_file".to_owned()
+                } else if let Some(v) = value.as_str() {
+                    format!("\"{v}\"")
+                } else if let Some(v) = value.as_i64() {
+                    format!("\"{v}\"")
+                } else if let Some(v) = value.as_f64() {
+                    format!("\"{v}\"")
+                } else {
+                    panic!("invalid value of opts {}: {:?}", key, value);
+                };
+                write!(
+                    buf,
+                    r#"
+        .arg({arg:?})
+        .arg({argv})"#,
+                );
+            }
+        }
+        if let Some(env) = env {
+            for (key, value) in env {
+                let value = if let Some(v) = value.as_str() {
+                    v
+                } else {
+                    panic!("invalid env {} value: {:?}", key, value);
+                };
+                write!(
+                    buf,
+                    r#"
+        .env({key:?}, {value:?})"#,
+                );
+            }
+        }
+        if let Some(cwd) = fs.get("cwd") {
+            let cwd = cwd.as_str().unwrap();
+            write!(
+                buf,
+                r#"
+        .current_dir({cwd:?})"#,
+            );
+        }
+        if let Some(home) = fs.get("homedir") {
+            let home = home.as_str().unwrap();
+            write!(
+                buf,
+                r#"
+        .env("HOME", {home:?})"#,
+            );
+        }
+        if let Some(files) = fs.get("files") {
+            let files = files.as_object().unwrap();
+            for (i, (path, value)) in files.iter().enumerate() {
+                if let Some(content) = value.as_str() {
+                    write!(
+                        testcase,
+                        r#"
+    let _file_{i} = mock_file({path:?}, {content:?});
+    "#,
+                    );
+                }
+            }
+        }
+
+        write!(
+            testcase,
+            r#"
+    Command::new("edgedb")
+        .arg("--test-output-conn-params")"#,
+        );
+        testcase.write_all(&buf).unwrap();
+        if result.is_some() {
+            write!(
+                testcase,
+                r#"
+        .assert()
+        .success()
+        .stdout(expect(result));
+}}"#,
+            );
+        } else {
+            let error = case
+                .get("error")
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get("type")
+                .unwrap()
+                .as_str()
+                .map(|e| error_mapping.get(e).map(|e| e.to_string()).unwrap_or(e.to_string()))
+                .unwrap();
+            write!(
+                testcase,
+                r#"
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains({error:?}));
+}}"#,
+            );
+        }
+        output.write_all(&testcase).unwrap();
+    }
+
+    let project_path_hashing_testcases = testcases.join("project_path_hashing_testcases.json");
+    println!(
+        "cargo:rerun-if-changed={}",
+        project_path_hashing_testcases.to_str().unwrap()
+    );
+    output.flush().unwrap();
+}

--- a/build.rs
+++ b/build.rs
@@ -238,6 +238,12 @@ fn connection_{i}() {{
         if let Some(cwd) = fs.get("cwd") {
             let cwd = cwd.as_str().unwrap();
             write!(
+                testcase,
+                r#"
+    ensure_dir(&PathBuf::from({cwd:?}));
+    "#,
+            );
+            write!(
                 buf,
                 r#"
         .current_dir({cwd:?})"#,

--- a/edgedb-client/src/builder.rs
+++ b/edgedb-client/src/builder.rs
@@ -1326,7 +1326,7 @@ impl Builder {
             "database": self.database,
             "user": self.user,
             "password": self.password,
-            "secret_key": self.secret_key,
+            // "secret_key": self.secret_key,
             "tlsCAData": self.pem,
             "tlsSecurity": self.build().unwrap().0.tls_security,
             "serverSettings": self.con_params,

--- a/edgedb-client/src/builder.rs
+++ b/edgedb-client/src/builder.rs
@@ -522,7 +522,7 @@ impl Builder {
            get_env("EDGEDB_DSN")?.is_none() &&
            get_env("EDGEDB_CONFIGURATION_FILE")?.is_none()
         {
-            builder.read_project(None, false).await?;
+            builder.read_project(None, true).await?;
         }
 
         builder.read_env_vars().await?;

--- a/edgedb-client/src/builder.rs
+++ b/edgedb-client/src/builder.rs
@@ -21,7 +21,7 @@ use futures_util::AsyncReadExt;
 use rand::{thread_rng, Rng};
 use rustls::client::ServerCertVerifier;
 use scram::ScramClient;
-use serde_json::from_slice;
+use serde_json::{from_slice, json};
 use sha1::Digest;
 use tls_api::{TlsConnectorBox, TlsConnector as _, TlsConnectorBuilder as _};
 use tls_api::{TlsStream, TlsStreamDyn as _};
@@ -1160,6 +1160,25 @@ impl Builder {
             Address::Unix(path) => Ok(Some(path.clone())),
             Address::Tcp(_) => Ok(None),
         }
+    }
+
+    /// Generate debug JSON string
+    #[cfg(feature="unstable")]
+    pub fn to_json(&self) -> String {
+        json!({
+            "address": match &self.address {
+                Address::Tcp((host, port)) => json!([host, port]),
+                Address::Unix(path) => json!(path.to_str().unwrap()),
+            },
+            "database": self.database,
+            "user": self.user,
+            "password": self.password,
+            "secret_key": self.secret_key,
+            "tlsCAData": self.pem,
+            "tlsSecurity": self.build().unwrap().0.tls_security,
+            "serverSettings": {},
+            "waitUntilAvailable": self.wait.as_micros() as i64,
+        }).to_string()
     }
 }
 

--- a/edgedb-client/src/builder.rs
+++ b/edgedb-client/src/builder.rs
@@ -369,7 +369,7 @@ impl<'a> DsnHelper<'a> {
     async fn retrieve_value<T>(
         &mut self,
         key: &'static str,
-        v: Option<T>,
+        v_from_url: Option<T>,
         conv: impl FnOnce(String) -> Result<T, Error>,
     ) -> Result<Option<T>, Error> {
         let v_query = self.query.remove(key);
@@ -379,7 +379,7 @@ impl<'a> DsnHelper<'a> {
         let v_file = self.query.remove(k_file.as_str());
 
         let defined_param_names = vec![
-            v.as_ref().map(|_| format!("{key} of URL")),
+            v_from_url.as_ref().map(|_| format!("{key} of URL")),
             v_query.as_ref().map(|_| format!("query {key}")),
             v_env.as_ref().map(|_| format!("query {k_env}")),
             v_file.as_ref().map(|_| format!("query {k_file}")),
@@ -394,8 +394,8 @@ impl<'a> DsnHelper<'a> {
             )));
         }
 
-        if v.is_some() {
-            Ok(v)
+        if v_from_url.is_some() {
+            Ok(v_from_url)
         } else if let Some(val) = v_query {
             conv(val.to_string())
                 .map(|rv| Some(rv))

--- a/edgedb-client/src/credentials.rs
+++ b/edgedb-client/src/credentials.rs
@@ -59,7 +59,8 @@ fn default_port() -> u16 {
 
 
 impl TlsSecurity {
-    pub fn from_str(val: &str) -> Result<Self, Error> {
+    pub fn from_str(val: impl AsRef<str>) -> Result<Self, Error> {
+        let val = val.as_ref();
         match val {
             "default" => Ok(TlsSecurity::Default),
             "insecure" => Ok(TlsSecurity::Insecure),

--- a/edgedb-client/src/credentials.rs
+++ b/edgedb-client/src/credentials.rs
@@ -129,13 +129,12 @@ impl<'de> Deserialize<'de> for Credentials {
         let expected_verify = match creds.tls_security {
             Some(TlsSecurity::Strict) => Some(true),
             Some(TlsSecurity::NoHostVerification) => Some(false),
+            Some(TlsSecurity::Insecure) => Some(false),
             _ => None,
         };
-        if creds.tls_verify_hostname.is_some() &&
-            creds.tls_security.is_some() &&
-            expected_verify.zip(creds.tls_verify_hostname)
-                .map(|(creds, expected)| creds == expected)
-                .unwrap_or(false)
+        if expected_verify.zip(creds.tls_verify_hostname)
+            .map(|(creds, expected)| creds != expected)
+            .unwrap_or(false)
         {
             Err(de::Error::custom(format!(
                 "detected conflicting settings: \

--- a/edgedb-client/src/lib.rs
+++ b/edgedb-client/src/lib.rs
@@ -38,7 +38,7 @@ pub use errors::{Error};
 pub use traits::{Executor, ExecuteResult};
 
 #[cfg(feature="unstable")]
-pub use builder::{get_project_dir};
+pub use builder::{get_project_dir, SkipFields};
 
 pub use edgedb_protocol::model;
 pub use edgedb_protocol::query_arg::{QueryArg, QueryArgs};

--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -36,7 +36,7 @@ impl CloudInstance {
             .host_port(
                 Some(client.get_cloud_host(&self.org_slug, &self.name)),
                 None,
-            )
+            )?
             .secret_key(client.access_token.clone().unwrap());
         let mut creds = builder.as_credentials()?;
         creds.tls_ca = self.tls_ca.clone();

--- a/src/commands/dump.rs
+++ b/src/commands/dump.rs
@@ -206,7 +206,7 @@ pub async fn dump_all(cli: &mut Connection, options: &Options, dir: &Path)
     let mut conn_params = options.conn_params.clone();
     for database in &databases {
         let mut db_conn = conn_params
-            .modify(|p| { p.database(database); })?
+            .modify(|p| { p.database(database).unwrap(); })?
             .connect().await?;
         let filename = dir.join(&(urlencoding::encode(database) + ".dump")[..]);
         dump_db(&mut db_conn, options, &filename).await?;

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -316,7 +316,7 @@ pub async fn restore_all<'x>(cli: &mut Connection, options: &Options,
                 .with_context(|| format!("error creating database {:?}",
                                          database))?;
         }
-        conn_params.modify(|p| { p.database(&database); })?;
+        conn_params.modify(|p| { p.database(&database).unwrap(); })?;
         let mut db_conn = conn_params.connect().await.with_context(||
              format!("cannot connect to database {:?}", database))?;
         params.path = path.into();

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,11 @@ fn _main() -> anyhow::Result<()> {
         commands::cli::main(opt)
     } else {
         cli::directory_check::check_and_warn();
+        #[cfg(feature="portable_tests")]
+        if opt.test_output_conn_params {
+            println!("{}", opt.create_connector()?.get()?.to_json());
+            return Ok(());
+        }
         if opt.interactive {
             interactive::main(opt, cfg)
         } else {

--- a/src/options.rs
+++ b/src/options.rs
@@ -234,6 +234,10 @@ pub struct RawOptions {
     #[cfg_attr(not(feature="dev_mode"), clap(hide=true))]
     pub debug_print_codecs: bool,
 
+    #[cfg(feature="portable_tests")]
+    #[clap(long)]
+    pub test_output_conn_params: bool,
+
     /// Print all available connection options
     /// for the interactive shell and subcommands
     #[clap(long)]
@@ -369,6 +373,8 @@ pub struct Options {
     pub debug_print_codecs: bool,
     pub output_format: Option<OutputFormat>,
     pub no_cli_update_check: bool,
+    #[cfg(feature="portable_tests")]
+    pub test_output_conn_params: bool,
 }
 
 fn parse_duration(value: &str) -> anyhow::Result<Duration> {
@@ -631,6 +637,8 @@ impl Options {
                 None
             },
             no_cli_update_check,
+            #[cfg(feature="portable_tests")]
+            test_output_conn_params: tmp.test_output_conn_params,
         })
     }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use anyhow::Context;
 use anymap::AnyMap;
 use async_std::task;
 use atty;
@@ -685,7 +686,7 @@ pub fn conn_params(opts: &Options) -> anyhow::Result<Builder> {
         }
         bld.read_extra_env_vars()?;
     } else if let Some(dsn) = &tmp.dsn {
-        task::block_on(bld.read_dsn(dsn))?;
+        task::block_on(bld.read_dsn(dsn)).context("invalid DSN")?;
         bld.read_extra_env_vars()?;
     } else if let Some(instance) = &tmp.instance {
         match instance {

--- a/src/options.rs
+++ b/src/options.rs
@@ -680,7 +680,7 @@ pub fn conn_params(opts: &Options) -> anyhow::Result<Builder> {
                 bld.unix_path(host, tmp.port, tmp.admin);
             }
             _ => {
-                bld.host_port(tmp.host.clone(), tmp.port);
+                bld.host_port(tmp.host.clone(), tmp.port)?;
             }
         }
         bld.read_extra_env_vars()?;
@@ -701,7 +701,7 @@ pub fn conn_params(opts: &Options) -> anyhow::Result<Builder> {
             InstanceName::Cloud { org_slug, name } => {
                 let client = crate::cloud::client::CloudClient::new(&opts.cloud_options)?;
                 client.ensure_authenticated()?;
-                bld.host_port(Some(client.get_cloud_host(org_slug, name)), None);
+                bld.host_port(Some(client.get_cloud_host(org_slug, name)), None)?;
                 bld.secret_key(client.access_token.unwrap());
             }
             InstanceName::Local(instance) => {

--- a/src/options.rs
+++ b/src/options.rs
@@ -719,7 +719,7 @@ pub fn conn_params(opts: &Options) -> anyhow::Result<Builder> {
         bld.admin()?;
     }
     if let Some(user) = &tmp.user {
-        bld.user(user);
+        bld.user(user)?;
     }
     if let Some(database) = &tmp.database {
         bld.database(database);

--- a/src/options.rs
+++ b/src/options.rs
@@ -722,7 +722,7 @@ pub fn conn_params(opts: &Options) -> anyhow::Result<Builder> {
         bld.user(user)?;
     }
     if let Some(database) = &tmp.database {
-        bld.database(database);
+        bld.database(database)?;
     }
     if let Some(val) = tmp.wait_until_available {
         bld.wait_until_available(val);

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -326,7 +326,7 @@ fn prompt_conn_params(
                 .parse()?
         }
         if options.host.is_none() || options.port.is_none() {
-            builder.host_port(Some(host), Some(port));
+            builder.host_port(Some(host), Some(port))?;
         }
         if let Some(user) = &options.user {
             builder.user(user);

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -338,13 +338,13 @@ fn prompt_conn_params(
             )?;
         }
         if let Some(database) = &options.database {
-            builder.database(database);
+            builder.database(database)?;
         } else {
             builder.database(
                 question::String::new("Specify the database name")
                     .default(builder.get_database())
                     .ask()?
-            );
+            )?;
         }
     }
     Ok(())

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -329,13 +329,13 @@ fn prompt_conn_params(
             builder.host_port(Some(host), Some(port))?;
         }
         if let Some(user) = &options.user {
-            builder.user(user);
+            builder.user(user)?;
         } else {
             builder.user(
                 question::String::new("Specify the database user")
                     .default(builder.get_user())
                     .ask()?
-            );
+            )?;
         }
         if let Some(database) = &options.database {
             builder.database(database);

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -354,7 +354,7 @@ impl InstanceInfo {
     pub async fn admin_conn_params(&self) -> anyhow::Result<Builder> {
         let mut builder = Builder::uninitialized();
         builder.unix_path(runstate_dir(&self.name)?, Some(self.port), true);
-        builder.user("edgedb");
+        builder.user("edgedb")?;
         builder.database("edgedb");
         Ok(builder)
     }

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -355,7 +355,7 @@ impl InstanceInfo {
         let mut builder = Builder::uninitialized();
         builder.unix_path(runstate_dir(&self.name)?, Some(self.port), true);
         builder.user("edgedb")?;
-        builder.database("edgedb");
+        builder.database("edgedb")?;
         Ok(builder)
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -129,7 +129,7 @@ impl State {
     }
     pub async fn try_connect(&mut self, database: &str) -> anyhow::Result<()> {
         let mut params = self.conn_params.clone();
-        params.modify(|p| { p.database(database); })?;
+        params.modify(|p| { p.database(database).unwrap(); })?;
         let mut conn = params.connect().await?;
         let fetched_version = conn.get_version().await?;
         if self.last_version.as_deref() != Some(fetched_version) {

--- a/tests/docker_portable_wrapper.rs
+++ b/tests/docker_portable_wrapper.rs
@@ -72,11 +72,19 @@ static TEST_EXECUTABLES: Lazy<HashMap<String, PathBuf>> = Lazy::new(|| {
 });
 
 extern fn delete_docker_image() {
-    Command::new("docker")
+    std::process::Command::new("docker")
         .arg("image")
         .arg("rm")
         .arg("edgedb_test_portable")
-        .unwrap();
+        .output()
+        .map_or_else(
+            |e| println!("docker image rm failed: {:?}", e),
+            |o| {
+                if !o.status.success() {
+                    println!("docker image rm failed: {:?}", o)
+                }
+            },
+        );
 }
 
 fn dockerfile() -> String {

--- a/tests/docker_portable_wrapper.rs
+++ b/tests/docker_portable_wrapper.rs
@@ -99,6 +99,7 @@ fn dockerfile() -> String {
 #[test_case("portable_smoke")]
 #[test_case("portable_project")]
 #[test_case("portable_project_dir")]
+#[test_case("portable_shared")]
 fn run_test(name: &'static str) {
     let file_name = TEST_EXECUTABLES.get(name).unwrap()
         .file_name().unwrap()

--- a/tests/docker_portable_wrapper.rs
+++ b/tests/docker_portable_wrapper.rs
@@ -89,6 +89,7 @@ fn dockerfile() -> String {
         RUN adduser --uid 1000 --home /home/user1 \
             --shell /bin/bash --ingroup users --gecos "EdgeDB Test User" \
             user1
+        RUN mkdir /home/edgedb && chown user1 /home/edgedb
         ADD ./edgedb /usr/bin/edgedb
         ADD ./tests /tests
         RUN chown -R user1 /tests/proj
@@ -108,6 +109,7 @@ fn run_test(name: &'static str) {
     let script = format!(r###"
         export XDG_RUNTIME_DIR=/run/user/1000
         export EDGEDB_INSTALL_IN_DOCKER=allow
+        export RUST_TEST_THREADS=1
 
         /lib/systemd/systemd --user &
         exec /tests/{file_name}

--- a/tests/portable_shared.rs
+++ b/tests/portable_shared.rs
@@ -1,0 +1,90 @@
+#![cfg_attr(not(feature="portable_tests"), allow(dead_code, unused_imports))]
+
+use std::fmt::{Display, Formatter};
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use assert_cmd::Command;
+use edgedb_protocol::model::Duration;
+use predicates::Predicate;
+use predicates::reflection::PredicateReflection;
+use serde_json::Value;
+
+struct ResultPredicate {
+    result: Value,
+}
+
+impl Predicate<str> for ResultPredicate {
+    fn eval(&self, variable: &str) -> bool {
+        let actual: Value = serde_json::from_str(variable).unwrap();
+        for (k, v) in actual.as_object().unwrap() {
+            match self.result.get(k) {
+                Some(expected) if k != "waitUntilAvailable" => {
+                    if !expected.eq(v) {
+                        println!("{}: {} != {}", k, v, expected);
+                        return false;
+                    }
+                }
+                Some(expected) => {
+                    let expected = expected.as_str().unwrap().parse::<Duration>().unwrap();
+                    if v.as_i64().is_none() {
+                        panic!("illegal waitUntilAvailable: {}", v);
+                    }
+                    let v = Duration::from_micros(v.as_i64().unwrap());
+                    if expected != v {
+                        println!("{}: {} != {}", k, v, expected);
+                        return false;
+                    }
+                }
+                None => {
+                    println!("{}={} was not expected", k, v);
+                    return false;
+                }
+            }
+        }
+        for (k, v) in self.result.as_object().unwrap() {
+            if actual.get(k).is_none() {
+                println!("expect {}={}", k, v);
+                return false;
+            }
+        }
+        true
+    }
+}
+
+
+impl PredicateReflection for ResultPredicate {}
+
+impl Display for ResultPredicate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.result.fmt(f)
+    }
+}
+
+struct MockFile {
+    path: PathBuf
+}
+
+impl Drop for MockFile {
+    fn drop(&mut self) {
+        fs::remove_file(&self.path).unwrap();
+    }
+}
+
+fn mock_file(path: &str, content: &str) -> MockFile {
+    let path = PathBuf::from(path);
+    let parent = path.parent().unwrap();
+    if !parent.exists() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&path, content).unwrap();
+    MockFile { path }
+}
+
+fn expect(result: Value) -> ResultPredicate {
+    ResultPredicate {
+        result,
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/shared_client_testcases.rs"));

--- a/tests/portable_shared.rs
+++ b/tests/portable_shared.rs
@@ -9,6 +9,7 @@ use edgedb_protocol::model::Duration;
 use predicates::Predicate;
 use predicates::reflection::PredicateReflection;
 use serde_json::Value;
+use sha1::Digest;
 
 struct ResultPredicate {
     result: Value,
@@ -19,19 +20,19 @@ impl Predicate<str> for ResultPredicate {
         let actual: Value = serde_json::from_str(variable).unwrap();
         for (k, v) in actual.as_object().unwrap() {
             match self.result.get(k) {
-                Some(expected) if k != "waitUntilAvailable" => {
-                    if !expected.eq(v) {
-                        println!("{}: {} != {}", k, v, expected);
-                        return false;
-                    }
-                }
-                Some(expected) => {
+                Some(expected) if k == "waitUntilAvailable" => {
                     let expected = expected.as_str().unwrap().parse::<Duration>().unwrap();
                     if v.as_i64().is_none() {
                         panic!("illegal waitUntilAvailable: {}", v);
                     }
                     let v = Duration::from_micros(v.as_i64().unwrap());
                     if expected != v {
+                        println!("{}: {} != {}", k, v, expected);
+                        return false;
+                    }
+                }
+                Some(expected) => {
+                    if !expected.eq(v) {
                         println!("{}: {} != {}", k, v, expected);
                         return false;
                     }
@@ -75,10 +76,48 @@ fn mock_file(path: &str, content: &str) -> MockFile {
     let path = PathBuf::from(path);
     let parent = path.parent().unwrap();
     if !parent.exists() {
-        fs::create_dir_all(parent).unwrap();
+        fs::create_dir_all(parent).expect(&format!("mkdir -p {parent:?}"));
     }
-    fs::write(&path, content).unwrap();
+    fs::write(&path, content).expect(&format!("write {path:?}"));
     MockFile { path }
+}
+
+fn mock_project(
+    project_dir: &str,
+    instance_name: &str,
+    project_path: &str,
+) -> Vec<MockFile> {
+    let path = PathBuf::from(project_path);
+    #[cfg(windows)]
+    let bytes = path.to_str().unwrap().as_bytes();
+    #[cfg(unix)]
+    let bytes = {
+        use std::os::unix::ffi::OsStrExt;
+        path.as_os_str().as_bytes()
+    };
+    let hash = hex::encode(sha1::Sha1::new_with_prefix(bytes).finalize());
+    let project_dir = project_dir.replace("${HASH}", &hash);
+    let project_dir = PathBuf::from(project_dir);
+    let project_path_file = mock_file(
+        project_dir.join("project-path").to_str().unwrap(),
+        project_path,
+    );
+    let instance_name_file = mock_file(
+        project_dir.join("instance-name").to_str().unwrap(),
+        instance_name,
+    );
+    let link_file = project_dir.join("project-link");
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::symlink_dir;
+        symlink_dir(&path, &link_file).unwrap();
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+        symlink(&path, &link_file).unwrap();
+    }
+    vec![project_path_file, instance_name_file, MockFile { path: link_file }]
 }
 
 fn expect(result: Value) -> ResultPredicate {

--- a/tests/portable_shared.rs
+++ b/tests/portable_shared.rs
@@ -3,7 +3,7 @@
 use std::fmt::{Display, Formatter};
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use assert_cmd::Command;
 use edgedb_protocol::model::Duration;
 use predicates::Predicate;
@@ -74,10 +74,7 @@ impl Drop for MockFile {
 
 fn mock_file(path: &str, content: &str) -> MockFile {
     let path = PathBuf::from(path);
-    let parent = path.parent().unwrap();
-    if !parent.exists() {
-        fs::create_dir_all(parent).expect(&format!("mkdir -p {parent:?}"));
-    }
+    ensure_dir(&path.parent().unwrap());
     fs::write(&path, content).expect(&format!("write {path:?}"));
     MockFile { path }
 }
@@ -118,6 +115,12 @@ fn mock_project(
         symlink(&path, &link_file).unwrap();
     }
     vec![project_path_file, instance_name_file, MockFile { path: link_file }]
+}
+
+fn ensure_dir(path: &Path) {
+    if !path.exists() {
+        fs::create_dir_all(path).expect(&format!("mkdir -p {path:?}"));
+    }
 }
 
 fn expect(result: Value) -> ResultPredicate {

--- a/tests/portable_shared.rs
+++ b/tests/portable_shared.rs
@@ -90,12 +90,13 @@ fn mock_project(
     project_path: &str,
 ) -> Vec<MockFile> {
     let path = PathBuf::from(project_path);
+    let canon = fs::canonicalize(&path).unwrap();
     #[cfg(windows)]
-    let bytes = path.to_str().unwrap().as_bytes();
+    let bytes = canon.to_str().unwrap().as_bytes();
     #[cfg(unix)]
     let bytes = {
         use std::os::unix::ffi::OsStrExt;
-        path.as_os_str().as_bytes()
+        canon.as_os_str().as_bytes()
     };
     let hash = hex::encode(sha1::Sha1::new_with_prefix(bytes).finalize());
     let project_dir = project_dir.replace("${HASH}", &hash);


### PR DESCRIPTION
* CRF for #902 
* Store and use resolved `tls_security`
* Add error context for DSN parsing
* Added `SkipFields` to `parse_dsn()`
* DSN path `/` is None, not empty name
* Supported EDGEDB_CLIENT_SECURITY=strict
* EDGEDB_CLIENT_SECURITY=insecure_dev_mode is now only effective when EDGEDB_CLIENT_TLS_SECURITY=default
* Error on empty host, user and database
* Prevent DSN query parameters with the same name
* Strip leading `/` in ?database=/xxx
* Error out with multiple compound env vars
* Only take EDGEDB_WAIT_UNTIL_AVAILABLE on the env layer
* Reject multiple hosts
* Reject port=0
* Support connection parameters in DSN query
* [REPL will now try to find `edgedb.toml` in parent dirs](https://github.com/edgedb/edgedb-cli/pull/905/commits/227722781bc47c951ae658c6eee7252ce023820f)
* Fix credentials file legacy checking bug