### PR TITLE
Fix history (and migration) editor path

### DIFF
--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -60,7 +60,7 @@ Editing
   \s, \history              Show history
   \e, \edit [N]             Spawn $EDITOR to edit the last used query, using
                             the editor output as input in the REPL.
-                            Defaults to vi in Linux, Notepad in Windows.
+                            Defaults to vi (Notepad in Windows).
 
 Connection
   \c, \connect [DBNAME]     Connect to database DBNAME

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -58,8 +58,9 @@ Operations
 
 Editing
   \s, \history              Show history
-  \e, \edit [N]             Spawn $EDITOR to edit history entry N,
-                            then use the output as input
+  \e, \edit [N]             Spawn $EDITOR to edit the last used query, using
+                            the editor output as input in the REPL.
+                            Defaults to vi in Linux, Notepad in Windows.
 
 Connection
   \c, \connect [DBNAME]     Connect to database DBNAME

--- a/src/migrations/options.rs
+++ b/src/migrations/options.rs
@@ -33,8 +33,9 @@ pub enum MigrationCmd {
     /// Edit migration file
     ///
     /// Invokes $EDITOR on the last migration file, and then fixes
-    /// migration id after editor exits. Usually should be used for
-    /// migrations that have not been applied yet.
+    /// migration id after editor exits. Defaults to vi (Notepad
+    /// in Windows). Usually should be used for migrations that have
+    /// not been applied yet.
     Edit(MigrationEdit),
     /// Check if current schema is compatible with new EdgeDB version
     UpgradeCheck(UpgradeCheck),

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -174,14 +174,14 @@ pub fn detect_ipv6() -> bool {
 
 pub fn editor_path() -> String {
     env::var("EDGEDB_EDITOR")
-    .or_else(|_| env::var("EDITOR"))
-    .unwrap_or_else(|_| {
-        if cfg!(windows) {
-            String::from("notepad.exe")
-        } else {
-            String::from("vi")
-        }
-    })
+        .or_else(|_| env::var("EDITOR"))
+        .unwrap_or_else(|_| {
+            if cfg!(windows) {
+                String::from("notepad.exe")
+            } else {
+                String::from("vi")
+            }
+        })
 }
 
 pub async fn spawn_editor(path: &Path) -> anyhow::Result<()> {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -170,14 +170,23 @@ pub fn detect_ipv6() -> bool {
             0, // no scope id
         )
     ).is_ok()
+}
 
+pub fn editor_path() -> String {
+    env::var("EDGEDB_EDITOR")
+    .or_else(|_| env::var("EDITOR"))
+    .unwrap_or_else(|_| {
+        if cfg!(windows) {
+            String::from("notepad.exe")
+        } else {
+            String::from("vi")
+        }
+    })
 }
 
 pub async fn spawn_editor(path: &Path) -> anyhow::Result<()> {
 
-    let editor = env::var("EDGEDB_EDITOR")
-        .or_else(|_| env::var("EDITOR"))
-        .unwrap_or_else(|_| String::from("vim"));
+    let editor = editor_path();
     let mut items = editor.split_whitespace();
     let mut cmd = tokio::process::Command::new(items.next().unwrap());
     cmd.args(items);

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -434,15 +434,7 @@ fn spawn_editor(data: &str) -> Result<String, anyhow::Error> {
         .tempfile()?;
     temp_file.write_all(data.as_bytes())?;
     let temp_path = temp_file.into_temp_path();
-    let editor = env::var("EDGEDB_EDITOR")
-        .or_else(|_| env::var("EDITOR"))
-        .unwrap_or_else(|_| {
-            if cfg!(windows) {
-                String::from("notepad.exe")
-            } else {
-                String::from("vi")
-            }
-        });
+    let editor = crate::platform::editor_path();
     let mut items = editor.split_whitespace();
     let mut cmd = Command::new(items.next().unwrap());
     cmd.args(items);

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -27,6 +27,7 @@ use crate::print::style::Styler;
 use crate::highlight;
 use crate::prompt::variable::VariableInput;
 use crate::repl::{TX_MARKER, FAILURE_MARKER};
+use crate::platform::editor_path;
 
 use colorful::Colorful;
 
@@ -434,7 +435,7 @@ fn spawn_editor(data: &str) -> Result<String, anyhow::Error> {
         .tempfile()?;
     temp_file.write_all(data.as_bytes())?;
     let temp_path = temp_file.into_temp_path();
-    let editor = crate::platform::editor_path();
+    let editor = editor_path();
     let mut items = editor.split_whitespace();
     let mut cmd = Command::new(items.next().unwrap());
     cmd.args(items);


### PR DESCRIPTION
We have a command \edit or \e that pulls up an editor to change the last query in the history. It won't work on Windows unless one of the two env vars is set. Unfortunately Windows doesn't have a terminal editor anymore (apparently there used to be one called edit.exe but it's gone now) so the only possible default is pulling up Notepad which is at least better than nothing and works fine.

The second change is from vim to vi on Linux, because that looks to be the default. My WSL for example has vi but not vim, so with the change to vi it will work (doesn't work at the moment). But if vim really is a preferred default then we can keep it that way.

Later noticed that the \migration edit command also pulls up the editor so unified the editor path search into a single function and now that command works in Windows too.