### PR TITLE
Add hint for command to list versions

### DIFF
--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -652,7 +652,8 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
 
             let pkg = repository::get_server_package(&ver_query)?
                 .with_context(||
-                    format!("cannot find package matching {}", ver_query.display()))?;
+                    format!("cannot find package matching {}. \
+                    (Use `edgedb server list-versions` to see all available)", ver_query.display()))?;
             ver::print_version_hint(&pkg.version.specific(), &ver_query);
 
             let meth = if cfg!(windows) {
@@ -1754,7 +1755,8 @@ pub fn update_toml(
     let schema_dir = &config.project.schema_dir;
 
     let pkg = repository::get_server_package(&query)?.with_context(||
-        format!("cannot find package matching {}", query.display()))?;
+        format!("cannot find package matching {} \
+        (Use `edgedb server list-versions` to see all available)", query.display()))?;
     let pkg_ver = pkg.version.specific();
 
     let stash_dir = stash_path(&root)?;
@@ -1913,7 +1915,8 @@ fn upgrade_local(
 
     let instance_name = InstanceName::from_str(&inst.name)?;
     let pkg = repository::get_server_package(to_version)?.with_context(||
-        format!("cannot find package matching {}", to_version.display()))?;
+        format!("cannot find package matching {} \
+        (Use `edgedb server list-versions` to see all available)", to_version.display()))?;
     let pkg_ver = pkg.version.specific();
 
     if pkg_ver > inst_ver || cmd.force {

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -92,8 +92,9 @@ impl FromStr for Specific {
     type Err = anyhow::Error;
     fn from_str(value: &str) -> anyhow::Result<Specific> {
         let m = SPECIFIC.captures(value)
-            .context("unsupported version format. Examples: \
-                     `1.15`, `7.0`, `3.0-rc.1`")?;
+            .context("unsupported version format.\n\t\
+                    Examples: `1.15`, `7.0`, `4.0-rc.1`.\n\t\
+                    Use `edgedb server list-versions` to see all available versions.")?;
         let major = m.get(1).unwrap().as_str().parse()?;
         let g3 = m.get(3).map(|m| m.as_str().parse()).transpose()?;
         let minor = match m.get(2).map(|m| m.as_str()) {
@@ -120,8 +121,9 @@ impl FromStr for Filter {
                     deprecated = true;
                     m
                 }
-                None => anyhow::bail!("unsupported version format. Examples: \
-                     `1.15`, `7`, `3.0-rc.1`"),
+                None => anyhow::bail!("unsupported version format.\n\t\
+                    Examples: `1.15`, `7`, `4.0-rc.1`.\n\t\
+                    Use `edgedb server list-versions` to see all available versions."),
             }
         };
         let major = m.name("major").unwrap().as_str().parse()?;


### PR DESCRIPTION
Adds a few hints in places that there is a command to list all available versions when trying to do an upgrade. I don't see an issue for this but sometimes people on Discord don't know how to find them and I was hit with this myself in the past when trying to upgrade but didn't know the exact format (-rc3 or .rc3 or -rc-3 or any of the other combinations...)

I see five places in total which I think is all of the relevant locations.