### PR TITLE
Fix configure set from CLI

### DIFF
--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -1,41 +1,17 @@
+use std::fmt::Display;
+
 use edgeql_parser::helpers::{quote_string, quote_name};
 use crate::commands::Options;
 use crate::print;
 use crate::connect::Connection;
-use crate::commands::parser::{Configure, ConfigStr, ConfigBool};
-use crate::commands::parser::{AuthParameter};
+use crate::commands::parser::{Configure, ConfigStr, ListenPort, ListenAddresses, AuthParameter};
 
-
-async fn set_string(cli: &mut Connection, name: &str, value: &ConfigStr)
+async fn set(cli: &mut Connection, name: &str, cast: Option<&str>, value: impl Display)
     -> Result<(), anyhow::Error>
 {
-    print::completion(&cli.execute(
-        &format!("CONFIGURE INSTANCE SET {} := {}",
-            name, quote_string(&value.value)),
-        &(),
-    ).await?);
-    Ok(())
-}
-
-async fn set_bool(cli: &mut Connection, name: &str, value: &ConfigBool)
-    -> Result<(), anyhow::Error>
-{
-    print::completion(&cli.execute(
-        &format!("CONFIGURE INSTANCE SET {} := {}",
-            name, if value.value { "true" } else { "false" }),
-        &(),
-    ).await?);
-    Ok(())
-}
-
-async fn set_duration(cli: &mut Connection, name: &str, value: &ConfigStr)
-    -> Result<(), anyhow::Error>
-{
-    print::completion(&cli.execute(
-        &format!("CONFIGURE INSTANCE SET {} := <duration>{}",
-            name, quote_string(&value.value)),
-        &(),
-    ).await?);
+    let cast = cast.unwrap_or_default();
+    let query = format!("CONFIGURE INSTANCE SET {name} := {cast}{value}");
+    print::completion(&cli.execute(&query, &()).await?);
     Ok(())
 }
 
@@ -74,13 +50,13 @@ pub async fn configure(cli: &mut Connection, _options: &Options,
             ), &()).await?);
             Ok(())
         }
-        C::Set(Set { parameter: S::ListenAddresses(param) }) => {
+        C::Set(Set { parameter: S::ListenAddresses(ListenAddresses {address}) }) => {
+            let addresses = address
+                .iter()
+                .map(|x| quote_string(x))
+                .collect::<Vec<_>>().join(", ");
             print::completion(&cli.execute(
-                &format!("CONFIGURE INSTANCE SET listen_addresses := {{{}}}",
-                param.address.iter().map(|x| quote_string(x))
-                    .collect::<Vec<_>>().join(", ")),
-                &(),
-            ).await?);
+                &format!("CONFIGURE INSTANCE SET listen_addresses := {{{addresses}}}"), &()).await?);
             Ok(())
         }
         C::Set(Set { parameter: S::ListenPort(param) }) => {
@@ -91,41 +67,46 @@ pub async fn configure(cli: &mut Connection, _options: &Options,
             ).await?);
             Ok(())
         }
-        C::Set(Set { parameter: S::SharedBuffers(param) }) => {
-            set_string(cli, "shared_buffers", param).await
+        C::Set(Set { parameter: S::SharedBuffers(ConfigStr {value}) }) => {
+            set(cli, "shared_buffers", Some("<cfg::memory>"), value).await
         }
-        C::Set(Set { parameter: S::QueryWorkMem(param) }) => {
-            set_string(cli, "query_work_mem", param).await
+        C::Set(Set { parameter: S::QueryWorkMem(ConfigStr{ value}) }) => {
+            set(cli, "query_work_mem", Some("<cfg::memory>"), value).await
         }
-        C::Set(Set { parameter: S::MaintenanceWorkMem(param) }) => {
-            set_string(cli, "maintenance_work_mem", param).await
+        C::Set(Set { parameter: S::MaintenanceWorkMem(ConfigStr { value }) }) => {
+            set(cli, "maintenance_work_mem", Some("<cfg::memory>"), value).await
         }
-        C::Set(Set { parameter: S::EffectiveCacheSize(param) }) => {
-            set_string(cli, "effective_cache_size", param).await
+        C::Set(Set { parameter: S::EffectiveCacheSize(ConfigStr { value }) }) => {
+            set(cli, "effective_cache_size", Some("<cfg::memory>"), value).await
         }
-        C::Set(Set { parameter: S::DefaultStatisticsTarget(param) }) => {
-            set_string(cli, "default_statistics_target", param).await
+        C::Set(Set { parameter: S::DefaultStatisticsTarget(ConfigStr { value }) }) => {
+            set(cli, "default_statistics_target", None, value).await
         }
-        C::Set(Set { parameter: S::EffectiveIoConcurrency(param) }) => {
-            set_string(cli, "effective_io_concurrency", param).await
+        C::Set(Set { parameter: S::EffectiveIoConcurrency(ConfigStr { value }) }) => {
+            set(cli, "effective_io_concurrency", None, value).await
         }
-        C::Set(Set { parameter: S::SessionIdleTimeout(param) }) => {
-            set_duration(cli, "session_idle_timeout", param).await
+        C::Set(Set { parameter: S::SessionIdleTimeout(ConfigStr { value }) }) => {
+            set(cli, "session_idle_timeout", Some("<duration>"), format!("'{value}'")).await
         }
-        C::Set(Set { parameter: S::SessionIdleTransactionTimeout(param) }) => {
-            set_duration(cli, "session_idle_transaction_timeout", param).await
+        C::Set(Set { parameter: S::SessionIdleTransactionTimeout(ConfigStr { value }) }) => {
+            set(cli, "session_idle_transaction_timeout", Some("<duration>"), format!("'{value}'")).await
         }
-        C::Set(Set { parameter: S::QueryExecutionTimeout(param) }) => {
-            set_duration(cli, "query_execution_timeout", param).await
+        C::Set(Set { parameter: S::QueryExecutionTimeout(ConfigStr { value }) }) => {
+            set(cli, "query_execution_timeout", Some("<duration>"), format!("'{value}'")).await
         }
-        C::Set(Set { parameter: S::AllowBareDdl(param) }) => {
-            set_string(cli, "allow_bare_ddl", param).await
+        C::Set(Set { parameter: S::AllowBareDdl(ConfigStr { value }) }) => {
+            let ddl_config = match value.to_ascii_lowercase().as_str() {
+                "alwaysallow" => "'AlwaysAllow'",
+                "neverallow" => "'NeverAllow'",
+                _ => return Err(anyhow::anyhow!("allow_bare_ddl may only be set to AlwaysAllow or NeverAllow"))
+            };
+            set(cli, "allow_bare_ddl", None, ddl_config).await
         }
-        C::Set(Set { parameter: S::ApplyAccessPolicies(param) }) => {
-            set_bool(cli, "apply_access_policies", param).await
+        C::Set(Set { parameter: S::ApplyAccessPolicies(ConfigStr { value }) }) => {
+            set(cli, "apply_access_policies", None, value).await
         }
-        C::Set(Set { parameter: S::AllowUserSpecifiedId(param) }) => {
-            set_bool(cli, "allow_user_specified_id", param).await
+        C::Set(Set { parameter: S::AllowUserSpecifiedId(ConfigStr { value }) }) => {
+            set(cli, "allow_user_specified_id", None, value).await
         }
         C::Reset(Res { parameter }) => {
             use crate::commands::parser::ConfigParameter as C;
@@ -140,16 +121,15 @@ pub async fn configure(cli: &mut Connection, _options: &Options,
                 C::DefaultStatisticsTarget => "default_statistics_target",
                 C::EffectiveIoConcurrency => "effective_io_concurrency",
                 C::SessionIdleTimeout => "session_idle_timeout",
-                C::SessionIdleTransactionTimeout
-                    => "session_idle_transaction_timeout",
+                C::SessionIdleTransactionTimeout => "session_idle_transaction_timeout",
                 C::QueryExecutionTimeout => "query_execution_timeout",
                 C::AllowBareDdl => "allow_bare_ddl",
                 C::ApplyAccessPolicies => "apply_access_policies",
                 C::AllowUserSpecifiedId => "allow_user_specified_id",
             };
             print::completion(&cli.execute(
-                &format!("CONFIGURE INSTANCE RESET {}", name),
-                &(),
+                &format!("CONFIGURE INSTANCE RESET {name}"),
+                &()
             ).await?);
             Ok(())
         }

--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -95,11 +95,7 @@ pub async fn configure(cli: &mut Connection, _options: &Options,
             set(cli, "query_execution_timeout", Some("<duration>"), format!("'{value}'")).await
         }
         C::Set(Set { parameter: S::AllowBareDdl(ConfigStr { value }) }) => {
-            let ddl_config = match value.as_str() {
-                v @ ("AlwaysAllow" | "NeverAllow") => v,
-                _ => return Err(anyhow::anyhow!("allow_bare_ddl may only be set to AlwaysAllow or NeverAllow"))
-            };
-            set(cli, "allow_bare_ddl", None, format!("'{ddl_config}'")).await
+            set(cli, "allow_bare_ddl", None, format!("'{value}'")).await
         }
         C::Set(Set { parameter: S::ApplyAccessPolicies(ConfigStr { value }) }) => {
             set(cli, "apply_access_policies", None, value).await

--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -95,12 +95,11 @@ pub async fn configure(cli: &mut Connection, _options: &Options,
             set(cli, "query_execution_timeout", Some("<duration>"), format!("'{value}'")).await
         }
         C::Set(Set { parameter: S::AllowBareDdl(ConfigStr { value }) }) => {
-            let ddl_config = match value.to_ascii_lowercase().as_str() {
-                "alwaysallow" => "'AlwaysAllow'",
-                "neverallow" => "'NeverAllow'",
+            let ddl_config = match value.as_str() {
+                v @ ("AlwaysAllow" | "NeverAllow") => v,
                 _ => return Err(anyhow::anyhow!("allow_bare_ddl may only be set to AlwaysAllow or NeverAllow"))
             };
-            set(cli, "allow_bare_ddl", None, ddl_config).await
+            set(cli, "allow_bare_ddl", None, format!("'{ddl_config}'")).await
         }
         C::Set(Set { parameter: S::ApplyAccessPolicies(ConfigStr { value }) }) => {
             set(cli, "apply_access_policies", None, value).await

--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -4,7 +4,7 @@ use edgeql_parser::helpers::{quote_string, quote_name};
 use crate::commands::Options;
 use crate::print;
 use crate::connect::Connection;
-use crate::commands::parser::{Configure, ConfigStr, ListenPort, ListenAddresses, AuthParameter};
+use crate::commands::parser::{Configure, ConfigStr, ListenAddresses, AuthParameter};
 
 async fn set(cli: &mut Connection, name: &str, cast: Option<&str>, value: impl Display)
     -> Result<(), anyhow::Error>

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -575,12 +575,6 @@ pub struct ConfigStr {
 }
 
 #[derive(clap::Args, Clone, Debug)]
-pub struct ConfigBool {
-    #[arg(action = clap::ArgAction::Set)]
-    pub value: bool,
-}
-
-#[derive(clap::Args, Clone, Debug)]
 pub struct AuthParameter {
     /// Priority of the authentication rule. The lower the number, the
     /// higher the priority.

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -517,10 +517,10 @@ pub enum ValueParameter {
     ///
     /// User-specified access policies are not applied when set to `false`,
     /// allowing any queries to be executed.
-    ApplyAccessPolicies(ConfigBool),
+    ApplyAccessPolicies(ConfigStr),
 
     /// Allow setting user-specified object identifiers.
-    AllowUserSpecifiedId(ConfigBool),
+    AllowUserSpecifiedId(ConfigStr),
 }
 
 #[derive(clap::Subcommand, Clone, Debug)]
@@ -572,11 +572,6 @@ pub struct ListenPort {
 #[derive(clap::Args, Clone, Debug)]
 pub struct ConfigStr {
     pub value: String,
-}
-
-#[derive(clap::Args, Clone, Debug)]
-pub struct ConfigBool {
-    pub value: bool,
 }
 
 #[derive(clap::Args, Clone, Debug)]


### PR DESCRIPTION
Resolves https://github.com/edgedb/edgedb-cli/issues/1140

Currently most configure commands sent in directly from the CLI fail because the expected vs. actual types don't match. These are all simple queries under our control so seems easiest to just build a string for all of them with a cast in case of a scalar type like duration.

It also looks like clap was unhappy with ConfigBool which holds a bool, which it treats as a SetTrue action:

Argument 'value` is positional and it must take a value but action is SetTrue

https://docs.rs/clap/latest/clap/enum.ArgAction.html#variant.SetTrue

Which means that it assumes that `true` or `false` will not be following the parameter to set. You can modify the clap Command to allow this but ConfigBool itself isn't necessary either if we can just build a String and be done with it.

allow_bare_ddl is another interesting case as it feels like it's a bool but is actually an enum with the valiants AlwaysAllow and NeverAllow, so it handles the input ahead of time to let the user know which input is acceptable. Could even accept true or false on the user's end and convert it to the enum since there are only the two variants, would that be a good idea?

There could also be more input handling on the CLI side which could be nice since it doesn't require a database connection to happen first. (e.g. memory configs which have a minimum and maximum number of bytes) On Windows everything is a bit slower so connecting first to check an input always takes a few seconds. Could those be added as well or is it icky to have the CLI doing the same checks that the database then proceeds to do?