### PR TITLE
Dev mode migration hints

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -54,7 +54,7 @@ pub struct Trap {}
 type SigMask = u8;
 
 #[derive(Debug, thiserror::Error)]
-#[error("interrupted")]
+#[error("Interrupted by user")]
 pub struct InterruptError(pub Signal);
 
 pub struct Interrupt {

--- a/src/migrations/migrate.rs
+++ b/src/migrations/migrate.rs
@@ -263,8 +263,8 @@ async fn fixup(cli: &mut Connection, ctx: &Context,
         match db_migration.generated_by {
             Some(MigrationGeneratedBy::DevMode) => {
                 return Err(
-                    anyhow::anyhow!("Database contains Dev mode migrations.")
-                    .hint("Use `edgedb migrate --dev-mode` or `edgedb watch`")
+                    anyhow::anyhow!("Database contains Dev mode / `edgedb watch` migrations.")
+                    .hint("Use `edgedb migration create` followed by `edgedb migrate --dev-mode`, or resume `edgedb watch`")
                 )?;
             }
             Some(MigrationGeneratedBy::DDLStatement) => {

--- a/src/watch/main.rs
+++ b/src/watch/main.rs
@@ -75,11 +75,13 @@ pub fn watch(options: &Options, _watch: &WatchCommand)
 
     runtime.block_on(ctx.do_update())?;
 
-    eprintln!("Initialized. Monitoring {:?}.", project_dir);
+    eprintln!("EdgeDB Watch initialized.");
+    eprintln!("  Hint: Use `edgedb migration create` and `edgedb migrate --dev-mode` to apply changes once done.");
+    eprintln!("Monitoring {:?}.", project_dir);
     let res = runtime.block_on(watch_loop(rx, &mut ctx));
     runtime.block_on(ctx.try_connect_and_clear_error())
         .map_err(|e| log::error!("Cannot clear error: {:#}", e)).ok();
-    return res;
+    res
 }
 
 pub async fn wait_changes(rx: &mut watch::Receiver<()>,


### PR DESCRIPTION
Resolves https://github.com/edgedb/edgedb-cli/issues/1138

Adds a hint when starting up, from:

directory> edgedb watch
⠴ connecting
Connecting to EdgeDB instance at localhost:10704...
Initialized. Monitoring "C:\\directory".

To:

directory> edgedb watch
⠴ connecting
Connecting to EdgeDB instance at localhost:10704...
EdgeDB Watch initialized.
  Hint: Use `edgedb migration create` and `edgedb migrate --dev-mode` to apply changes once done.
Monitoring "C:\\directory".

Sometimes users might hit ctrl-c instead of opening a new terminal window, so changes 

edgedb error: Interrupted

to:

edgedb error: Interrupted by user

(Just to ensure that the user is aware that they caused the interruption as opposed to *something else* being interrupted when they hit ctrl-c)


And when user tries to apply migrations with the wrong command, from:

edgedb error: Database contains Dev mode migrations.
  Hint: Use `edgedb migrate --dev-mode` or `edgedb watch`

to:

edgedb error: Database contains Dev mode / `edgedb watch` migrations.
  Hint: Use `edgedb migration create` followed by `edgedb migrate --dev-mode`, or resume `edgedb watch`



I'm also curious about why dev mode is set to quiet by default as commented in the issue. Any thoughts or other context to add while the PR is open?