### PR TITLE
Skip rebuilding the same nightly

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -3,6 +3,15 @@
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.whichver.outputs.branch }}
+      scm_revision: ${{ steps.whatrev.outputs.rev }}
+<% if subdist == "nightly" %>
+<% for tgt in targets.linux %>
+      if_<< tgt.family >>_<< tgt.platform_version >>_<< tgt.arch >>: ${{ steps.scm.outputs.if_<< tgt.family >>_<< tgt.platform_version >>_<< tgt.arch >> }}
+<% endfor %>
+<% for tgt in targets.macos + targets.win %>
+      if_<< tgt.platform >>_<< tgt.platform_version >>: ${{ steps.scm.outputs.if_<< tgt.platform >>_<< tgt.platform_version >> }}
+<% endfor %>
+<% endif %>
     steps:
     - uses: actions/checkout@v3
       with:
@@ -15,11 +24,63 @@
         echo branch="${branch}" >> $GITHUB_OUTPUT
       id: whichver
 
+<% if subdist == "nightly" %>
+    - name: Determine SCM revision
+      id: scm
+      shell: bash
+      run: |
+        rev=$(git rev-parse HEAD)
+        jq_filter='.packages[] | select(.basename == "edgedb-cli") | select(.architecture == $ARCH) | .version_details.metadata.scm_revision | . as $rev | select($REV | startswith($rev))'
+<% for tgt in targets.linux %>
+        val=true
+<% if tgt.family == "debian" %>
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/<< tgt.platform_version >>.nightly.json | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing << tgt.family >>-<< tgt.platform_version >>-<< tgt.arch >>'
+          val=false
+        fi
+<% elif tgt.family == "redhat" %>
+        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el<< tgt.platform_version >>.nightly.json | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing << tgt.family >>-<< tgt.platform_version >>-<< tgt.arch >>'
+          val=false
+        fi
+<% elif tgt.family == "generic" %>
+        out=$(curl -s https://packages.edgedb.com/archive/.jsonindexes/<< tgt.platform_version >>-unknown-linux-<< "{}".format(tgt.platform_libc) if tgt.platform_libc else "gnu" >>.nightly.json | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing << tgt.family >>-<< tgt.platform_version >>-<< "{}".format(tgt.platform_libc) if tgt.platform_libc else "gnu" >>'
+          val=false
+        fi
+<% endif %>
+        echo if_<< tgt.family >>_<< tgt.platform_version >>_<< tgt.arch >>="$val" >> $GITHUB_OUTPUT
+<% endfor %>
+<% for tgt in targets.macos + targets.win %>
+        val=true
+<% if tgt.platform == "macos" %>
+        out=$(curl -s https://packages.edgedb.com/archive/.jsonindexes/<< tgt.platform_version >>-apple-darwin.nightly.json | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing << tgt.platform >>-<< tgt.platform_version >>'
+          val=false
+        fi
+<% elif tgt.platform == "win" %>
+        out=$(curl -s https://packages.edgedb.com/archive/.jsonindexes/<< tgt.platform_version >>-pc-windows-msvc.nightly.json | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing << tgt.platform >>-<< tgt.platform_version >>'
+          val=false
+        fi
+<% endif %>
+        echo if_<< tgt.platform >>_<< tgt.platform_version >>="$val" >> $GITHUB_OUTPUT
+<% endfor %>
+<% endif %>
+
 <% for tgt in targets.linux %>
 <% set plat_id = tgt.platform + ("{}".format(tgt.platform_libc) if tgt.platform_libc else "") + ("-{}".format(tgt.platform_version) if tgt.platform_version else "") %>
   build-<< tgt.name >>:
     runs-on: << tgt.runs_on if tgt.runs_on else "ubuntu-latest" >>
     needs: prep
+<% if subdist == "nightly" %>
+    if: needs.prep.outputs.if_<< tgt.family >>_<< tgt.platform_version >>_<< tgt.arch >> == 'true'
+<% endif %>
 
     steps:
     - uses: actions/checkout@v3
@@ -61,6 +122,9 @@
   build-<< tgt.name >>:
     runs-on: << tgt.runs_on if tgt.runs_on else "macos-latest" >>
     needs: prep
+<% if subdist == "nightly" %>
+    if: needs.prep.outputs.if_<< tgt.platform >>_<< tgt.platform_version >> == 'true'
+<% endif %>
 
     steps:
     - uses: actions/checkout@v3
@@ -106,6 +170,9 @@
   build-<< tgt.name >>:
     runs-on: windows-2019
     needs: prep
+<% if subdist == "nightly" %>
+    if: needs.prep.outputs.if_<< tgt.platform >>_<< tgt.platform_version >> == 'true'
+<% endif %>
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -31,13 +31,21 @@
 <% for tgt in targets.linux %>
         val=true
 <% if tgt.family == "debian" %>
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/<< tgt.platform_version >>.nightly.json | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
+        idx_file=<< tgt.platform_version >>.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing << tgt.name >>'
           val=false
         fi
 <% elif tgt.family == "redhat" %>
-        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el<< tgt.platform_version >>.nightly.json | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
+        idx_file=el<< tgt.platform_version >>.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
         if [ -n "$out" ]; then
           echo 'Skip rebuilding existing << tgt.name >>'
           val=false

--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -5,11 +5,8 @@
       branch: ${{ steps.whichver.outputs.branch }}
       scm_revision: ${{ steps.whatrev.outputs.rev }}
 <% if subdist == "nightly" %>
-<% for tgt in targets.linux %>
-      if_<< tgt.family >>_<< tgt.platform_version >>_<< tgt.arch >>: ${{ steps.scm.outputs.if_<< tgt.family >>_<< tgt.platform_version >>_<< tgt.arch >> }}
-<% endfor %>
-<% for tgt in targets.macos + targets.win %>
-      if_<< tgt.platform >>_<< tgt.platform_version >>: ${{ steps.scm.outputs.if_<< tgt.platform >>_<< tgt.platform_version >> }}
+<% for tgt in targets.linux + targets.macos + targets.win %>
+      if_<< tgt.name.replace('-', '_') >>: ${{ steps.scm.outputs.if_<< tgt.name.replace('-', '_') >> }}
 <% endfor %>
 <% endif %>
     steps:
@@ -36,23 +33,23 @@
 <% if tgt.family == "debian" %>
         out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/<< tgt.platform_version >>.nightly.json | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
         if [ -n "$out" ]; then 
-          echo 'Skip rebuilding existing << tgt.family >>-<< tgt.platform_version >>-<< tgt.arch >>'
+          echo 'Skip rebuilding existing << tgt.name >>'
           val=false
         fi
 <% elif tgt.family == "redhat" %>
         out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el<< tgt.platform_version >>.nightly.json | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing << tgt.family >>-<< tgt.platform_version >>-<< tgt.arch >>'
+          echo 'Skip rebuilding existing << tgt.name >>'
           val=false
         fi
 <% elif tgt.family == "generic" %>
         out=$(curl -s https://packages.edgedb.com/archive/.jsonindexes/<< tgt.platform_version >>-unknown-linux-<< "{}".format(tgt.platform_libc) if tgt.platform_libc else "gnu" >>.nightly.json | jq -r --arg REV "$rev" --arg ARCH "<< tgt.arch >>" "$jq_filter")
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing << tgt.family >>-<< tgt.platform_version >>-<< "{}".format(tgt.platform_libc) if tgt.platform_libc else "gnu" >>'
+          echo 'Skip rebuilding existing << tgt.name >>'
           val=false
         fi
 <% endif %>
-        echo if_<< tgt.family >>_<< tgt.platform_version >>_<< tgt.arch >>="$val" >> $GITHUB_OUTPUT
+        echo if_<< tgt.name.replace('-', '_') >>="$val" >> $GITHUB_OUTPUT
 <% endfor %>
 <% for tgt in targets.macos + targets.win %>
         val=true
@@ -69,7 +66,7 @@
           val=false
         fi
 <% endif %>
-        echo if_<< tgt.platform >>_<< tgt.platform_version >>="$val" >> $GITHUB_OUTPUT
+        echo if_<< tgt.name.replace('-', '_') >>="$val" >> $GITHUB_OUTPUT
 <% endfor %>
 <% endif %>
 
@@ -79,7 +76,7 @@
     runs-on: << tgt.runs_on if tgt.runs_on else "ubuntu-latest" >>
     needs: prep
 <% if subdist == "nightly" %>
-    if: needs.prep.outputs.if_<< tgt.family >>_<< tgt.platform_version >>_<< tgt.arch >> == 'true'
+    if: needs.prep.outputs.if_<< tgt.name.replace('-', '_') >> == 'true'
 <% endif %>
 
     steps:
@@ -123,7 +120,7 @@
     runs-on: << tgt.runs_on if tgt.runs_on else "macos-latest" >>
     needs: prep
 <% if subdist == "nightly" %>
-    if: needs.prep.outputs.if_<< tgt.platform >>_<< tgt.platform_version >> == 'true'
+    if: needs.prep.outputs.if_<< tgt.name.replace('-', '_') >> == 'true'
 <% endif %>
 
     steps:
@@ -171,7 +168,7 @@
     runs-on: windows-2019
     needs: prep
 <% if subdist == "nightly" %>
-    if: needs.prep.outputs.if_<< tgt.platform >>_<< tgt.platform_version >> == 'true'
+    if: needs.prep.outputs.if_<< tgt.name.replace('-', '_') >> == 'true'
 <% endif %>
 
     steps:

--- a/.github/workflows.src/build.targets.yml
+++ b/.github/workflows.src/build.targets.yml
@@ -26,11 +26,13 @@ targets:
           platform: debian
           platform_version: bookworm
           family: debian
+          arch: x86_64
           runs_on: [self-hosted, linux, x64]
         - name: debian-bookworm-aarch64
           platform: debian
           platform_version: bookworm
           family: debian
+          arch: aarch64
           runs_on: [self-hosted, linux, arm64]
         - name: ubuntu-bionic-x86_64
           platform: ubuntu
@@ -85,11 +87,13 @@ targets:
           platform: rockylinux
           platform_version: 9
           family: redhat
+          arch: x86_64
           runs_on: [self-hosted, linux, x64]
         - name: rockylinux-9-aarch64
           platform: rockylinux
           platform_version: 9
           family: redhat
+          arch: aarch64
           runs_on: [self-hosted, linux, arm64]
         - name: linux-x86_64
           platform: linux

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -144,7 +144,7 @@ jobs:
         if [ ! -e "/tmp/$idx_file" ]; then
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
-        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing debian-bookworm-x86_64'
           val=false
@@ -158,7 +158,7 @@ jobs:
         if [ ! -e "/tmp/$idx_file" ]; then
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
-        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing debian-bookworm-aarch64'
           val=false
@@ -298,7 +298,7 @@ jobs:
         if [ ! -e "/tmp/$idx_file" ]; then
           curl -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
-        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then
           echo 'Skip rebuilding existing rockylinux-9-x86_64'
           val=false
@@ -312,7 +312,7 @@ jobs:
         if [ ! -e "/tmp/$idx_file" ]; then
           curl -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
-        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then
           echo 'Skip rebuilding existing rockylinux-9-aarch64'
           val=false
@@ -533,7 +533,7 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "x86_64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
@@ -567,7 +567,7 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "aarch64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
@@ -907,7 +907,7 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "rockylinux"
         PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "x86_64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
@@ -941,7 +941,7 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "rockylinux"
         PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "aarch64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,55 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.whichver.outputs.branch }}
+      scm_revision: ${{ steps.whatrev.outputs.rev }}
+
+
+      if_debian_buster_x86_64: ${{ steps.scm.outputs.if_debian_buster_x86_64 }}
+
+      if_debian_buster_aarch64: ${{ steps.scm.outputs.if_debian_buster_aarch64 }}
+
+      if_debian_bullseye_x86_64: ${{ steps.scm.outputs.if_debian_bullseye_x86_64 }}
+
+      if_debian_bullseye_aarch64: ${{ steps.scm.outputs.if_debian_bullseye_aarch64 }}
+
+      if_debian_bookworm_: ${{ steps.scm.outputs.if_debian_bookworm_ }}
+
+      if_debian_bookworm_: ${{ steps.scm.outputs.if_debian_bookworm_ }}
+
+      if_debian_bionic_x86_64: ${{ steps.scm.outputs.if_debian_bionic_x86_64 }}
+
+      if_debian_bionic_aarch64: ${{ steps.scm.outputs.if_debian_bionic_aarch64 }}
+
+      if_debian_focal_x86_64: ${{ steps.scm.outputs.if_debian_focal_x86_64 }}
+
+      if_debian_focal_aarch64: ${{ steps.scm.outputs.if_debian_focal_aarch64 }}
+
+      if_debian_jammy_x86_64: ${{ steps.scm.outputs.if_debian_jammy_x86_64 }}
+
+      if_debian_jammy_aarch64: ${{ steps.scm.outputs.if_debian_jammy_aarch64 }}
+
+      if_redhat_7_x86_64: ${{ steps.scm.outputs.if_redhat_7_x86_64 }}
+
+      if_redhat_8_x86_64: ${{ steps.scm.outputs.if_redhat_8_x86_64 }}
+
+      if_redhat_8_aarch64: ${{ steps.scm.outputs.if_redhat_8_aarch64 }}
+
+      if_redhat_9_: ${{ steps.scm.outputs.if_redhat_9_ }}
+
+      if_redhat_9_: ${{ steps.scm.outputs.if_redhat_9_ }}
+
+      if_generic_x86_64_x86_64: ${{ steps.scm.outputs.if_generic_x86_64_x86_64 }}
+
+      if_generic_aarch64_aarch64: ${{ steps.scm.outputs.if_generic_aarch64_aarch64 }}
+
+
+      if_macos_x86_64: ${{ steps.scm.outputs.if_macos_x86_64 }}
+
+      if_macos_aarch64: ${{ steps.scm.outputs.if_macos_aarch64 }}
+
+      if_win_x86_64: ${{ steps.scm.outputs.if_win_x86_64 }}
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -27,10 +76,244 @@ jobs:
       id: whichver
 
 
+    - name: Determine SCM revision
+      id: scm
+      shell: bash
+      run: |
+        rev=$(git rev-parse HEAD)
+        jq_filter='.packages[] | select(.basename == "edgedb-cli") | select(.architecture == $ARCH) | .version_details.metadata.scm_revision | . as $rev | select($REV | startswith($rev))'
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/buster.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-buster-x86_64'
+          val=false
+        fi
+
+        echo if_debian_buster_x86_64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/buster.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-buster-aarch64'
+          val=false
+        fi
+
+        echo if_debian_buster_aarch64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bullseye.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-bullseye-x86_64'
+          val=false
+        fi
+
+        echo if_debian_bullseye_x86_64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bullseye.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-bullseye-aarch64'
+          val=false
+        fi
+
+        echo if_debian_bullseye_aarch64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bookworm.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-bookworm-'
+          val=false
+        fi
+
+        echo if_debian_bookworm_="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bookworm.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-bookworm-'
+          val=false
+        fi
+
+        echo if_debian_bookworm_="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bionic.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-bionic-x86_64'
+          val=false
+        fi
+
+        echo if_debian_bionic_x86_64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bionic.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-bionic-aarch64'
+          val=false
+        fi
+
+        echo if_debian_bionic_aarch64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/focal.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-focal-x86_64'
+          val=false
+        fi
+
+        echo if_debian_focal_x86_64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/focal.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-focal-aarch64'
+          val=false
+        fi
+
+        echo if_debian_focal_aarch64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/jammy.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-jammy-x86_64'
+          val=false
+        fi
+
+        echo if_debian_jammy_x86_64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/jammy.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        if [ -n "$out" ]; then 
+          echo 'Skip rebuilding existing debian-jammy-aarch64'
+          val=false
+        fi
+
+        echo if_debian_jammy_aarch64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el7.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing redhat-7-x86_64'
+          val=false
+        fi
+
+        echo if_redhat_7_x86_64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el8.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing redhat-8-x86_64'
+          val=false
+        fi
+
+        echo if_redhat_8_x86_64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el8.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing redhat-8-aarch64'
+          val=false
+        fi
+
+        echo if_redhat_8_aarch64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el9.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing redhat-9-'
+          val=false
+        fi
+
+        echo if_redhat_9_="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el9.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing redhat-9-'
+          val=false
+        fi
+
+        echo if_redhat_9_="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/archive/.jsonindexes/x86_64-unknown-linux-musl.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing generic-x86_64-musl'
+          val=false
+        fi
+
+        echo if_generic_x86_64_x86_64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-musl.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing generic-aarch64-musl'
+          val=false
+        fi
+
+        echo if_generic_aarch64_aarch64="$val" >> $GITHUB_OUTPUT
+
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/archive/.jsonindexes/x86_64-apple-darwin.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing macos-x86_64'
+          val=false
+        fi
+
+        echo if_macos_x86_64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-apple-darwin.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing macos-aarch64'
+          val=false
+        fi
+
+        echo if_macos_aarch64="$val" >> $GITHUB_OUTPUT
+
+        val=true
+
+        out=$(curl -s https://packages.edgedb.com/archive/.jsonindexes/x86_64-pc-windows-msvc.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        if [ -n "$out" ]; then
+          echo 'Skip rebuilding existing win-x86_64'
+          val=false
+        fi
+
+        echo if_win_x86_64="$val" >> $GITHUB_OUTPUT
+
+
+
+
 
   build-debian-buster-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
+    if: needs.prep.outputs.if_debian_buster_x86_64 == 'true'
+
 
     steps:
     - uses: actions/checkout@v3
@@ -63,6 +346,9 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+    if: needs.prep.outputs.if_debian_buster_aarch64 == 'true'
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -93,6 +379,9 @@ jobs:
   build-debian-bullseye-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
+    if: needs.prep.outputs.if_debian_bullseye_x86_64 == 'true'
+
 
     steps:
     - uses: actions/checkout@v3
@@ -125,6 +414,9 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+    if: needs.prep.outputs.if_debian_bullseye_aarch64 == 'true'
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -155,6 +447,9 @@ jobs:
   build-debian-bookworm-x86_64:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
+
+    if: needs.prep.outputs.if_debian_bookworm_ == 'true'
+
 
     steps:
     - uses: actions/checkout@v3
@@ -187,6 +482,9 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+    if: needs.prep.outputs.if_debian_bookworm_ == 'true'
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -217,6 +515,9 @@ jobs:
   build-ubuntu-bionic-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
+    if: needs.prep.outputs.if_debian_bionic_x86_64 == 'true'
+
 
     steps:
     - uses: actions/checkout@v3
@@ -249,6 +550,9 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+    if: needs.prep.outputs.if_debian_bionic_aarch64 == 'true'
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -279,6 +583,9 @@ jobs:
   build-ubuntu-focal-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
+    if: needs.prep.outputs.if_debian_focal_x86_64 == 'true'
+
 
     steps:
     - uses: actions/checkout@v3
@@ -311,6 +618,9 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+    if: needs.prep.outputs.if_debian_focal_aarch64 == 'true'
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -341,6 +651,9 @@ jobs:
   build-ubuntu-jammy-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
+    if: needs.prep.outputs.if_debian_jammy_x86_64 == 'true'
+
 
     steps:
     - uses: actions/checkout@v3
@@ -373,6 +686,9 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+    if: needs.prep.outputs.if_debian_jammy_aarch64 == 'true'
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -403,6 +719,9 @@ jobs:
   build-centos-7-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
+    if: needs.prep.outputs.if_redhat_7_x86_64 == 'true'
+
 
     steps:
     - uses: actions/checkout@v3
@@ -435,6 +754,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: prep
 
+    if: needs.prep.outputs.if_redhat_8_x86_64 == 'true'
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -465,6 +787,9 @@ jobs:
   build-centos-8-aarch64:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
+
+    if: needs.prep.outputs.if_redhat_8_aarch64 == 'true'
+
 
     steps:
     - uses: actions/checkout@v3
@@ -497,6 +822,9 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
 
+    if: needs.prep.outputs.if_redhat_9_ == 'true'
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -528,6 +856,9 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+    if: needs.prep.outputs.if_redhat_9_ == 'true'
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -558,6 +889,9 @@ jobs:
   build-linux-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
+    if: needs.prep.outputs.if_generic_x86_64_x86_64 == 'true'
+
 
     steps:
     - uses: actions/checkout@v3
@@ -594,6 +928,9 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+    if: needs.prep.outputs.if_generic_aarch64_aarch64 == 'true'
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -629,6 +966,9 @@ jobs:
   build-macos-x86_64:
     runs-on: macos-latest
     needs: prep
+
+    if: needs.prep.outputs.if_macos_x86_64 == 'true'
+
 
     steps:
     - uses: actions/checkout@v3
@@ -669,6 +1009,9 @@ jobs:
     runs-on: ['self-hosted', 'macOS', 'ARM64']
     needs: prep
 
+    if: needs.prep.outputs.if_macos_aarch64 == 'true'
+
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -708,6 +1051,9 @@ jobs:
   build-win-x86_64:
     runs-on: windows-2019
     needs: prep
+
+    if: needs.prep.outputs.if_win_x86_64 == 'true'
+
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,36 +25,35 @@ jobs:
 
       if_debian_bullseye_aarch64: ${{ steps.scm.outputs.if_debian_bullseye_aarch64 }}
 
-      if_debian_bookworm_: ${{ steps.scm.outputs.if_debian_bookworm_ }}
+      if_debian_bookworm_x86_64: ${{ steps.scm.outputs.if_debian_bookworm_x86_64 }}
 
-      if_debian_bookworm_: ${{ steps.scm.outputs.if_debian_bookworm_ }}
+      if_debian_bookworm_aarch64: ${{ steps.scm.outputs.if_debian_bookworm_aarch64 }}
 
-      if_debian_bionic_x86_64: ${{ steps.scm.outputs.if_debian_bionic_x86_64 }}
+      if_ubuntu_bionic_x86_64: ${{ steps.scm.outputs.if_ubuntu_bionic_x86_64 }}
 
-      if_debian_bionic_aarch64: ${{ steps.scm.outputs.if_debian_bionic_aarch64 }}
+      if_ubuntu_bionic_aarch64: ${{ steps.scm.outputs.if_ubuntu_bionic_aarch64 }}
 
-      if_debian_focal_x86_64: ${{ steps.scm.outputs.if_debian_focal_x86_64 }}
+      if_ubuntu_focal_x86_64: ${{ steps.scm.outputs.if_ubuntu_focal_x86_64 }}
 
-      if_debian_focal_aarch64: ${{ steps.scm.outputs.if_debian_focal_aarch64 }}
+      if_ubuntu_focal_aarch64: ${{ steps.scm.outputs.if_ubuntu_focal_aarch64 }}
 
-      if_debian_jammy_x86_64: ${{ steps.scm.outputs.if_debian_jammy_x86_64 }}
+      if_ubuntu_jammy_x86_64: ${{ steps.scm.outputs.if_ubuntu_jammy_x86_64 }}
 
-      if_debian_jammy_aarch64: ${{ steps.scm.outputs.if_debian_jammy_aarch64 }}
+      if_ubuntu_jammy_aarch64: ${{ steps.scm.outputs.if_ubuntu_jammy_aarch64 }}
 
-      if_redhat_7_x86_64: ${{ steps.scm.outputs.if_redhat_7_x86_64 }}
+      if_centos_7_x86_64: ${{ steps.scm.outputs.if_centos_7_x86_64 }}
 
-      if_redhat_8_x86_64: ${{ steps.scm.outputs.if_redhat_8_x86_64 }}
+      if_centos_8_x86_64: ${{ steps.scm.outputs.if_centos_8_x86_64 }}
 
-      if_redhat_8_aarch64: ${{ steps.scm.outputs.if_redhat_8_aarch64 }}
+      if_centos_8_aarch64: ${{ steps.scm.outputs.if_centos_8_aarch64 }}
 
-      if_redhat_9_: ${{ steps.scm.outputs.if_redhat_9_ }}
+      if_rockylinux_9_x86_64: ${{ steps.scm.outputs.if_rockylinux_9_x86_64 }}
 
-      if_redhat_9_: ${{ steps.scm.outputs.if_redhat_9_ }}
+      if_rockylinux_9_aarch64: ${{ steps.scm.outputs.if_rockylinux_9_aarch64 }}
 
-      if_generic_x86_64_x86_64: ${{ steps.scm.outputs.if_generic_x86_64_x86_64 }}
+      if_linux_x86_64: ${{ steps.scm.outputs.if_linux_x86_64 }}
 
-      if_generic_aarch64_aarch64: ${{ steps.scm.outputs.if_generic_aarch64_aarch64 }}
-
+      if_linux_aarch64: ${{ steps.scm.outputs.if_linux_aarch64 }}
 
       if_macos_x86_64: ${{ steps.scm.outputs.if_macos_x86_64 }}
 
@@ -127,151 +126,151 @@ jobs:
 
         out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bookworm.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
         if [ -n "$out" ]; then 
-          echo 'Skip rebuilding existing debian-bookworm-'
+          echo 'Skip rebuilding existing debian-bookworm-x86_64'
           val=false
         fi
 
-        echo if_debian_bookworm_="$val" >> $GITHUB_OUTPUT
+        echo if_debian_bookworm_x86_64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bookworm.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
         if [ -n "$out" ]; then 
-          echo 'Skip rebuilding existing debian-bookworm-'
+          echo 'Skip rebuilding existing debian-bookworm-aarch64'
           val=false
         fi
 
-        echo if_debian_bookworm_="$val" >> $GITHUB_OUTPUT
+        echo if_debian_bookworm_aarch64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bionic.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then 
-          echo 'Skip rebuilding existing debian-bionic-x86_64'
+          echo 'Skip rebuilding existing ubuntu-bionic-x86_64'
           val=false
         fi
 
-        echo if_debian_bionic_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_ubuntu_bionic_x86_64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bionic.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then 
-          echo 'Skip rebuilding existing debian-bionic-aarch64'
+          echo 'Skip rebuilding existing ubuntu-bionic-aarch64'
           val=false
         fi
 
-        echo if_debian_bionic_aarch64="$val" >> $GITHUB_OUTPUT
+        echo if_ubuntu_bionic_aarch64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/focal.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then 
-          echo 'Skip rebuilding existing debian-focal-x86_64'
+          echo 'Skip rebuilding existing ubuntu-focal-x86_64'
           val=false
         fi
 
-        echo if_debian_focal_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_ubuntu_focal_x86_64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/focal.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then 
-          echo 'Skip rebuilding existing debian-focal-aarch64'
+          echo 'Skip rebuilding existing ubuntu-focal-aarch64'
           val=false
         fi
 
-        echo if_debian_focal_aarch64="$val" >> $GITHUB_OUTPUT
+        echo if_ubuntu_focal_aarch64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/jammy.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then 
-          echo 'Skip rebuilding existing debian-jammy-x86_64'
+          echo 'Skip rebuilding existing ubuntu-jammy-x86_64'
           val=false
         fi
 
-        echo if_debian_jammy_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_ubuntu_jammy_x86_64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/jammy.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then 
-          echo 'Skip rebuilding existing debian-jammy-aarch64'
+          echo 'Skip rebuilding existing ubuntu-jammy-aarch64'
           val=false
         fi
 
-        echo if_debian_jammy_aarch64="$val" >> $GITHUB_OUTPUT
+        echo if_ubuntu_jammy_aarch64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el7.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing redhat-7-x86_64'
+          echo 'Skip rebuilding existing centos-7-x86_64'
           val=false
         fi
 
-        echo if_redhat_7_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_centos_7_x86_64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el8.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing redhat-8-x86_64'
+          echo 'Skip rebuilding existing centos-8-x86_64'
           val=false
         fi
 
-        echo if_redhat_8_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_centos_8_x86_64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el8.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing redhat-8-aarch64'
+          echo 'Skip rebuilding existing centos-8-aarch64'
           val=false
         fi
 
-        echo if_redhat_8_aarch64="$val" >> $GITHUB_OUTPUT
+        echo if_centos_8_aarch64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el9.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing redhat-9-'
+          echo 'Skip rebuilding existing rockylinux-9-x86_64'
           val=false
         fi
 
-        echo if_redhat_9_="$val" >> $GITHUB_OUTPUT
+        echo if_rockylinux_9_x86_64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el9.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing redhat-9-'
+          echo 'Skip rebuilding existing rockylinux-9-aarch64'
           val=false
         fi
 
-        echo if_redhat_9_="$val" >> $GITHUB_OUTPUT
+        echo if_rockylinux_9_aarch64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/archive/.jsonindexes/x86_64-unknown-linux-musl.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing generic-x86_64-musl'
+          echo 'Skip rebuilding existing linux-x86_64'
           val=false
         fi
 
-        echo if_generic_x86_64_x86_64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_x86_64="$val" >> $GITHUB_OUTPUT
 
         val=true
 
         out=$(curl -s https://packages.edgedb.com/archive/.jsonindexes/aarch64-unknown-linux-musl.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then
-          echo 'Skip rebuilding existing generic-aarch64-musl'
+          echo 'Skip rebuilding existing linux-aarch64'
           val=false
         fi
 
-        echo if_generic_aarch64_aarch64="$val" >> $GITHUB_OUTPUT
+        echo if_linux_aarch64="$val" >> $GITHUB_OUTPUT
 
 
         val=true
@@ -448,7 +447,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
 
-    if: needs.prep.outputs.if_debian_bookworm_ == 'true'
+    if: needs.prep.outputs.if_debian_bookworm_x86_64 == 'true'
 
 
     steps:
@@ -482,7 +481,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_debian_bookworm_ == 'true'
+    if: needs.prep.outputs.if_debian_bookworm_aarch64 == 'true'
 
 
     steps:
@@ -516,7 +515,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prep
 
-    if: needs.prep.outputs.if_debian_bionic_x86_64 == 'true'
+    if: needs.prep.outputs.if_ubuntu_bionic_x86_64 == 'true'
 
 
     steps:
@@ -550,7 +549,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_debian_bionic_aarch64 == 'true'
+    if: needs.prep.outputs.if_ubuntu_bionic_aarch64 == 'true'
 
 
     steps:
@@ -584,7 +583,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prep
 
-    if: needs.prep.outputs.if_debian_focal_x86_64 == 'true'
+    if: needs.prep.outputs.if_ubuntu_focal_x86_64 == 'true'
 
 
     steps:
@@ -618,7 +617,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_debian_focal_aarch64 == 'true'
+    if: needs.prep.outputs.if_ubuntu_focal_aarch64 == 'true'
 
 
     steps:
@@ -652,7 +651,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prep
 
-    if: needs.prep.outputs.if_debian_jammy_x86_64 == 'true'
+    if: needs.prep.outputs.if_ubuntu_jammy_x86_64 == 'true'
 
 
     steps:
@@ -686,7 +685,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_debian_jammy_aarch64 == 'true'
+    if: needs.prep.outputs.if_ubuntu_jammy_aarch64 == 'true'
 
 
     steps:
@@ -720,7 +719,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prep
 
-    if: needs.prep.outputs.if_redhat_7_x86_64 == 'true'
+    if: needs.prep.outputs.if_centos_7_x86_64 == 'true'
 
 
     steps:
@@ -754,7 +753,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prep
 
-    if: needs.prep.outputs.if_redhat_8_x86_64 == 'true'
+    if: needs.prep.outputs.if_centos_8_x86_64 == 'true'
 
 
     steps:
@@ -788,7 +787,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_redhat_8_aarch64 == 'true'
+    if: needs.prep.outputs.if_centos_8_aarch64 == 'true'
 
 
     steps:
@@ -822,7 +821,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
 
-    if: needs.prep.outputs.if_redhat_9_ == 'true'
+    if: needs.prep.outputs.if_rockylinux_9_x86_64 == 'true'
 
 
     steps:
@@ -856,7 +855,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_redhat_9_ == 'true'
+    if: needs.prep.outputs.if_rockylinux_9_aarch64 == 'true'
 
 
     steps:
@@ -890,7 +889,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prep
 
-    if: needs.prep.outputs.if_generic_x86_64_x86_64 == 'true'
+    if: needs.prep.outputs.if_linux_x86_64 == 'true'
 
 
     steps:
@@ -928,7 +927,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
-    if: needs.prep.outputs.if_generic_aarch64_aarch64 == 'true'
+    if: needs.prep.outputs.if_linux_aarch64 == 'true'
 
 
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,7 +84,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/buster.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        idx_file=buster.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing debian-buster-x86_64'
           val=false
@@ -94,7 +98,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/buster.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        idx_file=buster.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing debian-buster-aarch64'
           val=false
@@ -104,7 +112,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bullseye.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        idx_file=bullseye.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing debian-bullseye-x86_64'
           val=false
@@ -114,7 +126,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bullseye.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        idx_file=bullseye.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing debian-bullseye-aarch64'
           val=false
@@ -124,7 +140,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bookworm.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        idx_file=bookworm.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing debian-bookworm-x86_64'
           val=false
@@ -134,7 +154,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bookworm.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        idx_file=bookworm.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing debian-bookworm-aarch64'
           val=false
@@ -144,7 +168,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bionic.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        idx_file=bionic.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing ubuntu-bionic-x86_64'
           val=false
@@ -154,7 +182,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/bionic.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        idx_file=bionic.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing ubuntu-bionic-aarch64'
           val=false
@@ -164,7 +196,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/focal.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        idx_file=focal.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing ubuntu-focal-x86_64'
           val=false
@@ -174,7 +210,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/focal.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        idx_file=focal.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing ubuntu-focal-aarch64'
           val=false
@@ -184,7 +224,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/jammy.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        idx_file=jammy.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing ubuntu-jammy-x86_64'
           val=false
@@ -194,7 +238,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/apt/.jsonindexes/jammy.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        idx_file=jammy.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then 
           echo 'Skip rebuilding existing ubuntu-jammy-aarch64'
           val=false
@@ -204,7 +252,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el7.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        idx_file=el7.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then
           echo 'Skip rebuilding existing centos-7-x86_64'
           val=false
@@ -214,7 +266,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el8.nightly.json | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
+        idx_file=el8.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
         if [ -n "$out" ]; then
           echo 'Skip rebuilding existing centos-8-x86_64'
           val=false
@@ -224,7 +280,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el8.nightly.json | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
+        idx_file=el8.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
         if [ -n "$out" ]; then
           echo 'Skip rebuilding existing centos-8-aarch64'
           val=false
@@ -234,7 +294,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el9.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        idx_file=el9.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
         if [ -n "$out" ]; then
           echo 'Skip rebuilding existing rockylinux-9-x86_64'
           val=false
@@ -244,7 +308,11 @@ jobs:
 
         val=true
 
-        out=$(curl -s https://packages.edgedb.com/rpm/.jsonindexes/el9.nightly.json | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
+        idx_file=el9.nightly.json
+        if [ ! -e "/tmp/$idx_file" ]; then
+          curl -s https://packages.edgedb.com/rpm/.jsonindexes/$idx_file > /tmp/$idx_file
+        fi
+        out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "" "$jq_filter")
         if [ -n "$out" ]; then
           echo 'Skip rebuilding existing rockylinux-9-aarch64'
           val=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.whichver.outputs.branch }}
+      scm_revision: ${{ steps.whatrev.outputs.rev }}
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -23,9 +25,12 @@ jobs:
 
 
 
+
+
   build-debian-buster-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -58,6 +63,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -88,6 +94,7 @@ jobs:
   build-debian-bullseye-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -120,6 +127,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -150,6 +158,7 @@ jobs:
   build-debian-bookworm-x86_64:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -182,6 +191,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -212,6 +222,7 @@ jobs:
   build-ubuntu-bionic-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -244,6 +255,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -274,6 +286,7 @@ jobs:
   build-ubuntu-focal-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -306,6 +319,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -336,6 +350,7 @@ jobs:
   build-ubuntu-jammy-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -368,6 +383,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -398,6 +414,7 @@ jobs:
   build-centos-7-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -430,6 +447,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -460,6 +478,7 @@ jobs:
   build-centos-8-aarch64:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -492,6 +511,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -523,6 +543,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -553,6 +574,7 @@ jobs:
   build-linux-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -589,6 +611,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -624,6 +647,7 @@ jobs:
   build-macos-x86_64:
     runs-on: macos-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -664,6 +688,7 @@ jobs:
     runs-on: ['self-hosted', 'macOS', 'ARM64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -703,6 +728,7 @@ jobs:
   build-win-x86_64:
     runs-on: windows-2019
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "x86_64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
@@ -207,7 +207,7 @@ jobs:
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "aarch64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
@@ -527,7 +527,7 @@ jobs:
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "rockylinux"
         PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "x86_64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
@@ -559,7 +559,7 @@ jobs:
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "rockylinux"
         PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "aarch64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -180,7 +180,7 @@ jobs:
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "x86_64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
@@ -213,7 +213,7 @@ jobs:
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bookworm"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "aarch64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
@@ -543,7 +543,7 @@ jobs:
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "rockylinux"
         PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "x86_64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 
@@ -576,7 +576,7 @@ jobs:
         PKG_SUBDIST: "testing"
         PKG_PLATFORM: "rockylinux"
         PKG_PLATFORM_VERSION: "9"
-        PKG_PLATFORM_ARCH: ""
+        PKG_PLATFORM_ARCH: "aarch64"
         PACKAGE: edgedbpkg.edgedbcli:EdgeDBCLI
         EXTRA_OPTIMIZATIONS: "true"
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.whichver.outputs.branch }}
+      scm_revision: ${{ steps.whatrev.outputs.rev }}
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -23,9 +25,12 @@ jobs:
 
 
 
+
+
   build-debian-buster-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -59,6 +64,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -90,6 +96,7 @@ jobs:
   build-debian-bullseye-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -123,6 +130,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -154,6 +162,7 @@ jobs:
   build-debian-bookworm-x86_64:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -187,6 +196,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -218,6 +228,7 @@ jobs:
   build-ubuntu-bionic-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -251,6 +262,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -282,6 +294,7 @@ jobs:
   build-ubuntu-focal-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -315,6 +328,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -346,6 +360,7 @@ jobs:
   build-ubuntu-jammy-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -379,6 +394,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -410,6 +426,7 @@ jobs:
   build-centos-7-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -443,6 +460,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -474,6 +492,7 @@ jobs:
   build-centos-8-aarch64:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -507,6 +526,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -539,6 +559,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -570,6 +591,7 @@ jobs:
   build-linux-x86_64:
     runs-on: ubuntu-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -607,6 +629,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -643,6 +666,7 @@ jobs:
   build-macos-x86_64:
     runs-on: macos-latest
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3
@@ -684,6 +708,7 @@ jobs:
     runs-on: ['self-hosted', 'macOS', 'ARM64']
     needs: prep
 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -724,6 +749,7 @@ jobs:
   build-win-x86_64:
     runs-on: windows-2019
     needs: prep
+
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Sample run: https://github.com/edgedb/edgedb-cli/actions/runs/6165223876/job/16732610092#step:4:304

Not checking Docker registry separately - it follows the generic-linux build for now.

~CentOS `aarch64` packages are marked as `x86_64` in the `.jsonindexes` for some reason, so this PR is not skipping duplicate aarch64 CentOS builds for now.~