### PR TITLE
Restore git URLs for edgedb-rust in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.5.1"
+source = "git+https://github.com/edgedb/edgedb-rust/#9ba86e843e8ec88140a98f9a0ef20752cf019bd0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1142,6 +1143,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.4.1"
+source = "git+https://github.com/edgedb/edgedb-rust/#9ba86e843e8ec88140a98f9a0ef20752cf019bd0"
 dependencies = [
  "bytes",
 ]
@@ -1149,6 +1151,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.6.0"
+source = "git+https://github.com/edgedb/edgedb-rust/#9ba86e843e8ec88140a98f9a0ef20752cf019bd0"
 dependencies = [
  "bigdecimal",
  "bitflags 2.4.0",
@@ -1164,6 +1167,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.5.0"
+source = "git+https://github.com/edgedb/edgedb-rust/#9ba86e843e8ec88140a98f9a0ef20752cf019bd0"
 dependencies = [
  "anyhow",
  "arc-swap",


### PR DESCRIPTION
Apparently, if you override the dependency in a local Cargo config, it
removes the URLs from `Cargo.lock`.
