### PR TITLE
Switch to using Github's runners for macOS builds

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -10,7 +10,7 @@
 <% endfor %>
 <% endif %>
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -88,7 +88,7 @@
 <% endif %>
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -117,7 +117,7 @@
         PKG_PLATFORM_LIBC: "<< tgt.platform_libc >>"
 <% endif %>
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>/
@@ -132,17 +132,30 @@
 <% endif %>
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@55c7845fad90d0ae8b2e83715cb900e5e861e8cb
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
       with:
-        toolchain: stable
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "<< tgt.arch >>-apple-darwin"
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
+      with:
+        python-version: "3.x"
+
+    - name: Install dependencies
+      if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -165,7 +178,7 @@
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>/
@@ -180,7 +193,7 @@
 <% endif %>
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -232,7 +245,7 @@
         password: "${{ secrets.WIN_CODE_SIGNING_CERT_PASSWORD }}"
         folder: "artifacts/<< plat_id >>/"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
@@ -244,7 +257,7 @@
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>/
@@ -274,7 +287,7 @@
     runs-on: << tgt.runs_on if tgt.runs_on else "ubuntu-latest" >>
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>/
@@ -309,12 +322,12 @@
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -344,12 +357,12 @@
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master

--- a/.github/workflows.src/build.targets.yml
+++ b/.github/workflows.src/build.targets.yml
@@ -117,12 +117,13 @@ targets:
           platform_version: x86_64
           family: generic
           arch: x86_64
+          runs_on: [macos-14]
         - name: macos-aarch64
           platform: macos
           platform_version: aarch64
           family: generic
           arch: aarch64
-          runs_on: [self-hosted, macOS, ARM64]
+          runs_on: [macos-14]
 
     win:
        - name: win-x86_64

--- a/.github/workflows/install_tests.yaml
+++ b/.github/workflows/install_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Install musl-tools
         run: "sudo apt-get install musl-tools"
       - name: Systemd version
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os: [windows-2019, macos-latest]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -27,7 +27,7 @@ jobs:
         - upgrade
         - project
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Install musl-tools
         run: "sudo apt-get install musl-tools"
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,7 +63,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -89,7 +89,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing debian-buster-x86_64'
           val=false
         fi
@@ -103,7 +103,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing debian-buster-aarch64'
           val=false
         fi
@@ -117,7 +117,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing debian-bullseye-x86_64'
           val=false
         fi
@@ -131,7 +131,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing debian-bullseye-aarch64'
           val=false
         fi
@@ -145,7 +145,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing debian-bookworm-x86_64'
           val=false
         fi
@@ -159,7 +159,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing debian-bookworm-aarch64'
           val=false
         fi
@@ -173,7 +173,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing ubuntu-bionic-x86_64'
           val=false
         fi
@@ -187,7 +187,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing ubuntu-bionic-aarch64'
           val=false
         fi
@@ -201,7 +201,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing ubuntu-focal-x86_64'
           val=false
         fi
@@ -215,7 +215,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing ubuntu-focal-aarch64'
           val=false
         fi
@@ -229,7 +229,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "x86_64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing ubuntu-jammy-x86_64'
           val=false
         fi
@@ -243,7 +243,7 @@ jobs:
           curl -s https://packages.edgedb.com/apt/.jsonindexes/$idx_file > /tmp/$idx_file
         fi
         out=$(cat /tmp/$idx_file | jq -r --arg REV "$rev" --arg ARCH "aarch64" "$jq_filter")
-        if [ -n "$out" ]; then 
+        if [ -n "$out" ]; then
           echo 'Skip rebuilding existing ubuntu-jammy-aarch64'
           val=false
         fi
@@ -383,7 +383,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -403,7 +403,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster/
@@ -417,7 +417,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -437,7 +437,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster/
@@ -451,7 +451,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -471,7 +471,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye/
@@ -485,7 +485,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -505,7 +505,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye/
@@ -519,7 +519,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -539,7 +539,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm/
@@ -553,7 +553,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -573,7 +573,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm/
@@ -587,7 +587,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -607,7 +607,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic/
@@ -621,7 +621,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -641,7 +641,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic/
@@ -655,7 +655,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -675,7 +675,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal/
@@ -689,7 +689,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -709,7 +709,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal/
@@ -723,7 +723,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -743,7 +743,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy/
@@ -757,7 +757,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -777,7 +777,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy/
@@ -791,7 +791,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -811,7 +811,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-centos-7-x86_64
         path: artifacts/centos-7/
@@ -825,7 +825,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -845,7 +845,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8/
@@ -859,7 +859,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -879,7 +879,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8/
@@ -893,7 +893,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -913,7 +913,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9/
@@ -927,7 +927,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -947,7 +947,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9/
@@ -961,7 +961,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -985,7 +985,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-linux-x86_64
         path: artifacts/linuxmusl-x86_64/
@@ -999,7 +999,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -1023,7 +1023,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-linux-aarch64
         path: artifacts/linuxmusl-aarch64/
@@ -1031,24 +1031,37 @@ jobs:
 
 
   build-macos-x86_64:
-    runs-on: macos-latest
+    runs-on: ['macos-14']
     needs: prep
 
     if: needs.prep.outputs.if_macos_x86_64 == 'true'
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@55c7845fad90d0ae8b2e83715cb900e5e861e8cb
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       if: true
       with:
-        toolchain: stable
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "x86_64-apple-darwin"
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      if: true
+      with:
+        python-version: "3.x"
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -1066,31 +1079,44 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64/
 
 
   build-macos-aarch64:
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: ['macos-14']
     needs: prep
 
     if: needs.prep.outputs.if_macos_aarch64 == 'true'
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@55c7845fad90d0ae8b2e83715cb900e5e861e8cb
-      if: false
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      if: true
       with:
-        toolchain: stable
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "aarch64-apple-darwin"
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      if: true
+      with:
+        python-version: "3.x"
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -1108,7 +1134,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64/
@@ -1123,7 +1149,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -1168,7 +1194,7 @@ jobs:
         password: "${{ secrets.WIN_CODE_SIGNING_CERT_PASSWORD }}"
         folder: "artifacts/win-x86_64/"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-win-x86_64
         path: artifacts/win-x86_64
@@ -1180,7 +1206,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster/
@@ -1206,7 +1232,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster/
@@ -1238,7 +1264,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster/
@@ -1264,7 +1290,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster/
@@ -1296,7 +1322,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye/
@@ -1322,7 +1348,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye/
@@ -1354,7 +1380,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye/
@@ -1380,7 +1406,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye/
@@ -1412,7 +1438,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm/
@@ -1438,7 +1464,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm/
@@ -1470,7 +1496,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm/
@@ -1496,7 +1522,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm/
@@ -1528,7 +1554,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic/
@@ -1554,7 +1580,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic/
@@ -1586,7 +1612,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic/
@@ -1612,7 +1638,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic/
@@ -1644,7 +1670,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal/
@@ -1670,7 +1696,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal/
@@ -1702,7 +1728,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal/
@@ -1728,7 +1754,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal/
@@ -1760,7 +1786,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy/
@@ -1786,7 +1812,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy/
@@ -1818,7 +1844,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy/
@@ -1844,7 +1870,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy/
@@ -1876,7 +1902,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-7-x86_64
         path: artifacts/centos-7/
@@ -1902,7 +1928,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-7-x86_64
         path: artifacts/centos-7/
@@ -1934,7 +1960,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8/
@@ -1960,7 +1986,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8/
@@ -1992,7 +2018,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8/
@@ -2018,7 +2044,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8/
@@ -2050,7 +2076,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9/
@@ -2076,7 +2102,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9/
@@ -2108,7 +2134,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9/
@@ -2134,7 +2160,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9/
@@ -2166,7 +2192,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-x86_64
         path: artifacts/linuxmusl-x86_64/
@@ -2194,7 +2220,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-x86_64
         path: artifacts/linuxmusl-x86_64/
@@ -2226,7 +2252,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-aarch64
         path: artifacts/linuxmusl-aarch64/
@@ -2254,7 +2280,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-aarch64
         path: artifacts/linuxmusl-aarch64/
@@ -2287,12 +2313,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -2319,12 +2345,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -2352,12 +2378,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-win-x86_64
         path: artifacts/win-x86_64
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       scm_revision: ${{ steps.whatrev.outputs.rev }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -33,7 +33,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -53,7 +53,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster/
@@ -65,7 +65,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -85,7 +85,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster/
@@ -97,7 +97,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -117,7 +117,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye/
@@ -129,7 +129,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -149,7 +149,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye/
@@ -161,7 +161,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -181,7 +181,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm/
@@ -193,7 +193,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -213,7 +213,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm/
@@ -225,7 +225,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -245,7 +245,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic/
@@ -257,7 +257,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -277,7 +277,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic/
@@ -289,7 +289,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -309,7 +309,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal/
@@ -321,7 +321,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -341,7 +341,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal/
@@ -353,7 +353,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -373,7 +373,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy/
@@ -385,7 +385,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -405,7 +405,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy/
@@ -417,7 +417,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -437,7 +437,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-centos-7-x86_64
         path: artifacts/centos-7/
@@ -449,7 +449,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -469,7 +469,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8/
@@ -481,7 +481,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -501,7 +501,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8/
@@ -513,7 +513,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -533,7 +533,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9/
@@ -545,7 +545,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -565,7 +565,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9/
@@ -577,7 +577,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -601,7 +601,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-linux-x86_64
         path: artifacts/linuxmusl-x86_64/
@@ -613,7 +613,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -637,7 +637,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-linux-aarch64
         path: artifacts/linuxmusl-aarch64/
@@ -645,22 +645,35 @@ jobs:
 
 
   build-macos-x86_64:
-    runs-on: macos-latest
+    runs-on: ['macos-14']
     needs: prep
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@55c7845fad90d0ae8b2e83715cb900e5e861e8cb
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       if: true
       with:
-        toolchain: stable
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "x86_64-apple-darwin"
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      if: true
+      with:
+        python-version: "3.x"
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -678,29 +691,42 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64/
 
 
   build-macos-aarch64:
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: ['macos-14']
     needs: prep
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@55c7845fad90d0ae8b2e83715cb900e5e861e8cb
-      if: false
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      if: true
       with:
-        toolchain: stable
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "aarch64-apple-darwin"
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      if: true
+      with:
+        python-version: "3.x"
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -718,7 +744,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64/
@@ -731,7 +757,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -776,7 +802,7 @@ jobs:
         password: "${{ secrets.WIN_CODE_SIGNING_CERT_PASSWORD }}"
         folder: "artifacts/win-x86_64/"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-win-x86_64
         path: artifacts/win-x86_64
@@ -788,7 +814,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster/
@@ -813,7 +839,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster/
@@ -844,7 +870,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster/
@@ -869,7 +895,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster/
@@ -900,7 +926,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye/
@@ -925,7 +951,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye/
@@ -956,7 +982,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye/
@@ -981,7 +1007,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye/
@@ -1012,7 +1038,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm/
@@ -1037,7 +1063,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm/
@@ -1068,7 +1094,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm/
@@ -1093,7 +1119,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm/
@@ -1124,7 +1150,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic/
@@ -1149,7 +1175,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic/
@@ -1180,7 +1206,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic/
@@ -1205,7 +1231,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic/
@@ -1236,7 +1262,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal/
@@ -1261,7 +1287,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal/
@@ -1292,7 +1318,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal/
@@ -1317,7 +1343,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal/
@@ -1348,7 +1374,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy/
@@ -1373,7 +1399,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy/
@@ -1404,7 +1430,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy/
@@ -1429,7 +1455,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy/
@@ -1460,7 +1486,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-7-x86_64
         path: artifacts/centos-7/
@@ -1485,7 +1511,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-7-x86_64
         path: artifacts/centos-7/
@@ -1516,7 +1542,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8/
@@ -1541,7 +1567,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8/
@@ -1572,7 +1598,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8/
@@ -1597,7 +1623,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8/
@@ -1628,7 +1654,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9/
@@ -1653,7 +1679,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9/
@@ -1684,7 +1710,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9/
@@ -1709,7 +1735,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9/
@@ -1740,7 +1766,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-x86_64
         path: artifacts/linuxmusl-x86_64/
@@ -1767,7 +1793,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-x86_64
         path: artifacts/linuxmusl-x86_64/
@@ -1798,7 +1824,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-aarch64
         path: artifacts/linuxmusl-aarch64/
@@ -1825,7 +1851,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-aarch64
         path: artifacts/linuxmusl-aarch64/
@@ -1857,12 +1883,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -1888,12 +1914,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -1920,12 +1946,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-win-x86_64
         path: artifacts/win-x86_64
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
       scm_revision: ${{ steps.whatrev.outputs.rev }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -33,7 +33,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -54,7 +54,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster/
@@ -66,7 +66,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -87,7 +87,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster/
@@ -99,7 +99,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -120,7 +120,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye/
@@ -132,7 +132,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -153,7 +153,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye/
@@ -165,7 +165,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -186,7 +186,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm/
@@ -198,7 +198,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -219,7 +219,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm/
@@ -231,7 +231,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -252,7 +252,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic/
@@ -264,7 +264,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -285,7 +285,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic/
@@ -297,7 +297,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -318,7 +318,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal/
@@ -330,7 +330,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -351,7 +351,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal/
@@ -363,7 +363,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -384,7 +384,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy/
@@ -396,7 +396,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -417,7 +417,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy/
@@ -429,7 +429,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -450,7 +450,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-centos-7-x86_64
         path: artifacts/centos-7/
@@ -462,7 +462,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -483,7 +483,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8/
@@ -495,7 +495,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -516,7 +516,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8/
@@ -528,7 +528,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -549,7 +549,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9/
@@ -561,7 +561,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -582,7 +582,7 @@ jobs:
 
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9/
@@ -594,7 +594,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -619,7 +619,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-linux-x86_64
         path: artifacts/linuxmusl-x86_64/
@@ -631,7 +631,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -656,7 +656,7 @@ jobs:
         PKG_PLATFORM_LIBC: "musl"
 
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-linux-aarch64
         path: artifacts/linuxmusl-aarch64/
@@ -664,22 +664,35 @@ jobs:
 
 
   build-macos-x86_64:
-    runs-on: macos-latest
+    runs-on: ['macos-14']
     needs: prep
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@55c7845fad90d0ae8b2e83715cb900e5e861e8cb
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
       if: true
       with:
-        toolchain: stable
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "x86_64-apple-darwin"
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      if: true
+      with:
+        python-version: "3.x"
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -698,29 +711,42 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64/
 
 
   build-macos-aarch64:
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: ['macos-14']
     needs: prep
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb-pkg
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@55c7845fad90d0ae8b2e83715cb900e5e861e8cb
-      if: false
+      uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
+      if: true
       with:
-        toolchain: stable
+        components: "cargo,rustc,rust-std"
+        toolchain: "stable"
+        targets: "aarch64-apple-darwin"
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      if: true
+      with:
+        python-version: "3.x"
+
+    - name: Install dependencies
+      if: true
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Build
       env:
@@ -739,7 +765,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64/
@@ -752,7 +778,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -798,7 +824,7 @@ jobs:
         password: "${{ secrets.WIN_CODE_SIGNING_CERT_PASSWORD }}"
         folder: "artifacts/win-x86_64/"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: builds-win-x86_64
         path: artifacts/win-x86_64
@@ -810,7 +836,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster/
@@ -836,7 +862,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-x86_64
         path: artifacts/debian-buster/
@@ -868,7 +894,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster/
@@ -894,7 +920,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-buster-aarch64
         path: artifacts/debian-buster/
@@ -926,7 +952,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye/
@@ -952,7 +978,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-x86_64
         path: artifacts/debian-bullseye/
@@ -984,7 +1010,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye/
@@ -1010,7 +1036,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bullseye-aarch64
         path: artifacts/debian-bullseye/
@@ -1042,7 +1068,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm/
@@ -1068,7 +1094,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-x86_64
         path: artifacts/debian-bookworm/
@@ -1100,7 +1126,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm/
@@ -1126,7 +1152,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-debian-bookworm-aarch64
         path: artifacts/debian-bookworm/
@@ -1158,7 +1184,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic/
@@ -1184,7 +1210,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-x86_64
         path: artifacts/ubuntu-bionic/
@@ -1216,7 +1242,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic/
@@ -1242,7 +1268,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-bionic-aarch64
         path: artifacts/ubuntu-bionic/
@@ -1274,7 +1300,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal/
@@ -1300,7 +1326,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-x86_64
         path: artifacts/ubuntu-focal/
@@ -1332,7 +1358,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal/
@@ -1358,7 +1384,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-focal-aarch64
         path: artifacts/ubuntu-focal/
@@ -1390,7 +1416,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy/
@@ -1416,7 +1442,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-x86_64
         path: artifacts/ubuntu-jammy/
@@ -1448,7 +1474,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy/
@@ -1474,7 +1500,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-ubuntu-jammy-aarch64
         path: artifacts/ubuntu-jammy/
@@ -1506,7 +1532,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-7-x86_64
         path: artifacts/centos-7/
@@ -1532,7 +1558,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-7-x86_64
         path: artifacts/centos-7/
@@ -1564,7 +1590,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8/
@@ -1590,7 +1616,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-x86_64
         path: artifacts/centos-8/
@@ -1622,7 +1648,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8/
@@ -1648,7 +1674,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-centos-8-aarch64
         path: artifacts/centos-8/
@@ -1680,7 +1706,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9/
@@ -1706,7 +1732,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'x64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-x86_64
         path: artifacts/rockylinux-9/
@@ -1738,7 +1764,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9/
@@ -1764,7 +1790,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-rockylinux-9-aarch64
         path: artifacts/rockylinux-9/
@@ -1796,7 +1822,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-x86_64
         path: artifacts/linuxmusl-x86_64/
@@ -1824,7 +1850,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-x86_64
         path: artifacts/linuxmusl-x86_64/
@@ -1856,7 +1882,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-aarch64
         path: artifacts/linuxmusl-aarch64/
@@ -1884,7 +1910,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'arm64']
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-linux-aarch64
         path: artifacts/linuxmusl-aarch64/
@@ -1917,12 +1943,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -1949,12 +1975,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-macos-aarch64
         path: artifacts/macos-aarch64
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -1982,12 +2008,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: builds-win-x86_64
         path: artifacts/win-x86_64
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: edgedb/edgedb-pkg
         ref: master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         # migrations tests work only on nightly
         edgedb-version: ["nightly"]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions-rs/toolchain@v1
@@ -56,7 +56,7 @@ jobs:
         # migrations tests work only on nightly
         edgedb-version: ["nightly"]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -99,7 +99,7 @@ jobs:
         os: [ubuntu-20.04]
       fail-fast: false
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions-rs/toolchain@v1
@@ -126,7 +126,7 @@ jobs:
         test: [portable_smoke, portable_project, portable_project_dir, portable_shared]
       fail-fast: false
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions-rs/toolchain@v1
@@ -162,7 +162,7 @@ jobs:
       _EDGEDB_WSL_DISTRO: Debian
       _EDGEDB_WSL_LINUX_BINARY: ./linux-binary/edgedb
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions-rs/toolchain@v1
@@ -208,7 +208,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Those are now available, and though a tad slower than our current hosted
runners, allow us to avoid having to maintain hosted macOS runners.
