### PR TITLE
Remove use of unmaintained `actions-rs` actions

### DIFF
--- a/.github/workflows/install_tests.yaml
+++ b/.github/workflows/install_tests.yaml
@@ -20,20 +20,17 @@ jobs:
         run: "sudo apt-get install musl-tools"
       - name: Systemd version
         run: "systemd --version"
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
         with:
-          profile: minimal
-          toolchain: stable
-          target: x86_64-unknown-linux-musl
-          default: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=x86_64-unknown-linux-musl --features github_action_install --test github-actions
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features github_action_install --test github-actions
+          components: "cargo,rustc,rust-std"
+          toolchain: "stable"
+          targets: "x86_64-unknown-linux-musl"
+      - run: |
+          cargo build --target=x86_64-unknown-linux-musl \
+            --features github_action_install --test github-actions
+      - run: |
+          cargo test --features github_action_install --test github-actions
 
   test_other:
     runs-on: ${{ matrix.os }}
@@ -44,16 +41,12 @@ jobs:
         os: [windows-2019, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
         with:
-          profile: minimal
-          toolchain: stable
-          default: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features github_action_install --tests
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features github_action_install -- github_action
+          components: "cargo,rustc,rust-std"
+          toolchain: "stable"
+      - run: |
+          cargo build --features github_action_install --tests
+      - run: |
+          cargo test --features github_action_install -- github_action

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -30,21 +30,18 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install musl-tools
         run: "sudo apt-get install musl-tools"
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
         with:
-          profile: minimal
-          toolchain: 1.58.0
-          target: x86_64-unknown-linux-musl
-          default: true
+          components: "cargo,rustc,rust-std"
+          toolchain: "stable"
+          targets: "x86_64-unknown-linux-musl"
       - name: Docker Permissions
         run: sudo chmod a+rw /var/run/docker.sock
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: |
-            --target=x86_64-unknown-linux-musl
-            --test=github-nightly
-            --features=github_nightly
-            --
+      - run: |
+          cargo test \
+            --target=x86_64-unknown-linux-musl \
+            --test=github-nightly \
+            --features=github_nightly \
+            -- \
             ${{ matrix.test_suite }}::

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,11 +29,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
         with:
-          profile: minimal
-          toolchain: stable
-          default: true
+          components: "cargo,rustc,rust-std"
+          toolchain: "stable"
 
       - name: Install EdgeDB
         uses: edgedb/setup-edgedb@v1
@@ -41,10 +41,8 @@ jobs:
         with:
           server-version: ${{ matrix.edgedb-version }}
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features github_action_install
+      - run: |
+          cargo test --features github_action_install
 
   musl-test:
     runs-on: ${{ matrix.os }}
@@ -63,17 +61,15 @@ jobs:
       - name: Install musl-tools
         run: "sudo apt-get install musl-tools"
 
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
         with:
-          profile: minimal
-          toolchain: stable
-          target: x86_64-unknown-linux-musl
-          default: true
+          components: "cargo,rustc,rust-std"
+          toolchain: "stable"
+          targets: "x86_64-unknown-linux-musl"
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=x86_64-unknown-linux-musl
+      - run: |
+          cargo build --target=x86_64-unknown-linux-musl
 
       - uses: actions/upload-artifact@v2
         with:
@@ -86,10 +82,8 @@ jobs:
         with:
           server-version: ${{ matrix.edgedb-version }}
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target=x86_64-unknown-linux-musl
+      - run: |
+          cargo test --target=x86_64-unknown-linux-musl
 
   portable-install-tests:
     runs-on: ${{ matrix.os }}
@@ -102,21 +96,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          default: true
 
-      - uses: actions-rs/cargo@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
         with:
-          command: build
-          args: --tests --features docker_test_wrapper,portable_tests
+          components: "cargo,rustc,rust-std"
+          toolchain: "stable"
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --test=docker_portable_wrapper --features docker_test_wrapper,portable_tests
+      - run: |
+          cargo build --tests --features docker_test_wrapper,portable_tests
+
+      - run: |
+          cargo test --test=docker_portable_wrapper \
+            --features docker_test_wrapper,portable_tests
 
   portable-tests-macos:
     runs-on: macos-latest
@@ -129,26 +121,23 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          default: true
 
-      - uses: actions-rs/cargo@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
         with:
-          command: build
-          args: --tests --features portable_tests
+          components: "cargo,rustc,rust-std"
+          toolchain: "stable"
+
+      - run: |
+          cargo build --tests --features portable_tests
 
       - run: |
           sudo cp target/debug/edgedb /usr/local/bin/
           mkdir home_edgedb
           sudo mv home_edgedb /Users/edgedb
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --test=${{ matrix.test }} --features portable_tests
+      - run: |
+          cargo test --test=${{ matrix.test }} --features portable_tests
 
   portable-tests-windows:
     needs: musl-test
@@ -165,21 +154,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          default: true
 
-      - uses: actions-rs/cargo@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
         with:
-          command: build
-          args: --tests --features portable_tests
+          components: "cargo,rustc,rust-std"
+          toolchain: "stable"
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -- cli install -y --no-wait-for-exit-prompt
+      - run: |
+          cargo build --tests --features portable_tests
+
+      - run: |
+          cargo run -- cli install -y --no-wait-for-exit-prompt
 
       - uses: actions/download-artifact@v2
         with:
@@ -196,10 +182,8 @@ jobs:
         with:
             distribution: Debian
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --test=${{ matrix.test }} --features portable_tests
+      - run: |
+          cargo test --test=${{ matrix.test }} --features portable_tests
 
   test-bin-installable:
     runs-on: ${{ matrix.os }}
@@ -211,13 +195,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          default: true
 
-      - uses: actions-rs/cargo@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
         with:
-          command: install
-          args: "--locked --path=. --root=$TMPDIR"
+          components: "cargo,rustc,rust-std"
+          toolchain: "stable"
+
+      - run: |
+          cargo install --locked --path=. --root=$TMPDIR


### PR DESCRIPTION
Replace `actions-rs/toolchain` with `dtolnay/rust-toolchain` and
`actions-rs/cargo` with direct `cargo` runs.
