### PR TITLE
Fix some fallout from clap 4 port

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -60,6 +60,8 @@ pub struct CliInstall {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[derive(clap::ValueEnum)]
+#[value(rename_all="kebab-case")]
 pub enum Shell {
     Bash,
     Elvish,
@@ -71,9 +73,7 @@ pub enum Shell {
 #[derive(clap::Args, Clone, Debug)]
 pub struct GenCompletions {
     /// Shell to print out completions for
-    #[arg(long, value_parser=[
-        "bash", "elvish", "fish", "powershell", "zsh",
-    ])]
+    #[arg(long)]
     pub shell: Option<Shell>,
 
     /// Install all completions into the prefix

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -204,7 +204,7 @@ pub enum Setting {
 
 #[derive(clap::Args, Clone, Debug, Default)]
 pub struct InputMode {
-    #[arg(value_name="mode", value_parser=["vi", "emacs"])]
+    #[arg(value_name="mode")]
     pub value: Option<repl::InputMode>,
 }
 
@@ -239,23 +239,18 @@ pub struct SettingUsize {
 
 #[derive(clap::Args, Clone, Debug)]
 pub struct Edit {
-    #[arg(trailing_var_arg=true, allow_hyphen_values=true)]
+    #[arg(trailing_var_arg=true, allow_hyphen_values=true, num_args=..2)]
     pub entry: Option<isize>,
 }
 
 #[derive(clap::Args, Clone, Debug, Default)]
 pub struct OutputFormat {
-    #[arg(value_name="mode", value_parser=
-        ["default", "json-pretty", "json", "json-lines", "tab-separated"]
-    )]
+    #[arg(value_name="mode")]
     pub value: Option<repl::OutputFormat>,
 }
 
 #[derive(clap::Args, Clone, Debug, Default)]
 pub struct PrintStats {
-    #[arg(value_parser=
-        ["off", "query", "detailed"]
-    )]
     pub value: Option<repl::PrintStats>,
 }
 

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -127,6 +127,8 @@ pub struct ListVersions {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(clap::ValueEnum)]
+#[value(rename_all="kebab-case")]
 pub enum StartConf {
     Auto,
     Manual,
@@ -170,7 +172,7 @@ pub struct Create {
     pub region: Option<String>,
 
     /// Deprecated parameter, unused.
-    #[arg(long, hide=true, value_parser=["auto", "manual"])]
+    #[arg(long, hide=true)]
     pub start_conf: Option<StartConf>,
 
     /// Default database name (created during initialization and saved in

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -31,6 +31,8 @@ pub const FAILURE_MARKER: &str = "[tx:failed]";
 
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(clap::ValueEnum)]
+#[value(rename_all="kebab-case")]
 pub enum OutputFormat {
     Default,
     Json,
@@ -40,12 +42,16 @@ pub enum OutputFormat {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(clap::ValueEnum)]
+#[value(rename_all="kebab-case")]
 pub enum InputMode {
     Vi,
     Emacs,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(clap::ValueEnum)]
+#[value(rename_all="kebab-case")]
 pub enum PrintStats {
     Off,
     Query,


### PR DESCRIPTION
Enum-valued args should not use `value_parser`, it's both redundant and
wrong, and a `ValueEnum` derive should be used instead.

Another issue is that `trailing_var_arg` now requires `num_args` to be
set explicitly, which is also an improvement as `\e 10 12` would now get
rejected properly.

Fixes: #1152
