### PR TITLE
Add support for `_EDGEDB_CLOUD_CERTS=local`

### DIFF
--- a/edgedb-client/src/builder.rs
+++ b/edgedb-client/src/builder.rs
@@ -1379,7 +1379,8 @@ impl Builder {
                     )
                 })
             );
-            if matches!(get_env("_EDGEDB_CLOUD_CERTS")?.as_deref(), Some("staging")) {
+            let cloud_certs = get_env("_EDGEDB_CLOUD_CERTS")?;
+            if matches!(cloud_certs.as_deref(), Some("staging")) {
                 roots.add_server_trust_anchors(
                     tls::OwnedTrustAnchor::read_all(
                         "-----BEGIN CERTIFICATE-----
@@ -1428,6 +1429,29 @@ VR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQU3tGjWWQOwZo2o0busBB2766XlWYwCgYI
 KoZIzj0EAwMDaAAwZQIwRcp4ZKBsq9XkUuN8wfX+GEbY1N5nmCRc8e80kUkuAefo
 uc2j3cICeXo1cOybQ1iWAjEA3Ooawl8eQyR4wrjCofUE8h44p0j7Yl/kBlJZT8+9
 vbtH7QiVzeKCOTQPINyRql6P
+-----END CERTIFICATE-----"
+                    )
+                    .map_err(ClientError::with_source_ref)?
+                    .into_iter()
+                    .map(Into::into),
+                );
+            } else if matches!(cloud_certs.as_deref(), Some("local")) {
+                // Local nebula development root cert found in
+                // nebula/infra/terraform/local/ca/root.certificate.pem
+                roots.add_server_trust_anchors(
+                    tls::OwnedTrustAnchor::read_all(
+                        "----BEGIN CERTIFICATE-----
+MIICBjCCAaugAwIBAgIUGLnu92rPr79+DsDQBtolXEZENwMwCgYIKoZIzj0EAwIw
+UDELMAkGA1UEBhMCVVMxGjAYBgNVBAoMEUVkZ2VEQiAoaW50ZXJuYWwpMSUwIwYD
+VQQDDBxOZWJ1bGEgSW5mcmEgUm9vdCBDQSAobG9jYWwpMB4XDTIzMDExNDIzMDkw
+M1oXDTMyMTAxMzIzMDkwM1owUDELMAkGA1UEBhMCVVMxGjAYBgNVBAoMEUVkZ2VE
+QiAoaW50ZXJuYWwpMSUwIwYDVQQDDBxOZWJ1bGEgSW5mcmEgUm9vdCBDQSAobG9j
+YWwpMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHJk/v57y1dG1xekQjeYwqlW7
+45fvlWIIid/EfcyBNCyvWhLUyQUz3urmK81rJlFYCexq/kgazTeBFJyWbrvLLKNj
+MGEwHQYDVR0OBBYEFN5PvqC9p5e4HC99o3z0pJrRuIpeMB8GA1UdIwQYMBaAFN5P
+vqC9p5e4HC99o3z0pJrRuIpeMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQD
+AgEGMAoGCCqGSM49BAMCA0kAMEYCIQDedUpRy5YtQAHROrh/ZsWPlvek3vguuRrE
+y4u6fdOVhgIhAJ4pJLfdoWQsHPUOcnVG5fBgdSnoCJhGQyuGyp+NDu1q
 -----END CERTIFICATE-----"
                     )
                     .map_err(ClientError::with_source_ref)?

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -184,6 +184,29 @@ vbtH7QiVzeKCOTQPINyRql6P
                     )
                     .unwrap(),
                 )
+        } else if matches!(cloud_certs.as_deref(), Some("local")) {
+            // Local nebula development root cert found in
+            // nebula/infra/terraform/local/ca/root.certificate.pem
+            builder = builder
+                .add_root_certificate(
+                    reqwest::Certificate::from_pem(
+                        "----BEGIN CERTIFICATE-----
+MIICBjCCAaugAwIBAgIUGLnu92rPr79+DsDQBtolXEZENwMwCgYIKoZIzj0EAwIw
+UDELMAkGA1UEBhMCVVMxGjAYBgNVBAoMEUVkZ2VEQiAoaW50ZXJuYWwpMSUwIwYD
+VQQDDBxOZWJ1bGEgSW5mcmEgUm9vdCBDQSAobG9jYWwpMB4XDTIzMDExNDIzMDkw
+M1oXDTMyMTAxMzIzMDkwM1owUDELMAkGA1UEBhMCVVMxGjAYBgNVBAoMEUVkZ2VE
+QiAoaW50ZXJuYWwpMSUwIwYDVQQDDBxOZWJ1bGEgSW5mcmEgUm9vdCBDQSAobG9j
+YWwpMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHJk/v57y1dG1xekQjeYwqlW7
+45fvlWIIid/EfcyBNCyvWhLUyQUz3urmK81rJlFYCexq/kgazTeBFJyWbrvLLKNj
+MGEwHQYDVR0OBBYEFN5PvqC9p5e4HC99o3z0pJrRuIpeMB8GA1UdIwQYMBaAFN5P
+vqC9p5e4HC99o3z0pJrRuIpeMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQD
+AgEGMAoGCCqGSM49BAMCA0kAMEYCIQDedUpRy5YtQAHROrh/ZsWPlvek3vguuRrE
+y4u6fdOVhgIhAJ4pJLfdoWQsHPUOcnVG5fBgdSnoCJhGQyuGyp+NDu1q
+-----END CERTIFICATE-----"
+                        .as_bytes(),
+                    )
+                    .unwrap(),
+                )
         }
         Ok(Self {
             client: builder.build()?,


### PR DESCRIPTION
Local virtual Nebula deploys use a self-signed root certificate.  Trust
it when `_EDGEDB_CLOUD_CERTS` is set to `local`.