### PR TITLE
Fix devmode version check on 4.0

### DIFF
--- a/src/migrations/dev_mode.rs
+++ b/src/migrations/dev_mode.rs
@@ -26,8 +26,8 @@ enum Mode {
     Rebase,
 }
 
-const MINIMUM_VERSION: Lazy<ver::Filter> =
-    Lazy::new(|| "3.0-alpha.1".parse().unwrap());
+const MINIMUM_VERSION: Lazy<ver::Build> =
+    Lazy::new(|| "3.0-alpha.1+05474ea".parse().unwrap());
 
 mod ddl {  // Just for nice log filter
     use super::{execute, Connection};

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -349,11 +349,11 @@ impl Ord for Semver {
     }
 }
 
-pub async fn check_client(cli: &mut Connection, minimum_version: &Filter)
+pub async fn check_client(cli: &mut Connection, minimum_version: &Build)
     -> anyhow::Result<bool>
 {
     let ver = cli.get_version().await?;
-    return Ok(ver.is_nightly() || minimum_version.matches(&ver));
+    Ok(ver.is_nightly() || ver >= minimum_version)
 }
 
 pub fn print_version_hint(version: &Specific, ver_query: &Query) {


### PR DESCRIPTION
Fix a false alarm on 4.0 servers:

```
$ edgedb watch
Schema migration error: Dev mode is not supported on EdgeDB 4.0-alpha.3+34b6d0d. Please upgrade.
Initialized. Monitoring "...".
```

The current "filter match" works for 3.0 servers but not any more after major version bump. This PR changed to use `cmp()`