### PR TITLE
Fix failing tests

### DIFF
--- a/tests/func/configure.rs
+++ b/tests/func/configure.rs
@@ -24,6 +24,9 @@ fn configure_all_parameters() {
             FILTER .name != 'id' AND NOT .is_internal
                 # `force_database_error` should not be exposed
                 AND .name != 'force_database_error'
+                # xxx_* configs temporarily exist during the development of Auth
+                # Delete this after https://github.com/edgedb/edgedb/pull/6014
+                AND .name not like 'xxx_%'
         "###)
         .assert().success();
     let out = String::from_utf8(cmd.get_output().stdout.clone()).unwrap();
@@ -64,6 +67,9 @@ fn configure_all_parameters() {
             FILTER .is_system AND .target.name[:5] = 'cfg::'
                 # `force_database_error` should not be exposed
                 AND .name != 'force_database_error'
+                # xxx_* configs temporarily exist during the development of Auth
+                # Delete this after https://github.com/edgedb/edgedb/pull/6014
+                AND .name not like 'xxx_%'
         "###)
         .assert().success();
     let out = String::from_utf8(cmd.get_output().stdout.clone()).unwrap();

--- a/tests/func/migrations.rs
+++ b/tests/func/migrations.rs
@@ -496,13 +496,11 @@ fn error() -> anyhow::Result<()> {
         .env("NO_COLOR", "1")
         .assert().code(1)
         .stderr(ends_with(
-r###"error: Unexpected keyword 'create'
+r###"error: Unexpected keyword 'CREATE'
   ┌─ tests/migrations/db1/error/bad.esdl:3:9
   │
 3 │         create property text -> str;
-  │         ^^^^^^ Use a different identifier or quote the name with backticks: `create`
-  │
-  = Token 'create' is a reserved keyword and cannot be used as an identifier
+  │         ^^^^^^ error
 
 edgedb error: cannot proceed until .esdl files are fixed
 "###));
@@ -703,11 +701,13 @@ fn eof_err() -> anyhow::Result<()> {
         .arg("--schema-dir=tests/migrations/db_eof_err")
         .env("NO_COLOR", "1")
         .assert().code(1)
-        .stderr(ends_with(r###"error: Unexpected end of file
-  ┌─ tests/migrations/db_eof_err/default.esdl:9:19
-  │
-9 │ alias default::Foo
-  │                   ^ error
+        .stderr(ends_with(r###"error: Missing '{'
+   ┌─ tests/migrations/db_eof_err/default.esdl:9:19
+   │  
+ 9 │   alias default::Foo
+   │ ╭──────────────────^
+10 │ │ 
+   │ ╰^ error
 
 edgedb error: cannot proceed until .esdl files are fixed
 "###));


### PR DESCRIPTION
With the latest EdgeQL parser in 4.0, some of the error messages in tests are outdated.