### PR TITLE
cloud login: Obtain long-lived secret key explicitly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,6 +881,7 @@ dependencies = [
  "fn-error-context",
  "fs-err",
  "futures-util",
+ "gethostname",
  "hex",
  "humantime 2.1.0",
  "humantime-serde",
@@ -1347,6 +1348,16 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a329e22866dd78b35d2c639a4a23d7b950aeae300dfd79f4fb19f74055c2404"
+dependencies = [
+ "libc",
+ "windows",
 ]
 
 [[package]]
@@ -3734,6 +3745,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ tokio = {version="1.23.0",features=[
 ]}
 dissimilar = "1.0.6"
 notify = "5.0.0"
+gethostname = "0.4.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -7,7 +7,8 @@ use tokio::time::sleep;
 use anyhow::Context;
 use fs_err as fs;
 
-use crate::cloud::client::{cloud_config_dir, cloud_config_file, CloudClient, CloudConfig};
+use crate::cloud::client::{cloud_config_dir, cloud_config_file, CloudClient, CloudConfig, ErrorResponse};
+use crate::cloud::secret_keys::{CreateSecretKeyInput, SecretKey};
 use crate::cloud::options;
 use crate::commands::ExitCode;
 use crate::options::CloudOptions;
@@ -27,16 +28,48 @@ struct UserSession {
     auth_url: String,
 }
 
+#[derive(Debug, serde::Deserialize)]
+struct User {
+    id: String,
+    name: String,
+    full_name: Option<String>,
+    github_handle: Option<String>,
+
+    #[serde(with="humantime_serde")]
+    tos_agreement_date: Option<std::time::SystemTime>,
+}
+
 pub fn login(_c: &options::Login, options: &CloudOptions) -> anyhow::Result<()> {
-    do_login(&CloudClient::new(options)?)
+    let mut client = CloudClient::new(options)?;
+    do_login(&mut client)
 }
 
 #[tokio::main]
-pub async fn do_login(client: &CloudClient) -> anyhow::Result<()> {
+pub async fn do_login(client: &mut CloudClient) -> anyhow::Result<()> {
     _do_login(client).await
 }
 
-pub async fn _do_login(client: &CloudClient) -> anyhow::Result<()> {
+pub async fn _do_login(client: &mut CloudClient) -> anyhow::Result<()> {
+    // See if we're already logged in.
+    let user_resp: anyhow::Result<User> = client.get("user").await;
+
+    match user_resp {
+        Ok(user) => {
+            print::success(format!(
+                "Already logged in as {}.", user.name));
+            return Ok(());
+        },
+        Err(ref err) if matches!(
+            err.downcast_ref::<ErrorResponse>(),
+            Some(ErrorResponse { code: reqwest::StatusCode::UNAUTHORIZED, .. })
+        ) => {
+            // Fallthrough.
+        },
+        Err(err) => {
+            return Err(err);
+        }
+    }
+
     let UserSession {
         id,
         auth_url,
@@ -60,14 +93,30 @@ pub async fn _do_login(client: &CloudClient) -> anyhow::Result<()> {
                 auth_url: _,
                 token: Some(secret_key),
             }) => {
+                // `token` is a short-lived secret key, obtain a
+                // non-expiring secret key from the secretkeys/ API now.
+                client.set_secret_key(Some(&secret_key))?;
+                let hostname = gethostname::gethostname();
+                let key: SecretKey = client.post("secretkeys/", &CreateSecretKeyInput{
+                    name: Some(format!("CLI @ {hostname:#?}")),
+                    description: None,
+                    scopes: None,
+                    ttl: None,
+                }).await?;
+
                 write_json(
                     &cloud_config_file(&client.profile)?,
                     "cloud config",
                     &CloudConfig {
-                        secret_key: Some(secret_key),
+                        secret_key: key.secret_key,
                     },
                 )?;
-                print::success("Successfully authenticated to EdgeDB Cloud.");
+                client.set_secret_key(None)?;
+
+                let user: User = client.get("user").await?;
+                print::success(format!(
+                    "Successfully logged in to EdgeDB Cloud as {}.",
+                    user.name));
                 return Ok(());
             }
             Err(e) => print::warn(format!(

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -30,13 +30,7 @@ struct UserSession {
 
 #[derive(Debug, serde::Deserialize)]
 struct User {
-    id: String,
     name: String,
-    full_name: Option<String>,
-    github_handle: Option<String>,
-
-    #[serde(with="humantime_serde")]
-    tos_agreement_date: Option<std::time::SystemTime>,
 }
 
 pub fn login(_c: &options::Login, options: &CloudOptions) -> anyhow::Result<()> {

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -259,6 +259,11 @@ y4u6fdOVhgIhAJ4pJLfdoWQsHPUOcnVG5fBgdSnoCJhGQyuGyp+NDu1q
         Ok(())
     }
 
+    pub fn set_secret_key(&mut self, key: Option<&String>) -> anyhow::Result<()> {
+        self.options_secret_key = key.cloned();
+        self.reinit()
+    }
+
     pub fn ensure_authenticated(&self) -> anyhow::Result<()> {
         if self.is_logged_in {
             Ok(())

--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -234,7 +234,7 @@ pub fn prompt_cloud_login(client: &mut CloudClient) -> anyhow::Result<()> {
         "You're not authenticated to the EdgeDB Cloud yet, login now?",
     );
     if q.default(true).ask()? {
-        crate::cloud::auth::do_login(&client)?;
+        crate::cloud::auth::do_login(client)?;
         client.reinit()?;
         client.ensure_authenticated()?;
         Ok(())

--- a/src/cloud/secret_keys.rs
+++ b/src/cloud/secret_keys.rs
@@ -16,27 +16,27 @@ use crate::question;
 use crate::print::{self, Highlight};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
-struct SecretKey {
-    id: String,
-    name: Option<String>,
-    description: Option<String>,
-    scopes: Vec<String>,
+pub struct SecretKey {
+    pub id: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub scopes: Vec<String>,
 
     #[serde(with="humantime_serde")]
-    created_on: std::time::SystemTime,
+    pub created_on: std::time::SystemTime,
 
     #[serde(with = "humantime_serde")]
-    expires_on: Option<std::time::SystemTime>,
+    pub expires_on: Option<std::time::SystemTime>,
 
-    secret_key: Option<String>,
+    pub secret_key: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize)]
-struct CreateSecretKeyInput {
-    name: Option<String>,
-    description: Option<String>,
-    scopes: Option<Vec<String>>,
-    ttl: Option<String>,
+pub struct CreateSecretKeyInput {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub scopes: Option<Vec<String>>,
+    pub ttl: Option<String>,
 }
 
 pub fn main(cmd: &SecretKeyCommand, options: &CloudOptions) -> anyhow::Result<()> {
@@ -135,7 +135,7 @@ pub async fn _do_create(c: &options::CreateSecretKey, client: &CloudClient) -> a
         Some(s) => Some(s),
     };
 
-    let key: SecretKey = client.post("secretkeys/", &params).await?;
+    let key: SecretKey = create_secret_key(client, &params).await?;
 
     if c.json {
         println!("{}", serde_json::to_string_pretty(&key)?);
@@ -153,6 +153,10 @@ pub async fn _do_create(c: &options::CreateSecretKey, client: &CloudClient) -> a
     }
 
     Ok(())
+}
+
+pub async fn create_secret_key(client: &CloudClient, params: &CreateSecretKeyInput) -> anyhow::Result<SecretKey> {
+   client.post("secretkeys/", params).await
 }
 
 pub fn revoke(c: &options::RevokeSecretKey, options: &CloudOptions) -> anyhow::Result<()> {


### PR DESCRIPTION
The CLI auth cycle returns a short-lived key which should be used to
obtain a proper long-lived secret key if necessary, so do just that.

Also, avoid re-logging-in if a valid secret key is already present.  We
might need to consider adding `--force` to initiate a new login (or just
recommend doing `edgedb cloud logout` to force login).