### PR TITLE
Remove transaction from edgedb migrate

### DIFF
--- a/src/migrations/dev_mode.rs
+++ b/src/migrations/dev_mode.rs
@@ -68,7 +68,7 @@ pub async fn migrate(cli: &mut Connection, ctx: &Context, bar: &ProgressBar)
                 .ok_or_else(|| bug::error("`skip` is out of range"))?;
             if !migrations.is_empty() {
                 bar.set_message("applying migrations");
-                apply_migrations(cli, migrations, &ctx).await?;
+                apply_migrations(cli, migrations, &ctx, false).await?;
             }
             bar.set_message("calculating diff");
             log::info!("Calculating schema diff.");

--- a/src/migrations/migrate.rs
+++ b/src/migrations/migrate.rs
@@ -196,7 +196,7 @@ async fn _migrate(cli: &mut Connection, _options: &Options,
         }
         return Ok(());
     }
-    apply_migrations(cli, migrations, &ctx).await?;
+    apply_migrations(cli, migrations, &ctx, migrate.single_transaction).await?;
     if db_migrations.is_empty() {
         disable_ddl(cli).await?;
     }
@@ -339,7 +339,7 @@ async fn fixup(
         }
     }
 
-    apply_migrations(cli, &operations, ctx).await?;
+    apply_migrations(cli, &operations, ctx, _options.single_transaction).await?;
     Ok(())
 }
 
@@ -431,13 +431,28 @@ fn backtrack<'a>(markup: &HashMap<&String, u32>,
 }
 
 pub async fn apply_migrations(cli: &mut Connection,
-    migrations: impl AsOperations<'_>, ctx: &Context)
+    migrations: impl AsOperations<'_>, ctx: &Context, single_transaction: bool)
     -> anyhow::Result<()>
 {
     let old_timeout = timeout::inhibit_for_transaction(cli).await?;
     async_try! {
         async {
-            apply_migrations_inner(cli, migrations, ctx.quiet).await
+            if single_transaction {
+                execute(cli, "START TRANSACTION").await?;
+                async_try! {
+                    async {
+                        apply_migrations_inner(cli, migrations, ctx.quiet).await
+                    },
+                    except async {
+                        execute_if_connected(cli, "ROLLBACK").await
+                    },
+                    else async {
+                        execute(cli, "COMMIT").await
+                    }
+                }
+            } else {
+                apply_migrations_inner(cli, migrations, ctx.quiet).await
+            }
         },
         finally async {
             timeout::restore_for_transaction(cli, old_timeout).await

--- a/src/migrations/migrate.rs
+++ b/src/migrations/migrate.rs
@@ -437,18 +437,7 @@ pub async fn apply_migrations(cli: &mut Connection,
     let old_timeout = timeout::inhibit_for_transaction(cli).await?;
     async_try! {
         async {
-            execute(cli, "START TRANSACTION").await?;
-            async_try! {
-                async {
-                    apply_migrations_inner(cli, migrations, ctx.quiet).await
-                },
-                except async {
-                    execute_if_connected(cli, "ROLLBACK").await
-                },
-                else async {
-                    execute(cli, "COMMIT").await
-                }
-            }
+            apply_migrations_inner(cli, migrations, ctx.quiet).await
         },
         finally async {
             timeout::restore_for_transaction(cli, old_timeout).await

--- a/src/migrations/options.rs
+++ b/src/migrations/options.rs
@@ -120,7 +120,7 @@ pub struct Migrate {
     #[arg(long)]
     pub dev_mode: bool,
 
-    /// Runs the migration(s) in a single transaction (legacy behaviour).
+    /// Runs the migration(s) in a single transaction.
     #[arg(long="single-transaction")]
     pub single_transaction: bool,
 }

--- a/src/migrations/options.rs
+++ b/src/migrations/options.rs
@@ -119,6 +119,10 @@ pub struct Migrate {
     /// a regular `.edgeql` file, after which the above query will return nothing.
     #[arg(long)]
     pub dev_mode: bool,
+
+    /// Runs the migration(s) in a single transaction (legacy behaviour).
+    #[arg(long="single-transaction")]
+    pub single_transaction: bool,
 }
 
 #[derive(clap::Args, Clone, Debug)]

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -1116,6 +1116,7 @@ async fn migrate_async(inst: &Handle<'_>, ask_for_running: bool)
             quiet: false,
             to_revision: None,
             dev_mode: false,
+            single_transaction: false,
             conn: None,
         }).await?;
     Ok(())


### PR DESCRIPTION
Removes the transaction block from `edgedb migrate`, as proposed in https://github.com/edgedb/edgedb-cli/issues/1185.

Closes https://github.com/edgedb/edgedb-cli/issues/1185