### PR TITLE
restore: add usage example with the database name

### DIFF
--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -349,6 +349,10 @@ pub struct Dump {
 }
 
 #[derive(EdbClap, Clone, Debug)]
+#[clap(override_usage(
+    "edgedb restore [OPTIONS] <path>\n    \
+     edgedb restore -d <database-name> <path>"
+))]
 pub struct Restore {
     /// Path to file (or directory in case of `--all`) to read dump from.
     /// Use dash `-` to read from stdin

--- a/src/options.rs
+++ b/src/options.rs
@@ -69,6 +69,7 @@ pub struct ConnectionOptions {
     /// Path to JSON file to read credentials from
     #[clap(long, help_heading=Some(CONN_OPTIONS_GROUP))]
     #[clap(conflicts_with_all=&["dsn", "instance"])]
+    #[clap(hide=true)]
     pub credentials_file: Option<PathBuf>,
 
     /// Host of the EdgeDB instance


### PR DESCRIPTION
Also removes `--credentials-file` from the shortlist of connection options.

Fixes #1025

New usage is:
```
Restore a database backup from file

USAGE:
    edgedb restore [OPTIONS] <path>
    edgedb restore -d <database-name> <path>

ARGS:
    <path>    Path to file (or directory in case of --all) to read dump from. Use dash
              - to read from stdin

OPTIONS:
        --all        Restore all databases and the server configuration. path is a
                     directory in this case
    -v, --verbose    Verbose output
    -h, --help       Print help information

CONNECTION OPTIONS (`edgedb --help-connect` to see the full list):
    -I, --instance <instance>    Local instance name created with edgedb instance create
                                 to connect to (overrides host and port)
        --dsn <dsn>              DSN for EdgeDB to connect to (overrides all other options
                                 except password)
```