### PR TITLE
Add question and progress bar to dump

### DIFF
--- a/src/commands/dump.rs
+++ b/src/commands/dump.rs
@@ -1,17 +1,19 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
+use indicatif::{ProgressBar, HumanBytes, ProgressStyle};
 use tokio::fs;
 use tokio::io::{self, AsyncWrite, AsyncWriteExt};
-use sha1::{Digest};
+use sha1::Digest;
 
-use tokio_stream::{StreamExt};
+use tokio_stream::StreamExt;
 
 use crate::commands::Options;
 use crate::commands::list_databases::get_databases;
 use crate::commands::parser::{Dump as DumpOptions, DumpFormat};
 use crate::connect::Connection;
 use crate::platform::tmp_file_name;
+use crate::question::Confirm;
 
 
 type Output = Box<dyn AsyncWrite + Unpin + Send>;
@@ -79,6 +81,16 @@ pub async fn dump(cli: &mut Connection, general: &Options,
 async fn dump_db(cli: &mut Connection, _options: &Options, filename: &Path)
     -> Result<(), anyhow::Error>
 {
+    let dbname = cli.database().to_string();
+    let question = Confirm::new(format!("Start dump for database {dbname}?"));
+    match question.ask()? {
+        true => println!("Starting dump for {dbname}..."),
+        false => {
+            println!("Skipped dump for {dbname}.\n");
+            return Ok(())
+        }
+    };
+
     let (mut output, guard) = Guard::open(filename).await?;
     output.write_all(
         b"\xFF\xD8\x00\x00\xD8EDGEDB\x00DUMP\x00\
@@ -88,47 +100,47 @@ async fn dump_db(cli: &mut Connection, _options: &Options, filename: &Path)
     let (header, mut blocks) = cli.dump().await?;
 
     // this is ensured because length in the protocol is u32 too
-    assert!(header.data.len() <= u32::max_value() as usize);
+    assert!(header.data.len() <= u32::MAX as usize);
 
     let mut header_buf = Vec::with_capacity(25);
 
     header_buf.push(b'H');
-    header_buf.extend(
-        &sha1::Sha1::new_with_prefix(&header.data).finalize()[..]);
-    header_buf.extend(
-        &(header.data.len() as u32).to_be_bytes()[..]);
+    header_buf.extend(&sha1::Sha1::new_with_prefix(&header.data).finalize()[..]);
+    header_buf.extend(&(header.data.len() as u32).to_be_bytes()[..]);
     output.write_all(&header_buf).await?;
     output.write_all(&header.data).await?;
 
+    let bar = ProgressBar::new_spinner();
+    let mut processed = 0;
+
     while let Some(packet) = blocks.next().await.transpose()? {
+        let packet_length = packet.data.len();
+        bar.tick();
+        processed += packet_length;
+        bar.set_message(format!("Database {dbname} dump: {} processed.", HumanBytes(processed as u64)));
+        bar.message();
+        
         // this is ensured because length in the protocol is u32 too
-        assert!(packet.data.len() <= u32::max_value() as usize);
+        assert!(packet_length <= u32::MAX as usize);
 
         header_buf.truncate(0);
         header_buf.push(b'D');
-        header_buf.extend(
-            &sha1::Sha1::new_with_prefix(&packet.data).finalize()[..]);
-        header_buf.extend(
-            &(packet.data.len() as u32).to_be_bytes()[..]);
+        header_buf.extend(&sha1::Sha1::new_with_prefix(&packet.data).finalize()[..]);
+        header_buf.extend(&(packet_length as u32).to_be_bytes()[..]);
         output.write_all(&header_buf).await?;
         output.write_all(&packet.data).await?;
     }
     guard.commit().await?;
+    bar.abandon_with_message(format!("Finished dump for {dbname}. Total size: {}", HumanBytes(processed as u64)));
     Ok(())
 }
 
 pub async fn dump_all(cli: &mut Connection, options: &Options, dir: &Path)
     -> Result<(), anyhow::Error>
 {
-    let databases: Vec<_> = get_databases(cli).await?;
-    let config = cli.query_required_single::<String, _>(
-        "DESCRIBE SYSTEM CONFIG",
-        &(),
-    ).await?;
-    let roles = cli.query_required_single::<String, _>(
-        "DESCRIBE ROLES",
-        &(),
-    ).await?;
+    let databases = get_databases(cli).await?;
+    let config: String = cli.query_required_single("DESCRIBE SYSTEM CONFIG", &()).await?;
+    let roles: String = cli.query_required_single("DESCRIBE ROLES", &()).await?;
 
     fs::create_dir_all(dir).await?;
 


### PR DESCRIPTION
This adds a question before doing a database dump along with a spinner bar that updates each time a package comes in, which is 10MB at a time.

I did some looking around beforehand to see if there is any way to get the total database size and as far as I can tell there isn't, and even with pg_database_size it adds a performance penalty (quote from Elvis 3 years ago):

> The concern here is that pg_database_size is basically just a loop over a directory with a bunch of stat calls. It's not cached or updated/maintained by postgres.  Hence, on somewhat slow (read: cloud) storage with a bunch of tables you can easily add tens of milliseconds of latency penalty per statement.

But a spinner bar is much better than the current behavior which just starts the dump and displays nothing until it's done.

The prompt happens per database so requires typing y each time but also adds the option to dump some and not others which is pretty nice. We could also add another flag like --non-interactive if we think users might need to use --all and not deal with a prompt...or just remove the question and have the spinning bar.

```
     Running `target\debug\edgedb.exe dump --all --format=dir somedir`
Connecting to EdgeDB instance at localhost:10704...
Connecting to EdgeDB instance at localhost:10704...
Start dump for database edgedb? [y/n]
> n
Skipped dump for edgedb.

Connecting to EdgeDB instance at localhost:10704...
Start dump for database empty_db? [y/n]
> y
Starting dump for new_thing...
  Finished dump for empty_db. Total size: 0B
```

Also changes u32::max_value() to u32::MAX as the method is set to be deprecated: https://doc.rust-lang.org/std/primitive.u32.html#method.max_value