### PR TITLE
chore(nix): initial flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.vagga
 /target
 .vscode
+
+# Nix artifacts
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,107 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698166613,
+        "narHash": "sha256-y4rdN4flxRiROqNi1waMYIZj/Fs7L2OrszFk/1ry9vU=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "b7db46f0f1751f7b1d1911f6be7daf568ad5bc65",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": []
+      },
+      "locked": {
+        "lastModified": 1698474008,
+        "narHash": "sha256-t7uGih9Q/ucsXUnb7oWbI+J24+VmhP4wGmrs+4Fbp6c=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "0087479649aab847e515e90e7f7333983dea798e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1696343447,
+        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1698336494,
+        "narHash": "sha256-sO72WDBKyijYD1GcKPlGsycKbMBiTJMBCnmOxLAs880=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "808c0d8c53c7ae50f82aca8e7df263225cf235bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
                   inherit src;
                   doCheck = false; # disable tests
                   nativeBuildInputs = [pkg-config openssl openssl.dev];
-                  buildInputs = [openssl openssl.dev] ++ lib.optionals stdenv.isDarwin [pkgslibiconv];
+                  buildInputs = [openssl openssl.dev] ++ lib.optionals stdenv.isDarwin [pkgs.libiconv];
                   OPENSSL_NO_VENDOR = "1";
                 };
               cargoArtifacts = craneLib.buildDepsOnly common;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "The EdgeDB CLI";
+  inputs = {
+    # <frameworks>
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+
+    # <app builders>
+    fenix.url = "github:nix-community/fenix";
+    fenix.inputs.nixpkgs.follows = "nixpkgs";
+    fenix.inputs.rust-analyzer-src.follows = "";
+
+    crane.url = "github:ipetkov/crane";
+    crane.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs:
+    with builtins; let
+      lib = inputs.nixpkgs.lib;
+      createPkgs = system:
+        import inputs.nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
+    in
+      with lib;
+        inputs.flake-parts.lib.mkFlake {inherit inputs;}
+        {
+          systems = ["x86_64-linux" "x86_64-darwin"];
+          perSystem = {
+            config,
+            self',
+            system,
+            inputs',
+            ...
+          }: let
+            pkgs = createPkgs system;
+            rustToolchain = with inputs.fenix.packages.${system};
+              combine [
+                stable.rustc
+                stable.cargo
+              ];
+          in {
+            packages.edgedb-cli = let
+              craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
+              pInfo = craneLib.crateNameFromCargoToml {cargoToml = ./Cargo.toml;};
+              src = pkgs.lib.cleanSourceWith {
+                src = craneLib.path ./.;
+                filter = path: type: ((builtins.match ".*tests.*" path != null) || (craneLib.filterCargoSources path type));
+              };
+              common = with pkgs;
+                pInfo
+                // {
+                  inherit src;
+                  doCheck = false; # disable tests
+                  nativeBuildInputs = [pkg-config openssl openssl.dev];
+                  buildInputs = [openssl openssl.dev] ++ lib.optionals stdenv.isDarwin [pkgslibiconv];
+                  OPENSSL_NO_VENDOR = "1";
+                };
+              cargoArtifacts = craneLib.buildDepsOnly common;
+            in
+              craneLib.buildPackage (common // {inherit cargoArtifacts;});
+            packages.default = self'.packages.edgedb-cli;
+          };
+        };
+}


### PR DESCRIPTION
I was struggling to update nixpkgs's edgedb package, so I decied to nixify this repo instead.
Why you could consider to use Nix:
1. Declarative configuration of build system and dev shell
2. Repoducable packages from any machine
3. Same developer environment for every contributor. For example, share same edgedb version(s), rust toolchain etc.
4. Make onboarding easier for new contributors, as they will not have problems with setup. All will run with few commands
5. Attract users from Nix community
6. Simplify CI setup, as it can use or share configuration from your dev shell: https://determinate.systems/posts/nix-github-actions

Right now it's already possible to build edgedb-cli package via `nix build .?submodules=1`. Result binary will be located in `./result/bin/edgedb`

Current limitations:
- There is a little inconvinience because of using git submodules. Nix requires to pass `?submodules=1` to handle this. For using in consumer flake.nix, following syntax is required:
```nix
edgedb-cli = {
  type = "git";
  url = "https://github.com/mrfoxpro/edgedb-cli.git";
  submodules = true;
  ref = "nix";
};
```
Related PR: https://github.com/NixOS/nix/pull/7862
- Tests should be adjusted to run in isolated environment. I disabled tests for now (https://github.com/MrFoxPro/edgedb-cli/blob/9e793dbba528a61612a72780c5a048796d3c162d/flake.nix#L55)

I also created draft PR with developer environment setup with edgedb-server (https://github.com/edgedb/edgedb-cli/pull/1160). Related: https://github.com/NixOS/nixpkgs/issues/179635#issuecomment-1667764435

Current used Nix libs:

**flake-parts**: framework for convinient cross-platform flake shape: https://flake.parts. Allows splitting flake to modules, also provides opportunity to confiure some usefull tools declaratively

**fenix**: convinient rust toolchain managment: https://github.com/nix-community/fenix. Allows creating single package from multiple toolchains (cargo, rustc, rustc-src, rustfmt, rust-analyzer, clippy and so on)

**crane**: https://crane.dev. Usefull tool for effecient building of Rust project. Caches cargo artifacts. 

I think it would be nice to configure integration with cachix later, so users will download cached result instead of rebuilding themselfs