### PR TITLE
project init: show why later version is installed

### DIFF
--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -770,6 +770,13 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
     echo!("Checking EdgeDB versions...");
 
     let (ver_query, pkg) = ask_version(options)?;
+    if let Some(filter) = &ver_query.version {
+        if !filter.matches_exact(&pkg.version.specific()) {
+            echo!("Latest version compatible with the specification",
+                  "\""; filter; "\"",
+                  "is", pkg.version.emphasize());
+        }
+    }
 
     match &inst_name {
         InstanceName::Cloud { org_slug, name } => {


### PR DESCRIPTION
Fixes #1012

Looks like this:
```
$ ~/edgedb project init --server-version=2.3
No `edgedb.toml` found in `/home/admin/project1` or above
Do you want to initialize a new project? [Y/n]
> Y
Specify the name of EdgeDB instance to use with this project [default: project1]:
> project1
Checking EdgeDB versions...
Latest version compatible with the specification "2.3" is 2.15+75c3494
┌────────────────────────┬──────────────────────────────────┐
│ Project directory      │ /home/admin/project1             │
│ Project config         │ /home/admin/project1/edgedb.toml │
│ Schema dir (non-empty) │ /home/admin/project1/dbschema    │
│ Installation method    │ portable package                 │
│ Version                │ 2.15+75c3494                     │
│ Instance name          │ project1                         │
└────────────────────────┴──────────────────────────────────┘
```