### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -196,7 +196,7 @@ jobs:
         echo "SNAPSHOT_TAG=${tag}" >> $GITHUB_ENV
 
     - name: Publish docker image
-      uses: elgohr/Publish-Docker-Github-Action@2.19
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         PKG_PLATFORM_FULL: "<<tgt.platform>><< "-{}".format(tgt.platform_version) if tgt.platform_version >>"
       with:

--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -147,7 +147,7 @@ jobs:
         echo "CLI_VERSION=${ver}" >> $GITHUB_ENV
 
     - name: Publish docker image
-      uses: elgohr/Publish-Docker-Github-Action@2.19
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         PKG_PLATFORM_FULL: "<<tgt.platform>><< "-{}".format(tgt.platform_version) if tgt.platform_version >>"
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -516,7 +516,7 @@ jobs:
         echo "SNAPSHOT_TAG=${tag}" >> $GITHUB_ENV
 
     - name: Publish docker image
-      uses: elgohr/Publish-Docker-Github-Action@2.19
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         PKG_PLATFORM_FULL: "linux-x86_64"
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -539,7 +539,7 @@ jobs:
         echo "CLI_VERSION=${ver}" >> $GITHUB_ENV
 
     - name: Publish docker image
-      uses: elgohr/Publish-Docker-Github-Action@2.19
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         PKG_PLATFORM_FULL: "linux-x86_64"
       with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore