### PR TITLE
Fix type name typo (Float32 -> Float64)

### DIFF
--- a/src/prompt/variable.rs
+++ b/src/prompt/variable.rs
@@ -100,7 +100,7 @@ pub struct Float64;
 impl VariableInput for Float64 {
     fn type_name(&self) -> &str { "float64" }
     fn parse(&self, input: &str) -> Result<Value, Error> {
-        Ok(Value::Float32(input.parse().map_err(no_pos_err)?))
+        Ok(Value::Float64(input.parse().map_err(no_pos_err)?))
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/edgedb/edgedb-cli/issues/1145

Just a tiny typo here: parse() should be returing a Float64 for Float64, not a Float32.