### PR TITLE
Hide `--all-profiles` from `edgedb cloud logout`

### DIFF
--- a/src/cloud/options.rs
+++ b/src/cloud/options.rs
@@ -29,6 +29,7 @@ pub struct Login {
 pub struct Logout {
     /// Logout from all Cloud profiles
     #[clap(long)]
+    #[clap(hide=true)]
     pub all_profiles: bool,
 
     /// Force destroy even if instance is referred to by a project


### PR DESCRIPTION
The profile options are not quite ready and are hidden elsewhere.
