### PR TITLE
Use pricing API to populate instance resource defaults

### DIFF
--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -97,27 +97,27 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
         }
     };
 
-    if let Some(cp) = &cmd.cloud_params {
-        if cp.region.is_some() {
-            return Err(opts.error(
-                clap::error::ErrorKind::ArgumentConflict,
-                cformat!("The <bold>--region</bold> option is only applicable to cloud instances."),
-            ))?;
-        }
+    let cp = &cmd.cloud_params;
 
-        if cp.billables.compute_size.is_some() {
-            return Err(opts.error(
-                clap::error::ErrorKind::ArgumentConflict,
-                cformat!("The <bold>--compute-size</bold> option is only applicable to cloud instances."),
-            ))?;
-        }
+    if cp.region.is_some() {
+        return Err(opts.error(
+            clap::error::ErrorKind::ArgumentConflict,
+            cformat!("The <bold>--region</bold> option is only applicable to cloud instances."),
+        ))?;
+    }
 
-        if cp.billables.storage_size.is_some() {
-            return Err(opts.error(
-                clap::error::ErrorKind::ArgumentConflict,
-                cformat!("The <bold>--storage-size</bold> option is only applicable to cloud instances."),
-            ))?;
-        }
+    if cp.billables.compute_size.is_some() {
+        return Err(opts.error(
+            clap::error::ErrorKind::ArgumentConflict,
+            cformat!("The <bold>--compute-size</bold> option is only applicable to cloud instances."),
+        ))?;
+    }
+
+    if cp.billables.storage_size.is_some() {
+        return Err(opts.error(
+            clap::error::ErrorKind::ArgumentConflict,
+            cformat!("The <bold>--storage-size</bold> option is only applicable to cloud instances."),
+        ))?;
     }
 
     let paths = Paths::get(&name)?;
@@ -200,9 +200,9 @@ fn create_cloud(
 
     client.ensure_authenticated()?;
 
-    let cp = cmd.cloud_params.as_ref();
+    let cp = &cmd.cloud_params;
 
-    let region = match &cp.and_then(|p| p.region.clone()) {
+    let region = match &cp.region {
         None => cloud::ops::get_current_region(&client)?.name,
         Some(region) => region.to_string(),
     };
@@ -222,10 +222,10 @@ fn create_cloud(
 
     let server_ver = cloud::versions::get_version(&query, client)?;
 
-    let compute_size = cp.and_then(|p| p.billables.compute_size);
-    let storage_size = cp.and_then(|p| p.billables.storage_size);
+    let compute_size = &cp.billables.compute_size;
+    let storage_size = &cp.billables.storage_size;
 
-    let tier = if let Some(tier) = cp.and_then(|p| p.billables.tier) {
+    let tier = if let Some(tier) = cp.billables.tier {
         tier
     } else if compute_size.is_some() || storage_size.is_some() || org.preferred_payment_method.is_some() {
         cloud::ops::CloudTier::Pro
@@ -250,36 +250,46 @@ fn create_cloud(
         }
     }
 
-    let compute_size_v: String;
-    let storage_size_v: String;
+    let prices = cloud::ops::get_prices(client)?;
+    let tier_prices = prices.get(&tier)
+        .context(format!("could not download pricing information for the {} tier", tier))?;
+    let region_prices = tier_prices.get(&region)
+        .context(format!("could not download pricing information for the {} region", region))?;
+    let default_compute = region_prices.into_iter()
+        .find(|&price| price.billable == "compute")
+        .context("could not download pricing information for compute")?;
+    let default_storage = region_prices.into_iter()
+        .find(|&price| price.billable == "storage")
+        .context("could not download pricing information for compute")?;
+
     let mut req_resources: Vec<cloud::ops::CloudInstanceResourceRequest> = vec![];
 
-    if org.preferred_payment_method.is_some() {
-        compute_size_v = compute_size.unwrap_or(1).to_string();
-        storage_size_v = storage_size.unwrap_or(20).to_string();
-    } else {
-        compute_size_v = compute_size.and_then(|v| Some(v.to_string()))
-            .unwrap_or(String::from("1/4"));
-        storage_size_v = storage_size.and_then(|v| Some(v.to_string()))
-            .unwrap_or(String::from("1"));
-    }
+    let compute_size_v = match compute_size {
+        None => default_compute.units_default.clone(),
+        Some(v) => v.clone(),
+    };
 
-    if let Some(compute_size) = compute_size {
+    let storage_size_v = match storage_size {
+        None => default_storage.units_default.clone(),
+        Some(v) => v.clone(),
+    };
+
+    if compute_size.is_some() {
         req_resources.push(
             cloud::ops::CloudInstanceResourceRequest{
                 name: "compute".to_string(),
-                value: compute_size,
+                value: compute_size_v.clone(),
             },
-        )
+        );
     }
 
-    if let Some(storage_size) = storage_size {
+    if storage_size.is_some() {
         req_resources.push(
             cloud::ops::CloudInstanceResourceRequest{
                 name: "storage".to_string(),
-                value: storage_size,
+                value: storage_size_v.clone(),
             },
-        )
+        );
     }
 
     let resources_display = format!(

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -146,6 +146,17 @@ pub enum InstanceName {
     },
 }
 
+fn billable_unit(s: &str) -> Result<String, String> {
+    let unit: usize = s
+        .parse()
+        .map_err(|_| format!("`{s}` is not a positive number"))?;
+    if unit <= 0 {
+        Err(String::from("`{s}` is not a positive number"))
+    } else {
+        Ok(s.to_string())
+    }
+}
+
 #[derive(clap::Args, IntoArgs, Debug, Clone)]
 pub struct CloudInstanceBillables {
     /// Cloud instance subscription tier.
@@ -155,13 +166,13 @@ pub struct CloudInstanceBillables {
 
     /// The size of compute to be allocated for the Cloud instance in
     /// Compute Units.
-    #[arg(long, value_name="number")]
-    pub compute_size: Option<u16>,
+    #[arg(long, value_name="number", value_parser=billable_unit)]
+    pub compute_size: Option<String>,
 
     /// The size of storage to be allocated for the Cloud instance in
     /// Gigabytes.
-    #[arg(long, value_name="GiB")]
-    pub storage_size: Option<u16>,
+    #[arg(long, value_name="GiB", value_parser=billable_unit)]
+    pub storage_size: Option<String>,
 }
 
 #[derive(clap::Args, IntoArgs, Debug, Clone)]
@@ -199,7 +210,7 @@ pub struct Create {
     pub port: Option<u16>,
 
     #[command(flatten)]
-    pub cloud_params: Option<CloudInstanceParams>,
+    pub cloud_params: CloudInstanceParams,
 
     /// Deprecated parameter, unused.
     #[arg(long, hide=true)]

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -81,11 +81,11 @@ pub enum Command {
     /// Get various metadata about project instance
     Info(Info),
     /// Upgrade EdgeDB instance used for current project
-    /// 
+    ///
     /// Data is preserved using a dump/restore mechanism.
-    /// 
+    ///
     /// Upgrades to version specified in `edgedb.toml` unless other options specified.
-    /// 
+    ///
     /// Note: May fail if lower version is specified (e.g. moving from nightly to stable).
     Upgrade(Upgrade),
 }
@@ -190,7 +190,7 @@ pub struct Upgrade {
     pub to_latest: bool,
 
     /// Upgrade specified instance to a specified version.
-    /// 
+    ///
     /// e.g. --to-version 4.0-beta.1
     #[arg(long)]
     #[arg(conflicts_with_all=&[
@@ -696,7 +696,14 @@ fn do_init(name: &str, pkg: &PackageInfo,
             nightly: false,
             channel: q.cli_channel(),
             version: q.version,
-            cloud_params: None,
+            cloud_params: options::CloudInstanceParams {
+                region: None,
+                billables: options::CloudInstanceBillables {
+                    tier: None,
+                    compute_size: None,
+                    storage_size: None,
+                },
+            },
             port: Some(port),
             start_conf: None,
             default_database: "edgedb".into(),


### PR DESCRIPTION
Use `/pricing` for instance resource defaults instead of hardcoding
them.

While here, fix handling of tier transitions (free -> pro) and handle
simultaneous resizes of compute and storage (by sending resize requests
in sequence).
