### PR TITLE
Display query history in windows

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -407,7 +407,7 @@ fn show_history(history: &History) -> Result<(), anyhow::Error> {
     cmd.stdin(Stdio::piped());
     cmd.args(items);
     let mut child = cmd.spawn()?;
-    let childin = child.stdin.as_mut().expect("stdin is piped");
+    let mut childin = child.stdin.take().expect("stdin is piped");
     for index in (0..history.len()).rev() {
         if let Some(s) = history.get(index) {
             let prefix = format!("[-{}] ", history.len() - index);

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -395,7 +395,13 @@ pub fn main(mut control: Receiver<Control>)
 fn show_history(history: &History) -> Result<(), anyhow::Error> {
     let pager = env::var("EDGEDB_PAGER")
         .or_else(|_| env::var("PAGER"))
-        .unwrap_or_else(|_| String::from("less -R"));
+        .unwrap_or_else(|_| 
+            if cfg!(windows) {
+                String::from("more.com")
+            } else {
+                String::from("less -R")
+            }
+        );
     let mut items = pager.split_whitespace();
     let mut cmd = Command::new(items.next().unwrap());
     cmd.stdin(Stdio::piped());


### PR DESCRIPTION
Another quality of life PR for Windows: it turns out that \s tries to call up `less` which doesn't exist in Windows and simply displays an error that no program can be found. Windows has its own pager called more which seems to do the trick. The one difference is that the history output stays on the console after the user is finished viewing the history but otherwise the behaviour is the same as far as I can tell.

https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/more

Also does away with the warning that has been kicking around about how dropping a reference (to the child stdin) does nothing, compared with .take() which will take by value: https://doc.rust-lang.org/std/process/struct.Child.html#structfield.stdin

```
The handle for writing to the child's standard input (stdin), if it has been captured. You might find it helpful to do

let stdin = child.stdin.take().unwrap();
to avoid partially moving the child and thus blocking yourself from calling functions on child while using stdin.
```