### PR TITLE
Fix --admin parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.5.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=optimistic#4f6a069c54682582463c0d9899ab11ea2197d38c"
+source = "git+https://github.com/edgedb/edgedb-rust/#81ca77bd3f2d8f79a0e2112c274dbb14df096f35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.4.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=optimistic#4f6a069c54682582463c0d9899ab11ea2197d38c"
+source = "git+https://github.com/edgedb/edgedb-rust/#81ca77bd3f2d8f79a0e2112c274dbb14df096f35"
 dependencies = [
  "bytes",
 ]
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.5.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=optimistic#4f6a069c54682582463c0d9899ab11ea2197d38c"
+source = "git+https://github.com/edgedb/edgedb-rust/#81ca77bd3f2d8f79a0e2112c274dbb14df096f35"
 dependencies = [
  "bigdecimal",
  "bitflags 2.3.1",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.4.0"
-source = "git+https://github.com/edgedb/edgedb-rust/?branch=optimistic#4f6a069c54682582463c0d9899ab11ea2197d38c"
+source = "git+https://github.com/edgedb/edgedb-rust/#81ca77bd3f2d8f79a0e2112c274dbb14df096f35"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2018"
 
 [dependencies]
 edgeql-parser = {git = "https://github.com/edgedb/edgedb"}
-edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust/", features=["all-types"], branch="optimistic"}
-edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust/", branch="optimistic"}
-edgedb-errors = {git = "https://github.com/edgedb/edgedb-rust/", branch="optimistic"}
-edgedb-tokio = {git = "https://github.com/edgedb/edgedb-rust/", features=["admin_socket", "unstable"], branch="optimistic"}
+edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust/", features=["all-types"]}
+edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust/"}
+edgedb-errors = {git = "https://github.com/edgedb/edgedb-rust/"}
+edgedb-tokio = {git = "https://github.com/edgedb/edgedb-rust/", features=["admin_socket", "unstable"]}
 snafu = {version="0.7.0", features=["backtraces"]}
 anyhow = "1.0.23"
 bytes = "1.0.1"


### PR DESCRIPTION
This mostly errors out suggesting `--unix-path` but, for named local instances it also allows to connect to them using admin socket easily.

Fixes #1057

Relies on edgedb/edgedb-rust#251
Note to myself: change Cargo.toml to point to the master branch.