### PR TITLE
Make "Connecting to..." line more informative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
+name = "ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3c0daaaae24df5995734b689627f8fa02101bc5bbc768be3055b66a010d7af"
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1000,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 name = "edgedb-cli"
 version = "4.1.0-dev"
 dependencies = [
+ "ansi-escapes",
  "anyhow",
  "arc-swap",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust/"}
 edgedb-errors = {git = "https://github.com/edgedb/edgedb-rust/"}
 edgedb-tokio = {git = "https://github.com/edgedb/edgedb-rust/", features=["admin_socket", "unstable"]}
 snafu = {version="0.7.0", features=["backtraces"]}
+ansi-escapes = "0.1"
 anyhow = "1.0.23"
 bytes = "1.0.1"
 blake2b_simd = "1.0.0"


### PR DESCRIPTION
Include the instance name, and, if the instance is a Cloud instance,
don't show the host name as it's not very informative.

Also, in interactive mode, erase the "Connecting to..." line once the
connection has been established for a cleaner initial look.
