### PR TITLE
Print credentials path if found

### DIFF
--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -107,7 +107,7 @@ pub fn show_ui(options: &Options, args: &UI) -> anyhow::Result<()> {
             Ok(_) => {
                 print::success("Opening URL in browser:");
                 println!("{}", url);
-                if let Some(path) = options.conn_options.credentials_file {
+                if let Some(path) = &options.conn_options.credentials_file {
                     println!("See login credentials at {path:?}");
                 }
                 Ok(())

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -107,6 +107,9 @@ pub fn show_ui(options: &Options, args: &UI) -> anyhow::Result<()> {
             Ok(_) => {
                 print::success("Opening URL in browser:");
                 println!("{}", url);
+                if let Some(path) = options.conn_options.credentials_file {
+                    println!(format!("See login credentials at {path:?}"));
+                }
                 Ok(())
             }
             Err(e) => {

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -108,7 +108,7 @@ pub fn show_ui(options: &Options, args: &UI) -> anyhow::Result<()> {
                 print::success("Opening URL in browser:");
                 println!("{}", url);
                 if let Some(path) = options.conn_options.credentials_file {
-                    println!(format!("See login credentials at {path:?}"));
+                    println!("See login credentials at {path:?}");
                 }
                 Ok(())
             }


### PR DESCRIPTION
I've noticed that the UI in version 3.0 first goes to a login screen (well, after telling the browser that the address can be trusted) and took me a bit of time to find my credentials when I first encountered the login screen.