### PR TITLE
Update cloud instance name policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.4.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#cb76455d98b9fe935424d07668d4a01afd07af7a"
+source = "git+https://github.com/edgedb/edgedb-rust/#ac5886ab236ee8a203dc3d2b73f5f067ea96330b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -984,7 +984,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.3.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#cb76455d98b9fe935424d07668d4a01afd07af7a"
+source = "git+https://github.com/edgedb/edgedb-rust/#ac5886ab236ee8a203dc3d2b73f5f067ea96330b"
 dependencies = [
  "bytes",
 ]
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.4.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#cb76455d98b9fe935424d07668d4a01afd07af7a"
+source = "git+https://github.com/edgedb/edgedb-rust/#ac5886ab236ee8a203dc3d2b73f5f067ea96330b"
 dependencies = [
  "bigdecimal",
  "bitflags",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.3.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#cb76455d98b9fe935424d07668d4a01afd07af7a"
+source = "git+https://github.com/edgedb/edgedb-rust/#ac5886ab236ee8a203dc3d2b73f5f067ea96330b"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.4.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#0c66dc5b3d2513739a036d1e9842acf789a79c1b"
+source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#cb76455d98b9fe935424d07668d4a01afd07af7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -984,7 +984,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.3.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#0c66dc5b3d2513739a036d1e9842acf789a79c1b"
+source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#cb76455d98b9fe935424d07668d4a01afd07af7a"
 dependencies = [
  "bytes",
 ]
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.4.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#0c66dc5b3d2513739a036d1e9842acf789a79c1b"
+source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#cb76455d98b9fe935424d07668d4a01afd07af7a"
 dependencies = [
  "bigdecimal",
  "bitflags",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.3.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#0c66dc5b3d2513739a036d1e9842acf789a79c1b"
+source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#cb76455d98b9fe935424d07668d4a01afd07af7a"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.4.0"
-source = "git+https://github.com/edgedb/edgedb-rust/#6459cd57ff5a8abf407516e7b913277ce1d97db0"
+source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#0c66dc5b3d2513739a036d1e9842acf789a79c1b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -984,7 +984,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.3.0"
-source = "git+https://github.com/edgedb/edgedb-rust/#6459cd57ff5a8abf407516e7b913277ce1d97db0"
+source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#0c66dc5b3d2513739a036d1e9842acf789a79c1b"
 dependencies = [
  "bytes",
 ]
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.4.0"
-source = "git+https://github.com/edgedb/edgedb-rust/#6459cd57ff5a8abf407516e7b913277ce1d97db0"
+source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#0c66dc5b3d2513739a036d1e9842acf789a79c1b"
 dependencies = [
  "bigdecimal",
  "bitflags",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.3.0"
-source = "git+https://github.com/edgedb/edgedb-rust/#6459cd57ff5a8abf407516e7b913277ce1d97db0"
+source = "git+https://github.com/edgedb/edgedb-rust/?branch=cloud-inst-name#0c66dc5b3d2513739a036d1e9842acf789a79c1b"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2018"
 
 [dependencies]
 edgeql-parser = {git = "https://github.com/edgedb/edgedb"}
-edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust/", branch="cloud-inst-name", features=["all-types"]}
-edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust/", branch="cloud-inst-name"}
-edgedb-errors = {git = "https://github.com/edgedb/edgedb-rust/", branch="cloud-inst-name"}
-edgedb-tokio = {git = "https://github.com/edgedb/edgedb-rust/", branch="cloud-inst-name", features=["admin_socket", "unstable"]}
+edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust/", features=["all-types"]}
+edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust/"}
+edgedb-errors = {git = "https://github.com/edgedb/edgedb-rust/"}
+edgedb-tokio = {git = "https://github.com/edgedb/edgedb-rust/", features=["admin_socket", "unstable"]}
 snafu = {version="0.7.0", features=["backtraces"]}
 anyhow = "1.0.23"
 bytes = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2018"
 
 [dependencies]
 edgeql-parser = {git = "https://github.com/edgedb/edgedb"}
-edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust/", features=["all-types"]}
-edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust/"}
-edgedb-errors = {git = "https://github.com/edgedb/edgedb-rust/"}
-edgedb-tokio = {git = "https://github.com/edgedb/edgedb-rust/", features=["admin_socket", "unstable"]}
+edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust/", branch="cloud-inst-name", features=["all-types"]}
+edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust/", branch="cloud-inst-name"}
+edgedb-errors = {git = "https://github.com/edgedb/edgedb-rust/", branch="cloud-inst-name"}
+edgedb-tokio = {git = "https://github.com/edgedb/edgedb-rust/", branch="cloud-inst-name", features=["admin_socket", "unstable"]}
 snafu = {version="0.7.0", features=["backtraces"]}
 anyhow = "1.0.23"
 bytes = "1.0.1"

--- a/build.rs
+++ b/build.rs
@@ -46,7 +46,10 @@ fn main() {
             "invalid_port",
             "(Invalid value.*for.*port|invalid port|EDGEDB_PORT is invalid)",
         ),
-        ("invalid_dsn_or_instance_name", "(invalid DSN|Invalid value.*for.*instance)"),
+        (
+            "invalid_dsn_or_instance_name",
+            "(invalid DSN|must be a valid identifier|instance name.*length cannot exceed)",
+        ),
         ("invalid_user", "invalid user"),
         ("invalid_database", "invalid database"),
         ("invalid_credentials_file", "cannot read credentials file"),

--- a/build.rs
+++ b/build.rs
@@ -48,8 +48,9 @@ fn main() {
         ),
         (
             "invalid_dsn_or_instance_name",
-            "(invalid DSN|must be a valid identifier|instance name.*length cannot exceed)",
+            "(invalid DSN|must be a valid identifier)",
         ),
+        ("invalid_instance_name", "invalid.*instance name"),
         ("invalid_user", "invalid user"),
         ("invalid_database", "invalid database"),
         ("invalid_credentials_file", "cannot read credentials file"),

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -11,7 +11,7 @@ use edgedb_tokio::credentials::Credentials;
 
 use crate::platform::{config_dir, tmp_file_name};
 use crate::question;
-use crate::portable::local::is_valid_instance_name;
+use crate::portable::local::is_valid_local_instance_name;
 
 
 pub fn base_dir() -> anyhow::Result<PathBuf> {
@@ -34,7 +34,7 @@ pub fn all_instance_names() -> anyhow::Result<BTreeSet<String>> {
         let item = item?;
         if let Ok(filename) = item.file_name().into_string() {
             if let Some(name) = filename.strip_suffix(".json") {
-                if is_valid_instance_name(name, false) {
+                if is_valid_local_instance_name(name) {
                     result.insert(name.into());
                 }
             }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -34,7 +34,7 @@ pub fn all_instance_names() -> anyhow::Result<BTreeSet<String>> {
         let item = item?;
         if let Ok(filename) = item.file_name().into_string() {
             if let Some(name) = filename.strip_suffix(".json") {
-                if is_valid_instance_name(name) {
+                if is_valid_instance_name(name, false) {
                     result.insert(name.into());
                 }
             }

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -25,7 +25,7 @@ use crate::hint::{HintExt};
 use crate::options::{Options, ConnectionOptions};
 use crate::options;
 use crate::portable::destroy::with_projects;
-use crate::portable::local::{InstanceInfo, is_valid_instance_name};
+use crate::portable::local::{InstanceInfo, is_valid_local_instance_name};
 use crate::portable::options::{Link, Unlink, instance_arg, InstanceName};
 use crate::portable::project;
 use crate::print;
@@ -226,10 +226,10 @@ pub fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
                     let name = question::String::new(
                         "Specify a new instance name for the remote server"
                     ).default(&default).ask()?;
-                    if !is_valid_instance_name(&name, false) {
+                    if !is_valid_local_instance_name(&name) {
                         print::error(
                             "Instance name must be a valid identifier, \
-                             (regex: ^[a-zA-Z_0-9](-?[a-zA-Z_0-9])*$)");
+                             (regex: ^[a-zA-Z_0-9]+(-[a-zA-Z_0-9]+)*$)");
                         continue;
                     }
                     break (credentials::path(&name)?, name);

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -226,10 +226,10 @@ pub fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
                     let name = question::String::new(
                         "Specify a new instance name for the remote server"
                     ).default(&default).ask()?;
-                    if !is_valid_instance_name(&name) {
+                    if !is_valid_instance_name(&name, false) {
                         print::error(
                             "Instance name must be a valid identifier, \
-                             (regex: ^[a-zA-Z_][a-zA-Z_0-9]*$)");
+                             (regex: ^[a-zA-Z_0-9](-?[a-zA-Z_0-9])*$)");
                         continue;
                     }
                     break (credentials::path(&name)?, name);

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -375,11 +375,14 @@ impl InstallInfo {
     }
 }
 
-pub fn is_valid_instance_name(name: &str, is_cloud: bool) -> bool {
+pub fn is_valid_local_instance_name(name: &str) -> bool {
+    // For local instance names:
+    //  1. Allow only letters, numbers, underscores and single dashes
+    //  2. Must not start or end with a dash
+    // regex: ^[a-zA-Z_0-9]+(-[a-zA-Z_0-9]+)*$
     let mut chars = name.chars();
     match chars.next() {
-        Some(c) if c.is_ascii_alphanumeric() => {}
-        Some(c) if !is_cloud && c == '_' => {}
+        Some(c) if c.is_ascii_alphanumeric() || c == '_' => {}
         _ => return false,
     }
     let mut was_dash = false;
@@ -391,17 +394,41 @@ pub fn is_valid_instance_name(name: &str, is_cloud: bool) -> bool {
                 was_dash = true;
             }
         } else {
-            if c == '_' {
-                if is_cloud {
-                    return false;
-                }
-            } else if !c.is_ascii_alphanumeric() {
+            if !c.is_ascii_alphanumeric() && c != '_' {
                 return false;
             }
             was_dash = false;
         }
     }
-    return true;
+    return !was_dash;
+}
+
+pub fn is_valid_cloud_name(name: &str) -> bool {
+    // For cloud instance name parts (organization slugs and instance names):
+    //  1. Allow only letters, numbers and single dashes
+    //  2. Must not start or end with a dash
+    // regex: ^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphanumeric() => {}
+        _ => return false,
+    }
+    let mut was_dash = false;
+    for c in chars {
+        if c == '-' {
+            if was_dash {
+                return false;
+            } else {
+                was_dash = true;
+            }
+        } else {
+            if !c.is_ascii_alphanumeric() {
+                return false;
+            }
+            was_dash = false;
+        }
+    }
+    return !was_dash;
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -375,29 +375,30 @@ impl InstallInfo {
     }
 }
 
-pub fn is_valid_instance_name(name: &str) -> bool {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
-        _ => return false,
-    }
-    for c in chars {
-        if !c.is_ascii_alphanumeric() && c != '_' {
-            return false;
-        }
-    }
-    return true;
-}
-
-pub fn is_valid_org_name(name: &str) -> bool {
+pub fn is_valid_instance_name(name: &str, is_cloud: bool) -> bool {
     let mut chars = name.chars();
     match chars.next() {
         Some(c) if c.is_ascii_alphanumeric() => {}
+        Some(c) if !is_cloud && c == '_' => {}
         _ => return false,
     }
+    let mut was_dash = false;
     for c in chars {
-        if !c.is_ascii_alphanumeric() && c != '-' {
-            return false;
+        if c == '-' {
+            if was_dash {
+                return false;
+            } else {
+                was_dash = true;
+            }
+        } else {
+            if c == '_' {
+                if is_cloud {
+                    return false;
+                }
+            } else if !c.is_ascii_alphanumeric() {
+                return false;
+            }
+            was_dash = false;
         }
     }
     return true;

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -27,7 +27,7 @@ use crate::platform::{data_dir};
 use crate::portable::control;
 use crate::portable::exit_codes;
 use crate::portable::local::{InstanceInfo, Paths};
-use crate::portable::local::{read_ports, is_valid_instance_name, lock_file};
+use crate::portable::local::{read_ports, is_valid_local_instance_name, lock_file};
 use crate::portable::options::{Status, List, instance_arg, InstanceName};
 use crate::portable::upgrade::{UpgradeMeta, BackupMeta};
 use crate::portable::{windows, linux, macos};
@@ -374,7 +374,7 @@ pub fn list_local<'x>(dir: &'x Path)
             res => return Some(Err(res.with_context(err_ctx).unwrap_err())),
         };
         let fname = entry.file_name();
-        let name_op = fname.to_str().and_then(|x| is_valid_instance_name(x, false).then(|| x));
+        let name_op = fname.to_str().and_then(|x| is_valid_local_instance_name(x).then(|| x));
         if let Some(name) = name_op {
             return Some(Ok((name.into(), entry.path())))
         } else {

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -374,7 +374,7 @@ pub fn list_local<'x>(dir: &'x Path)
             res => return Some(Err(res.with_context(err_ctx).unwrap_err())),
         };
         let fname = entry.file_name();
-        let name_op = fname.to_str().and_then(|x| is_valid_instance_name(x).then(|| x));
+        let name_op = fname.to_str().and_then(|x| is_valid_instance_name(x, false).then(|| x));
         if let Some(name) = name_op {
             return Some(Ok((name.into(), entry.path())))
         } else {


### PR DESCRIPTION
* Disallow underscores
* Disallow consecutive dashes in org slug
* Limit total length to 62
* Allow single dashes in instance name
* Allow leading digits in instance name

Also widen local instance name policy:

* Allow leading digits
* Allow single dashes

Depends on edgedb/edgedb-rust#226, edgedb/shared-client-testcases#27