### PR TITLE
Pass on name in Windows so won't be prompted twice

### DIFF
--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -208,11 +208,12 @@ pub fn create_instance(options: &options::Create, name: &str,
     let wsl = ensure_wsl()?;
 
     let inner_options = options::Create {
+        name: Some(InstanceName::Local(name.to_string())),
         port: Some(port),
         ..options.clone()
     };
     wsl.edgedb()
-        .arg("instance").arg("create").arg(name).args(&inner_options)
+        .arg("instance").arg("create").args(&inner_options)
         .run()?;
 
     if let Some(dir) = paths.credentials.parent() {

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -212,7 +212,7 @@ pub fn create_instance(options: &options::Create, name: &str,
         ..options.clone()
     };
     wsl.edgedb()
-        .arg("instance").arg("create").args(&inner_options)
+        .arg("instance").arg("create").arg(name).args(&inner_options)
         .run()?;
 
     if let Some(dir) = paths.credentials.parent() {


### PR DESCRIPTION
At the moment the CLI prompts the user twice on Windows when using instance create without an instance name indicated up front (e.g. `instance create --version 2.6`) due to the following flow:

* Asks for a name here https://github.com/edgedb/edgedb-cli/blob/master/src/portable/create.rs#L87
* Checks if on Windows, calls windows::create_instance() if so: https://github.com/edgedb/edgedb-cli/blob/master/src/portable/create.rs#L113
* Starts a new process here but does not pass on the name: https://github.com/edgedb/edgedb-cli/blob/master/src/portable/windows.rs#L215
* The command for the process itself is initiated here two functions deeper: https://github.com/edgedb/edgedb-cli/blob/master/src/process.rs#L354

And without the name argument passed on it will then prompt the user a second time for the name of the instance.

Also looks like https://github.com/edgedb/edgedb-cli/pull/1135 will need to be merged first to have the tests pass.