### PR TITLE
rv option output on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -130,8 +130,6 @@ fn _main() -> anyhow::Result<()> {
         Default::default()
     });
 
-    log::debug!(target: "edgedb::cli", "Options: {:#?}", opt);
-
     if !is_cli_upgrade(&opt.subcommand) {
         version_check::check(opt.no_cli_update_check)?;
     }


### PR DESCRIPTION
It turns out that this Options struct is 38,000 lines(!) in length, so anyone setting their RUST_LOG to debug or finer will get hit with that every time they start the CLI before the relevant output begins to show up. Plus I can't think of a use for this output in any case.