### PR TITLE
Handle missing shared tests submod

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -87,7 +87,8 @@ fn main() {
         "cargo:rerun-if-changed={}",
         connection_testcases.to_str().unwrap()
     );
-    let connection_testcases = fs::read_to_string(connection_testcases).unwrap();
+    let connection_testcases = fs::read_to_string(connection_testcases)
+        .expect("Could not find connection test cases: Ensure git submodules are included in your checkout.");
     let connection_testcases: Value = serde_json::from_str(&connection_testcases).unwrap();
     let empty_map = Map::new();
     write!(output, "

--- a/build.rs
+++ b/build.rs
@@ -80,17 +80,12 @@ fn main() {
         .join("shared-client-testcases");
 
     let connection_testcases = testcases.join("connection_testcases.json");
-
-    if !testcases.exists() || !connection_testcases.exists() {
-        eprintln!("Warning: Shared test git submodule is missing: ensure git checkout includes submodules with --recurse-submodules");
-        return;
-    }
-    
     println!(
         "cargo:rerun-if-changed={}",
         connection_testcases.to_str().unwrap()
     );
-    let connection_testcases = fs::read_to_string(connection_testcases).unwrap();
+    let connection_testcases = fs::read_to_string(connection_testcases)
+        .expect("Shared test git submodule is missing: ensure git checkout includes submodules with --recurse-submodules");
     let connection_testcases: Value = serde_json::from_str(&connection_testcases).unwrap();
     let empty_map = Map::new();
     write!(output, "

--- a/build.rs
+++ b/build.rs
@@ -83,12 +83,15 @@ fn main() {
     }
 
     let connection_testcases = testcases.join("connection_testcases.json");
+    if !connection_testcases.exists() {
+        return;
+    }
+    
     println!(
         "cargo:rerun-if-changed={}",
         connection_testcases.to_str().unwrap()
     );
-    let connection_testcases = fs::read_to_string(connection_testcases)
-        .expect("Could not find connection test cases: Ensure git submodules are included in your checkout.");
+    let connection_testcases = fs::read_to_string(connection_testcases).unwrap();
     let connection_testcases: Value = serde_json::from_str(&connection_testcases).unwrap();
     let empty_map = Map::new();
     write!(output, "

--- a/build.rs
+++ b/build.rs
@@ -78,12 +78,11 @@ fn main() {
     let testcases = Path::new(&root)
         .join("tests")
         .join("shared-client-testcases");
-    if !testcases.exists() {
-        return;
-    }
 
     let connection_testcases = testcases.join("connection_testcases.json");
-    if !connection_testcases.exists() {
+
+    if !testcases.exists() || !connect_testcases.exists() {
+        eprintln!("Warning: Shared test git submodule is missing: ensure git checkout includes submodules with --recurse-submodules");
         return;
     }
     

--- a/build.rs
+++ b/build.rs
@@ -81,7 +81,7 @@ fn main() {
 
     let connection_testcases = testcases.join("connection_testcases.json");
 
-    if !testcases.exists() || !connect_testcases.exists() {
+    if !testcases.exists() || !connection_testcases.exists() {
         eprintln!("Warning: Shared test git submodule is missing: ensure git checkout includes submodules with --recurse-submodules");
         return;
     }


### PR DESCRIPTION
The generic message you get isn't helpful for debugging _why_ the build failed.