### PR TITLE
Output for restore

### DIFF
--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -148,9 +148,10 @@ async fn restore_db<'x>(cli: &mut Connection, _options: &Options,
     let mut input = if filename.to_str() == Some("-") {
         Box::new(io::stdin()) as Input
     } else {
-        fs::File::open(filename).await
-        .map(Box::new)
-        .with_context(file_ctx)?
+        let file = fs::File::open(filename).await.with_context(file_ctx)?;
+        let file_size = file.metadata().await?.len();
+        eprintln!("\nRestoring database from file `{}`. Total size: {:.02} MB", filename.display(), file_size as f64 / 1048576.0);
+        Box::new(file)
         as Input
     };
     let mut buf = [0u8; 17+8];

--- a/src/log_levels.rs
+++ b/src/log_levels.rs
@@ -5,7 +5,7 @@ use crate::options::{Options, Command};
 use crate::portable::options::Command as Server;
 use crate::portable::options::InstanceCommand as Instance;
 use crate::portable::project::Command as Project;
-
+use std::io::Write;
 
 pub fn init(builder: &mut env_logger::Builder, opt: &Options) {
     if opt.debug_print_frames {
@@ -26,6 +26,9 @@ pub fn init(builder: &mut env_logger::Builder, opt: &Options) {
         },
         Some(Command::Common(Common::Restore(r))) if r.verbose => {
             builder.filter_module("edgedb::restore", log::LevelFilter::Info);
+            builder.format(|buf, record| {
+                writeln!(buf, "{}", record.args())
+            });
         }
         Some(Command::Watch(w)) if w.verbose => {
             builder.filter_module("edgedb::migrations::dev_mode::ddl",


### PR DESCRIPTION
Edgedb-tokio has some env logging already set up when doing restore, and PR 278 adds some verbosity when the `--verbose` flag is used to let the user know when each block has been processed: https://github.com/edgedb/edgedb-rust/pull/278

The env_logger output is pretty noisy though and can be filtered on the edgedb-cli side to only output the args instead of also including the timestamp, module path and logging level.

Another commit adds the size of the file used to restore.

All in all this results in an output like this when `--verbose` is used (and once the edgedb-tokio PR is merged):

```
Connecting to EdgeDB instance at localhost:10704...

Restoring database from file `filename`. Total size: 234.37 MB
Block 1 processed: 10.00 MB restored
Block 2 processed: 20.00 MB restored
...Block 24 processed: 234.36 MB restored
Database restored in 10.4409124s
```

I think it makes sense to at least indicate the file size even without `--verbose`, so that part outputs regardless of the flag with the following output:

```
Connecting to EdgeDB instance at localhost:10704...

Restoring database from file `something`. Total size: 234.37 MB
```