### PR TITLE
Dump progress bar

### DIFF
--- a/src/commands/dump.rs
+++ b/src/commands/dump.rs
@@ -88,7 +88,7 @@ async fn dump_db(cli: &mut Connection, _options: &Options, filename: &Path)
     let (header, mut blocks) = cli.dump().await?;
 
     // this is ensured because length in the protocol is u32 too
-    assert!(header.data.len() <= u32::max_value() as usize);
+    assert!(header.data.len() <= u32::MAX as usize);
 
     let mut header_buf = Vec::with_capacity(25);
 
@@ -102,7 +102,7 @@ async fn dump_db(cli: &mut Connection, _options: &Options, filename: &Path)
 
     while let Some(packet) = blocks.next().await.transpose()? {
         // this is ensured because length in the protocol is u32 too
-        assert!(packet.data.len() <= u32::max_value() as usize);
+        assert!(packet.data.len() <= u32::MAX as usize);
 
         header_buf.truncate(0);
         header_buf.push(b'D');


### PR DESCRIPTION
This adds a spinner bar when doing a database dump that updates each time a package comes in, which is 10MB at a time.

I did some looking around beforehand to see if there is any way to get the total database size and as far as I can tell there isn't, and even with pg_database_size it adds a performance penalty (quote from Elvis 3 years ago):

> The concern here is that pg_database_size is basically just a loop over a directory with a bunch of stat calls. It's not cached or updated/maintained by postgres. Hence, on somewhat slow (read: cloud) storage with a bunch of tables you can easily add tens of milliseconds of latency penalty per statement.

But a spinner bar is much better than the current behavior which just starts the dump and displays nothing until it's done.

Also changes u32::max_value() to u32::MAX as the method is set to be deprecated: https://doc.rust-lang.org/std/primitive.u32.html#method.max_value

I had originally added a prompt per database which looked pretty nice (output below) but it interferes with the current tests so removed that code for the moment as adding some sort of output to dump and restore is the most urgent priority. Might add something like an --interactive flag in a later PR though as being able to dump some databases and not others was nice to have.

```
     Running `target\debug\edgedb.exe dump --all --format=dir somedir`
Connecting to EdgeDB instance at localhost:10704...
Connecting to EdgeDB instance at localhost:10704...
Start dump for database edgedb? [y/n]
> n
Skipped dump for edgedb.

Connecting to EdgeDB instance at localhost:10704...
Start dump for database empty_db? [y/n]
> y
Starting dump for new_thing...
  Finished dump for empty_db. Total size: 0B
```