### PR TITLE
allow_bare_ddl applies to database not instance

### DIFF
--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -94,14 +94,18 @@ pub async fn configure(cli: &mut Connection, _options: &Options,
         C::Set(Set { parameter: S::QueryExecutionTimeout(ConfigStr { value }) }) => {
             set(cli, "query_execution_timeout", Some("<duration>"), format!("'{value}'")).await
         }
-        C::Set(Set { parameter: S::AllowBareDdl(ConfigStr { value }) }) => {
-            set(cli, "allow_bare_ddl", None, format!("'{value}'")).await
-        }
         C::Set(Set { parameter: S::ApplyAccessPolicies(ConfigStr { value }) }) => {
             set(cli, "apply_access_policies", None, value).await
         }
         C::Set(Set { parameter: S::AllowUserSpecifiedId(ConfigStr { value }) }) => {
             set(cli, "allow_user_specified_id", None, value).await
+        }
+        C::Set(Set { parameter: S::AllowBareDdl(ConfigStr { value }) }) => {
+            let query = format!("CONFIGURE CURRENT DATABASE SET allow_bare_ddl := '{value}'");
+            let res = &cli.execute(&query, &()).await?;
+            eprintln!("Current database within instance set to {value}.");
+            print::completion(res);
+            Ok(())
         }
         C::Reset(Res { parameter }) => {
             use crate::commands::parser::ConfigParameter as C;


### PR DESCRIPTION
I thought I had discovered a bug with `configure instance allow_bare_ddl` changing not actually allowing a user to use DDL but noticed inside this issue https://github.com/edgedb/edgedb/issues/4792 that it is set by database instead. (The InstanceConfig can indeed be set to AlwaysAllow or NeverAllow but that doesn't change the behavior when one actuall tries to use a DDL command).