### PR TITLE
Slim down project upgrade output

### DIFF
--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -81,22 +81,12 @@ pub enum Command {
     /// Get various metadata about project instance
     Info(Info),
     /// Upgrade EdgeDB instance used for current project
-    ///
-    /// This command has two modes of operation.
-    ///
-    /// Upgrade instance to version specified in `edgedb.toml`:
-    ///
-    ///     project upgrade
-    ///
-    /// Update `edgedb.toml` to new version and upgrade the instance:
-    ///
-    ///     project upgrade --to-latest
-    ///     project upgrade --to-version=1-beta2
-    ///     project upgrade --to-nightly
-    ///
-    /// In all cases your data is preserved and converted using dump/restore
-    /// mechanism. May fail if lower version is specified (e.g. if upgrading
-    /// from nightly to stable).
+    /// 
+    /// Data is preserved using a dump/restore mechanism.
+    /// 
+    /// Upgrades to version specified in `edgedb.toml` unless other options specified.
+    /// 
+    /// Note: May fail if lower version is specified (e.g. moving from nightly to stable).
     Upgrade(Upgrade),
 }
 
@@ -199,7 +189,9 @@ pub struct Upgrade {
     ])]
     pub to_latest: bool,
 
-    /// Upgrade specified instance to a specified version
+    /// Upgrade specified instance to a specified version.
+    /// 
+    /// e.g. --to-version=4.0-beta.1
     #[arg(long)]
     #[arg(conflicts_with_all=&[
         "to_testing", "to_latest", "to_nightly", "to_channel",

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -191,7 +191,7 @@ pub struct Upgrade {
 
     /// Upgrade specified instance to a specified version.
     /// 
-    /// e.g. --to-version=4.0-beta.1
+    /// e.g. --to-version 4.0-beta.1
     #[arg(long)]
     #[arg(conflicts_with_all=&[
         "to_testing", "to_latest", "to_nightly", "to_channel",


### PR DESCRIPTION
Resolves https://github.com/edgedb/edgedb-cli/issues/1190

First took a look at getting the multiline-into-single line issue solved through the attributes that clap (Rust's command-line parser) has, but on second look there's no info there that isn't contained in the options below, except for one example of an argument when moving to a specific version. So outright deleting this legacy comment seems best.

(As always, feel free to suggest a rewording)

Changes the output from this:

```
Upgrade EdgeDB instance used for current project

This command has two modes of operation.

Upgrade instance to version specified in `edgedb.toml`:

project upgrade

Update `edgedb.toml` to new version and upgrade the instance:

project upgrade --to-latest project upgrade --to-version=1-beta2 project upgrade --to-nightly

In all cases your data is preserved and converted using dump/restore mechanism. May fail if lower
version is specified (e.g. if upgrading from nightly to stable).

Usage: edgedb.exe project upgrade [OPTIONS]

Options:
      --project-dir <PROJECT_DIR>
          Explicitly set a root directory for the project

      --to-latest
          Upgrade specified instance to latest version

      --to-version <TO_VERSION>
          Upgrade specified instance to a specified version

      --to-nightly
          Upgrade specified instance to latest nightly version

      --to-testing
          Upgrade specified instance to latest testing version

      --to-channel <TO_CHANNEL>
          Upgrade specified instance to the specified channel

          [possible values: stable, testing, nightly]

  -v, --verbose
          Verbose output

      --force
          Force upgrade process even if there is no new version

      --non-interactive
          Do not ask questions, assume user wants to upgrade instance

  -h, --help
          Print help (see a summary with '-h')
```

to this

```
Upgrade EdgeDB instance used for current project

Data is preserved using a dump/restore mechanism.

Upgrades to version specified in `edgedb.toml` unless other options specified.

Note: May fail if lower version is specified (e.g. moving from nightly to stable).

Usage: edgedb.exe project upgrade [OPTIONS]

Options:
      --project-dir <PROJECT_DIR>
          Explicitly set a root directory for the project

      --to-latest
          Upgrade specified instance to latest version

      --to-version <TO_VERSION>
          Upgrade specified instance to a specified version.

          e.g. --to-version=4.0-beta.1

      --to-nightly
          Upgrade specified instance to latest nightly version

      --to-testing
          Upgrade specified instance to latest testing version

      --to-channel <TO_CHANNEL>
          Upgrade specified instance to the specified channel

          [possible values: stable, testing, nightly]

  -v, --verbose
          Verbose output

      --force
          Force upgrade process even if there is no new version

      --non-interactive
          Do not ask questions, assume user wants to upgrade instance

  -h, --help
          Print help (see a summary with '-h')
```