### PR TITLE
Add `version` to server info option

### DIFF
--- a/src/portable/info.rs
+++ b/src/portable/info.rs
@@ -48,6 +48,14 @@ pub fn info(options: &Info) -> anyhow::Result<()> {
                 }
 
             }
+            "version" => {
+                let version = inst.version()
+                if options.json {
+                    println!("{}", serde_json::to_string(version)?);
+                } else {
+                    println!("{}", version);
+                }
+            }
             _ => unreachable!(),
         }
     } else if options.json {

--- a/src/portable/info.rs
+++ b/src/portable/info.rs
@@ -49,7 +49,7 @@ pub fn info(options: &Info) -> anyhow::Result<()> {
 
             }
             "version" => {
-                let version = inst.version()
+                let version = &inst.version;
                 if options.json {
                     println!("{}", serde_json::to_string(version)?);
                 } else {

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -543,6 +543,7 @@ pub struct Info {
 
     #[clap(long, possible_values=&[
         "bin-path",
+        "version",
     ][..])]
     /// Get specific value:
     ///

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -547,6 +547,7 @@ pub struct Info {
     /// Get specific value:
     ///
     /// * `bin-path` -- Path to the server binary
+    /// * `version` -- Server version
     pub get: Option<String>,
 }
 

--- a/tests/portable_smoke.rs
+++ b/tests/portable_smoke.rs
@@ -38,6 +38,26 @@ fn install() {
         .context("server-info", "show info about just installed server")
         .success();
 
+    Command::new("edgedb")
+        .arg("server").arg("info").arg("--get").arg("bin-path").arg("--latest")
+        .assert()
+        .context("server-info", "show binary parth")
+        .success()
+        .stdout(predicates::str::contains("edgedb-server"));
+
+    // TODO check output somehow
+    Command::new("edgedb")
+        .arg("server").arg("info").arg("--get").arg("version").arg("--latest")
+        .assert()
+        .context("server-info", "show server version")
+        .success();
+
+    // TODO check output somehow
+    Command::new("edgedb")
+        .arg("server").arg("info").arg("--json").arg("--get").arg("version").arg("--latest")
+        .assert()
+        .context("server-info", "show server version")
+        .success();
 
     Command::new("edgedb")
         .arg("server").arg("list-versions")


### PR DESCRIPTION
Want to add the server version in the `setup-edgedb` GitHub action and instead of needing to parse the JSON output, I thought it would be easier to add a `--get version` option to the `server info` command.

I didn't see any tests for bin-path, but if you can help point me at a good place for tests, I'm happy to add them!