### PR TITLE
Fix `edgedb ui` with prefixed tokens

### DIFF
--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -1,16 +1,8 @@
-use std::env;
 use std::io::{stdout, Write};
-use std::path::PathBuf;
-
-use fs_err as fs;
-use ring::rand::SecureRandom;
-use ring::signature::KeyPair;
-use ring::{aead, agreement, digest, rand, signature};
 
 use crate::commands::ExitCode;
 use crate::options::{Options, UI};
-use crate::platform::data_dir;
-use crate::portable::local::{instance_data_dir, NonLocalInstance};
+use crate::portable::local::NonLocalInstance;
 use crate::portable::repository::USER_AGENT;
 use crate::print;
 
@@ -22,23 +14,21 @@ pub fn show_ui(options: &Options, args: &UI) -> anyhow::Result<()> {
     let mut token = None;
     let mut is_remote = true;
     if let Some(instance) = builder.get_instance_name() {
-        match read_jose_keys(instance) {
-            Ok(keys) => match generate_jwt(keys) {
-                Ok(t) => {
-                    is_remote = false;
-                    token = Some(t);
-                }
-                Err(e) => {
-                    is_remote = false;
-                    print::warn(format!("Cannot generate authToken: {:#}", e));
-                }
-            },
+        match jwt::LocalJWT::new(instance).generate() {
+            Ok(t) => {
+                is_remote = false;
+                token = Some(t);
+            }
             Err(e) if e.is::<NonLocalInstance>() => {
                 // Continue without token for remote instances
                 log::debug!("Assuming remote instance because: {:#}", e);
             }
+            Err(e) if e.is::<jwt::ReadKeyError>() => {
+                print::warn(format!("{:#}", e));
+            }
             Err(e) => {
-                print::warn(format!("Cannot read JOSE key files: {:#})", e));
+                is_remote = false;
+                print::warn(format!("Cannot generate authToken: {:#}", e));
             }
         }
     }
@@ -133,105 +123,178 @@ async fn open_url(url: &str) -> Result<reqwest::Response, reqwest::Error> {
         .await
 }
 
-fn read_jose_keys(name: &str) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
-    if cfg!(windows) {
-        crate::portable::windows::read_jose_keys(name)
-    } else {
-        let data_dir = if name == "_localdev" {
-            match env::var("EDGEDB_SERVER_DEV_DIR") {
-                Ok(path) => PathBuf::from(path),
-                Err(_) => data_dir()?.parent().unwrap().join("_localdev"),
-            }
-        } else {
-            instance_data_dir(name)?
-        };
-        if !data_dir.exists() {
-            anyhow::bail!(NonLocalInstance);
-        }
-        Ok((
-            fs::read(data_dir.join("edbjwskeys.pem"))?,
-            fs::read(data_dir.join("edbjwekeys.pem"))?,
-        ))
+mod jwt {
+    use std::env;
+    use std::path::PathBuf;
+
+    use fs_err as fs;
+    use ring::rand::SecureRandom;
+    use ring::signature::KeyPair;
+    use ring::{aead, agreement, digest, rand, signature};
+
+    use crate::platform::data_dir;
+    use crate::portable::local::{instance_data_dir, NonLocalInstance};
+    use crate::portable::status;
+    use crate::print;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("Cannot read JOSE key file(s)")]
+    pub struct ReadKeyError(anyhow::Error);
+
+    pub struct LocalJWT {
+        instance_name: String,
+        legacy: bool,
+        rng: rand::SystemRandom,
+        jws_key: Option<Vec<u8>>,
+        jwe_key: Option<Vec<u8>>,
     }
-}
 
-fn generate_jwt<B: AsRef<[u8]>>(keys: (B, B)) -> anyhow::Result<String> {
-    // Replace this ES256/ECDH-ES implementation using raw ring
-    // with biscuit when the algorithms are supported in biscuit
-    let rng = rand::SystemRandom::new();
+    impl LocalJWT {
+        pub fn new(instance_name: impl Into<String>) -> Self {
+            let instance_name = instance_name.into();
+            let legacy = status::instance_status(&instance_name)
+                .ok()
+                .and_then(|v| v.json().version)
+                .as_deref()
+                .map(|v| v < "3.0")
+                .unwrap_or_else(|| {
+                    print::warn("Cannot detect version of instance; assuming 3.0+");
+                    false
+                });
+            let rng = rand::SystemRandom::new();
+            Self {
+                instance_name,
+                legacy,
+                rng,
+                jws_key: None,
+                jwe_key: None,
+            }
+        }
 
-    let jws_pem = pem::parse(keys.0)?;
-    let jwe_pem = pem::parse(keys.1)?;
+        #[cfg(windows)]
+        fn read_keys(&mut self) -> anyhow::Result<()> {
+            use crate::portable::windows;
+            if self.legacy {
+                let (jws_key, jwe_key) = windows::read_jose_keys_legacy(&self.instance_name)?;
+                self.jws_key = Some(jws_key);
+                self.jwe_key = Some(jwe_key);
+            } else {
+                self.jws_key = Some(windows::read_jws_key(&self.instance_name)?);
+            }
+            Ok(())
+        }
+        #[cfg(not(windows))]
+        fn read_keys(&mut self) -> anyhow::Result<()> {
+            let data_dir = if self.instance_name == "_localdev" {
+                match env::var("EDGEDB_SERVER_DEV_DIR") {
+                    Ok(path) => PathBuf::from(path),
+                    Err(_) => data_dir()?.parent().unwrap().join("_localdev"),
+                }
+            } else {
+                instance_data_dir(&self.instance_name)?
+            };
+            if !data_dir.exists() {
+                anyhow::bail!(NonLocalInstance);
+            }
+            self.jws_key = Some(fs::read(data_dir.join("edbjwskeys.pem"))?);
+            if self.legacy {
+                self.jwe_key = Some(fs::read(data_dir.join("edbjwekeys.pem"))?);
+            }
+            Ok(())
+        }
 
-    let jws = signature::EcdsaKeyPair::from_pkcs8(
-        &signature::ECDSA_P256_SHA256_FIXED_SIGNING,
-        jws_pem.contents.as_slice(),
-    )?;
-    let message = format!(
-        "{}.{}",
-        base64::encode_config(
-            b"{\"typ\":\"JWT\",\"alg\":\"ES256\"}",
-            base64::URL_SAFE_NO_PAD
-        ),
-        base64::encode_config(
-            b"{\"edgedb.server.any_role\":true}",
-            base64::URL_SAFE_NO_PAD
-        ),
-    );
-    let signature = jws.sign(&rng, message.as_bytes())?;
-    let signed_token = format!(
-        "{}.{}",
-        message,
-        base64::encode_config(signature, base64::URL_SAFE_NO_PAD),
-    );
+        pub fn generate(&mut self) -> anyhow::Result<String> {
+            self.read_keys().map_err(ReadKeyError)?;
 
-    let jwe = signature::EcdsaKeyPair::from_pkcs8(
-        &signature::ECDSA_P256_SHA256_FIXED_SIGNING,
-        jwe_pem.contents.as_slice(),
-    )?;
+            let token = self.generate_token()?;
+            if !self.legacy {
+                return Ok(format!("edbt_{}", token));
+            }
 
-    let priv_key = agreement::EphemeralPrivateKey::generate(&agreement::ECDH_P256, &rng)?;
-    let pub_key =
-        agreement::UnparsedPublicKey::new(&agreement::ECDH_P256, jwe.public_key().as_ref());
-    let epk = priv_key.compute_public_key()?.as_ref().to_vec();
-    let cek = agreement::agree_ephemeral(priv_key, &pub_key, (), |key_material| {
-        let mut ctx = digest::Context::new(&digest::SHA256);
-        ctx.update(&[0, 0, 0, 1]);
-        ctx.update(key_material);
-        ctx.update(&[0, 0, 0, 7]); // AlgorithmID
-        ctx.update(b"A256GCM");
-        ctx.update(&[0, 0, 0, 0]); // PartyUInfo
-        ctx.update(&[0, 0, 0, 0]); // PartyVInfo
-        ctx.update(&[0, 0, 1, 0]); // SuppPubInfo (bitsize=256)
-        Ok(ctx.finish())
-    })
-    .map_err(|_| anyhow::anyhow!("Error occurred deriving key for JWT"))?;
-    let enc_key = aead::LessSafeKey::new(aead::UnboundKey::new(&aead::AES_256_GCM, cek.as_ref())?);
-    let x = base64::encode_config(&epk[1..33], base64::URL_SAFE_NO_PAD);
-    let y = base64::encode_config(&epk[33..], base64::URL_SAFE_NO_PAD);
-    let protected = format!(
-        "{{\
-            \"alg\":\"ECDH-ES\",\"enc\":\"A256GCM\",\"epk\":{{\
-                \"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"{}\",\"y\":\"{}\"\
-            }}\
-        }}",
-        x, y
-    );
-    let protected = base64::encode_config(protected.as_bytes(), base64::URL_SAFE_NO_PAD);
-    let mut nonce = vec![0; 96 / 8];
-    rng.fill(&mut nonce)?;
-    let mut in_out = signed_token.as_bytes().to_vec();
-    let tag = enc_key.seal_in_place_separate_tag(
-        aead::Nonce::try_assume_unique_for_key(&nonce)?,
-        aead::Aad::from(protected.clone()),
-        &mut in_out,
-    )?;
+            self.generate_legacy_token(token)
+        }
 
-    Ok(format!(
-        "{}..{}.{}.{}",
-        protected,
-        base64::encode_config(nonce, base64::URL_SAFE_NO_PAD),
-        base64::encode_config(in_out, base64::URL_SAFE_NO_PAD),
-        base64::encode_config(tag.as_ref(), base64::URL_SAFE_NO_PAD),
-    ))
+        fn generate_token(&mut self) -> anyhow::Result<String> {
+            let jws_pem = pem::parse(self.jws_key.as_deref().expect("jws_key not set"))?;
+
+            let jws = signature::EcdsaKeyPair::from_pkcs8(
+                &signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+                jws_pem.contents.as_slice(),
+            )?;
+            let message = format!(
+                "{}.{}",
+                base64::encode_config(
+                    b"{\"typ\":\"JWT\",\"alg\":\"ES256\"}",
+                    base64::URL_SAFE_NO_PAD,
+                ),
+                base64::encode_config(
+                    b"{\"edgedb.server.any_role\":true}",
+                    base64::URL_SAFE_NO_PAD,
+                ),
+            );
+            let signature = jws.sign(&self.rng, message.as_bytes())?;
+            Ok(format!(
+                "{}.{}",
+                message,
+                base64::encode_config(signature, base64::URL_SAFE_NO_PAD),
+            ))
+        }
+
+        fn generate_legacy_token(&self, signed_token: String) -> anyhow::Result<String> {
+            // Replace this ES256/ECDH-ES implementation using raw ring
+            // with biscuit when the algorithms are supported in biscuit
+            let jwe_pem = pem::parse(self.jwe_key.as_deref().expect("jwe_key not set"))?;
+            let jwe = signature::EcdsaKeyPair::from_pkcs8(
+                &signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+                jwe_pem.contents.as_slice(),
+            )?;
+
+            let priv_key =
+                agreement::EphemeralPrivateKey::generate(&agreement::ECDH_P256, &self.rng)?;
+            let pub_key =
+                agreement::UnparsedPublicKey::new(&agreement::ECDH_P256, jwe.public_key().as_ref());
+            let epk = priv_key.compute_public_key()?.as_ref().to_vec();
+            let cek = agreement::agree_ephemeral(priv_key, &pub_key, (), |key_material| {
+                let mut ctx = digest::Context::new(&digest::SHA256);
+                ctx.update(&[0, 0, 0, 1]);
+                ctx.update(key_material);
+                ctx.update(&[0, 0, 0, 7]); // AlgorithmID
+                ctx.update(b"A256GCM");
+                ctx.update(&[0, 0, 0, 0]); // PartyUInfo
+                ctx.update(&[0, 0, 0, 0]); // PartyVInfo
+                ctx.update(&[0, 0, 1, 0]); // SuppPubInfo (bitsize=256)
+                Ok(ctx.finish())
+            })
+            .map_err(|_| anyhow::anyhow!("Error occurred deriving key for JWT"))?;
+            let enc_key =
+                aead::LessSafeKey::new(aead::UnboundKey::new(&aead::AES_256_GCM, cek.as_ref())?);
+            let x = base64::encode_config(&epk[1..33], base64::URL_SAFE_NO_PAD);
+            let y = base64::encode_config(&epk[33..], base64::URL_SAFE_NO_PAD);
+            let protected = format!(
+                "{{\
+                    \"alg\":\"ECDH-ES\",\"enc\":\"A256GCM\",\"epk\":{{\
+                        \"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"{}\",\"y\":\"{}\"\
+                    }}\
+                }}",
+                x, y
+            );
+            let protected = base64::encode_config(protected.as_bytes(), base64::URL_SAFE_NO_PAD);
+            let mut nonce = vec![0; 96 / 8];
+            self.rng.fill(&mut nonce)?;
+            let mut in_out = signed_token.as_bytes().to_vec();
+            let tag = enc_key.seal_in_place_separate_tag(
+                aead::Nonce::try_assume_unique_for_key(&nonce)?,
+                aead::Aad::from(protected.clone()),
+                &mut in_out,
+            )?;
+
+            Ok(format!(
+                "{}..{}.{}.{}",
+                protected,
+                base64::encode_config(nonce, base64::URL_SAFE_NO_PAD),
+                base64::encode_config(in_out, base64::URL_SAFE_NO_PAD),
+                base64::encode_config(tag.as_ref(), base64::URL_SAFE_NO_PAD),
+            ))
+        }
+    }
 }


### PR DESCRIPTION
Backport the UI command fix 26b244cf883f5b07da78241d440671cbff32d356  for 3.x instances