### PR TITLE
Add `instance create` options for compute and storage size

### DIFF
--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -85,11 +85,19 @@ pub struct Version {
 }
 
 #[derive(Debug, serde::Serialize)]
+pub struct CloudInstanceResourceRequest {
+    pub name: String,
+    pub value: u16,
+}
+
+#[derive(Debug, serde::Serialize)]
 pub struct CloudInstanceCreate {
     pub name: String,
     pub org: String,
     pub version: String,
     pub region: Option<String>,
+    pub requested_resources: Option<Vec<CloudInstanceResourceRequest>>,
+    pub tier: Option<String>,
     // #[serde(skip_serializing_if = "Option::is_none")]
     // pub default_database: Option<String>,
     // #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -190,10 +190,57 @@ fn create_cloud(cmd: &Create, org_slug: &str, name: &str, client: &cloud::client
     )?;
 
     let server_ver = cloud::versions::get_version(&query, client)?;
+    let tier = if cmd.free_tier {
+        String::from("Free")
+    } else {
+        String::from("Pro")
+    };
+
+    let compute_size = cmd.compute_size.unwrap_or(1);
+    let storage_size = cmd.storage_size.unwrap_or(20);
+
+    let req_resources = match cmd.free_tier {
+        true => {
+            None
+        },
+        false => {
+            Some(vec![
+                cloud::ops::CloudInstanceResourceRequest{
+                    name: "compute".to_string(),
+                    value: compute_size,
+                },
+                cloud::ops::CloudInstanceResourceRequest{
+                    name: "storage".to_string(),
+                    value: storage_size,
+                },
+            ])
+        },
+    };
+
+    let resources_display = if req_resources.is_some() {
+        format!(
+            "\nCompute Size: {} compute unit{}\
+            \nStorage Size: {} gigabyte{}",
+            compute_size,
+            if compute_size == 1 {""} else {"s"},
+            storage_size,
+            if storage_size == 1 {""} else {"s"},
+        )
+    } else {
+        format!(
+            "\nCompute Size: 1/4 compute units\
+            \nStorage Size: 1 gigabyte",
+        )
+    };
 
     if !cmd.non_interactive && !question::Confirm::new(format!(
-        "This will create a new EdgeDB cloud instance with the following parameters: \
-        \n\n Region: {region}\n Server Version: {server_ver}\nIs this acceptable?",
+        "This will create a new EdgeDB cloud instance with the following parameters:\
+        \n\
+        \nTier: {tier}\
+        \nRegion: {region}\
+        \nServer Version: {server_ver}\
+        {resources_display}\
+        \n\nIs this acceptable?",
     )).ask()? {
         return Ok(());
     }
@@ -203,6 +250,8 @@ fn create_cloud(cmd: &Create, org_slug: &str, name: &str, client: &cloud::client
         org: org_slug.to_string(),
         version: server_ver.to_string(),
         region: Some(region),
+        requested_resources: req_resources,
+        tier: Some(tier),
     };
     cloud::ops::create_cloud_instance(&client, &request)?;
     echo!(

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -171,6 +171,20 @@ pub struct Create {
     #[clap(long)]
     pub region: Option<String>,
 
+    /// Request a free tier instance.
+    #[clap(long, conflicts_with_all=&["compute_size", "storage_size"])]
+    pub free_tier: bool,
+
+    /// The size of compute to be allocated for the Cloud instance in
+    /// Compute Units.
+    #[clap(long, value_name="number")]
+    pub compute_size: Option<u16>,
+
+    /// The size of storage to be allocated for the Cloud instance in
+    /// Gigabytes.
+    #[clap(long, value_name="GiB")]
+    pub storage_size: Option<u16>,
+
     /// Deprecated parameter, unused.
     #[clap(long, hide=true, possible_values=&["auto", "manual"][..])]
     pub start_conf: Option<StartConf>,

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -146,7 +146,7 @@ pub struct Unlink {
     #[clap(long, value_hint=ValueHint::DirPath)]
     pub project_dir: Option<PathBuf>,
 
-    /// If specified, the associated EdgeDB instance is destroyed 
+    /// If specified, the associated EdgeDB instance is destroyed
     /// using `edgedb instance destroy`.
     #[clap(long, short='D')]
     pub destroy_server_instance: bool,
@@ -690,6 +690,9 @@ fn do_init(name: &str, pkg: &PackageInfo,
             channel: q.cli_channel(),
             version: q.version,
             region: None,
+            free_tier: false,
+            compute_size: None,
+            storage_size: None,
             port: Some(port),
             start_conf: None,
             default_database: "edgedb".into(),
@@ -769,6 +772,8 @@ fn do_cloud_init(
         org: org.clone(),
         version: version.to_string(),
         region: None,
+        tier: None,
+        requested_resources: None,
     };
     crate::cloud::ops::create_cloud_instance(client, &request)?;
     let full_name = format!("{}/{}", org, name);


### PR DESCRIPTION
The new `--compute-size` and `--storage-size` options allow specifying
the amount of compute and storage respectively.  The new `--free-tier`
(exclusive with `...-size`) can be used to explicitly request a Free
tier instance.
