### PR TITLE
macos: Add `LSBackgroundOnly` key to plist

### DIFF
--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -120,6 +120,9 @@ fn plist_data(name: &str, info: &InstanceInfo) -> anyhow::Result<String> {
          <false/>
     </dict>
 
+    <key>LSBackgroundOnly</key>
+    <true/>
+
     {sockets}
 
 </dict>


### PR DESCRIPTION
This should suppress unintended notifications by MacOS.

Fixes #1054