### PR TITLE
Move the custom build.rs into a separate crate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        test: [portable_smoke, portable_project, portable_project_dir, portable_shared]
+        test: [portable_smoke, portable_project, portable_project_dir, "portable_shared --package=shared-client-tests"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -145,7 +145,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        test: [portable_smoke, portable_project, portable_project_dir, portable_shared]
+        test: [portable_smoke, portable_project, portable_project_dir, "portable_shared --package=shared-client-tests"]
       fail-fast: false
     env:
       _EDGEDB_WSL_DISTRO: Debian

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
           server-version: ${{ matrix.edgedb-version }}
 
       - run: |
-          cargo test --target=x86_64-unknown-linux-musl
+          cargo test --target=x86_64-unknown-linux-musl --all
 
   portable-install-tests:
     runs-on: ${{ matrix.os }}
@@ -104,10 +104,10 @@ jobs:
           toolchain: "stable"
 
       - run: |
-          cargo build --tests --features docker_test_wrapper,portable_tests
+          cargo build --all --tests --features docker_test_wrapper,portable_tests
 
       - run: |
-          cargo test --test=docker_portable_wrapper \
+          cargo test --all --test=docker_portable_wrapper \
             --features docker_test_wrapper,portable_tests
 
   portable-tests-macos:
@@ -115,7 +115,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        test: [portable_smoke, portable_project, portable_project_dir, "portable_shared --package=shared-client-tests"]
+        test: [portable_smoke, portable_project, portable_project_dir, portable_shared"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -137,7 +137,7 @@ jobs:
           sudo mv home_edgedb /Users/edgedb
 
       - run: |
-          cargo test --test=${{ matrix.test }} --features portable_tests
+          cargo test --all --test=${{ matrix.test }} --features portable_tests
 
   portable-tests-windows:
     needs: musl-test
@@ -145,7 +145,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        test: [portable_smoke, portable_project, portable_project_dir, "portable_shared --package=shared-client-tests"]
+        test: [portable_smoke, portable_project, portable_project_dir, portable_shared]
       fail-fast: false
     env:
       _EDGEDB_WSL_DISTRO: Debian
@@ -183,7 +183,7 @@ jobs:
             distribution: Debian
 
       - run: |
-          cargo test --test=${{ matrix.test }} --features portable_tests
+          cargo test --all --test=${{ matrix.test }} --features portable_tests
 
   test-bin-installable:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        test: [portable_smoke, portable_project, portable_project_dir, portable_shared"]
+        test: [portable_smoke, portable_project, portable_project_dir, portable_shared]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
  "clap 4.5.0",
  "clap_generate",
  "heck",
- "indexmap 1.9.3",
+ "indexmap 2.0.0-pre",
  "proc-macro-error",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ dependencies = [
  "serde_str",
  "sha1",
  "sha2",
+ "shared-client-tests",
  "shell-escape",
  "shutdown_hooks",
  "signal-hook",
@@ -3240,6 +3241,20 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shared-client-tests"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "edgedb-protocol",
+ "hex",
+ "indexmap 2.0.0-pre",
+ "predicates 2.1.5",
+ "serde_json",
+ "sha1",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     ".",
     "edgedb-cli-derive",
+    "tests/shared-client-tests",
 ]
 
 [package]
@@ -122,6 +123,7 @@ test-case = "2.0.0"
 openssl = "0.10.30"
 tokio = {version="1.1.0", features=["rt-multi-thread"]}
 warp = {git="https://github.com/seanmonstar/warp.git", rev="7b07043cee0ca24e912155db4e8f6d9ab7c049ed", default-features=false, features=["tls"]}
+shared-client-tests = {path = "./tests/shared-client-tests"}
 
 [build-dependencies]
 serde_json = "1.0"
@@ -130,7 +132,7 @@ serde_json = "1.0"
 dev_mode = []
 github_action_install = []
 github_nightly = []
-portable_tests = []
+portable_tests = ["shared-client-tests/portable_tests"]
 docker_test_wrapper = []
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,26 @@ version = "4.2.0-dev"
 authors = ["EdgeDB Inc. <hello@edgedb.com>"]
 edition = "2018"
 
+[[bin]]
+name = "edgedb"
+path = "src/main.rs"
+
+[features]
+dev_mode = []
+github_action_install = []
+github_nightly = []
+portable_tests = ["shared-client-tests/portable_tests"]
+docker_test_wrapper = []
+
+[workspace.dependencies]
+clap = "4.4.6"
+clap_generate = "3.0.3"
+termimad = "0.20.1"
+trybuild = "1.0.19"
+# we need slicing of indexmap, so need version 2.0
+indexmap = {git="https://github.com/bluss/indexmap", rev="11ac52c", features=["serde"]}
+heck = "0.4.0"
+
 [dependencies]
 edgeql-parser = {git = "https://github.com/edgedb/edgedb"}
 edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust/", features=["all-types"]}
@@ -25,7 +45,7 @@ bytes = "1.5.0"
 blake2b_simd = "1.0.0"
 blake3 = "1.1.0"
 rustyline = { git="https://github.com/tailhook/rustyline", branch="edgedb_20210403"}
-clap = {version="4.4.6", features=["derive", "cargo", "deprecated", "wrap_help"]}
+clap = {workspace = true, features=["derive", "cargo", "deprecated", "wrap_help"]}
 clap_complete = "4.4.3"
 color-print = "0.3.5"
 strsim = "0.10.0"
@@ -66,8 +86,7 @@ reqwest = {version="0.11.11", features=["json", "native-tls"]}
 native-tls = {version="0.2.4"}
 thiserror = "1.0.16"
 which = {version="4", default-features=false}
-# we need slicing of indexmap, so need version 2.0
-indexmap = {git="https://github.com/bluss/indexmap", rev="11ac52c", features=["serde"]}
+indexmap = {workspace=true}
 term = "0.7"
 libc = "0.2.68"
 urlencoding = "2.1.0"
@@ -86,7 +105,7 @@ url = { version = "2.1.1", features=["serde"] }
 immutable-chunkmap = "1.0.1"
 regex = "1.4.5"
 toml = "0.5.8"
-termimad = "0.20.1"
+termimad = {workspace=true}
 minimad = "0.9.0"
 edgedb-cli-derive = { path="edgedb-cli-derive" }
 fs-err = "2.6.0"
@@ -128,13 +147,6 @@ shared-client-tests = {path = "./tests/shared-client-tests"}
 [build-dependencies]
 serde_json = "1.0"
 
-[features]
-dev_mode = []
-github_action_install = []
-github_nightly = []
-portable_tests = ["shared-client-tests/portable_tests"]
-docker_test_wrapper = []
-
 [target.'cfg(unix)'.dependencies]
 signal-hook = {version="0.3.10", features=["iterator"]}
 nix = "0.26.2"
@@ -149,10 +161,6 @@ rexpect = {git="https://github.com/tailhook/rexpect", branch="default_terminal_s
 
 [target.'cfg(target_env="musl")'.dependencies]
 native-tls = {version="0.2.4", features=["vendored"]}
-
-[[bin]]
-name = "edgedb"
-path = "src/main.rs"
 
 [profile.dev]
 opt-level = 2 # 1 -- needed so windows don't get stack overflow, 2 - for GHA

--- a/edgedb-cli-derive/Cargo.toml
+++ b/edgedb-cli-derive/Cargo.toml
@@ -19,3 +19,4 @@ heck = {workspace = true}
 
 [lib]
 proc-macro = true
+test = false

--- a/edgedb-cli-derive/Cargo.toml
+++ b/edgedb-cli-derive/Cargo.toml
@@ -6,16 +6,16 @@ authors = ["EdgeDB Inc. <hello@edgedb.com>"]
 edition = "2018"
 
 [dependencies]
-clap = "4.4.6"
-clap_generate = "3.0.3"
-termimad = "0.20.1"
 syn = {version="1.0.72", features=["extra-traits"]}
 quote = "1.0.9"
 proc-macro2 = "1.0.78"
 proc-macro-error = "1.0.4"
-trybuild = "1.0.19"
-indexmap = "1.9.3"
-heck = "0.4.0"
+clap = {workspace = true}
+clap_generate = {workspace = true}
+termimad = {workspace = true}
+trybuild = {workspace = true}
+indexmap = {workspace = true}
+heck = {workspace = true}
 
 [lib]
 proc-macro = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ fn _main() -> anyhow::Result<()> {
         commands::cli::main(&opt)
     } else {
         cli::directory_check::check_and_warn();
-        #[cfg(feature="portable_tests")]
+
         if opt.test_output_conn_params {
             println!("{}", opt.block_on_create_connector()?.get()?.to_json());
             return Ok(());

--- a/src/options.rs
+++ b/src/options.rs
@@ -266,8 +266,7 @@ pub struct RawOptions {
     #[cfg_attr(not(feature="dev_mode"), arg(hide=true))]
     pub debug_print_codecs: bool,
 
-    #[cfg(feature="portable_tests")]
-    #[arg(long)]
+    #[arg(long, hide=true)]
     pub test_output_conn_params: bool,
 
     /// Print all available connection options
@@ -409,7 +408,6 @@ pub struct Options {
     pub debug_print_codecs: bool,
     pub output_format: Option<OutputFormat>,
     pub no_cli_update_check: bool,
-    #[cfg(feature="portable_tests")]
     pub test_output_conn_params: bool,
 }
 
@@ -747,7 +745,6 @@ impl Options {
                 None
             },
             no_cli_update_check,
-            #[cfg(feature="portable_tests")]
             test_output_conn_params: args.test_output_conn_params,
         })
     }

--- a/tests/docker_portable_wrapper.rs
+++ b/tests/docker_portable_wrapper.rs
@@ -31,6 +31,7 @@ static TEST_EXECUTABLES: Lazy<HashMap<String, PathBuf>> = Lazy::new(|| {
 
     let tests = std::process::Command::new("cargo")
         .arg("build")
+        .arg("--all")
         .arg("--tests")
         .arg("--features=docker_test_wrapper,portable_tests")
         .arg("--message-format=json")

--- a/tests/shared-client-tests/Cargo.toml
+++ b/tests/shared-client-tests/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "shared-client-tests"
+license = "MIT/Apache-2.0"
+version = "0.1.0"
+authors = ["EdgeDB Inc. <hello@edgedb.com>"]
+edition = "2018"
+
+[features]
+portable_tests = []
+
+[build-dependencies]
+serde_json = "1.0"
+
+[lib]
+path = "lib.rs"
+test = false
+doctest = false
+
+[dev-dependencies]
+tempfile = "3.1.0"
+assert_cmd = "2.0.8"
+predicates = "2.1.1"
+serde_json = "1.0"
+edgedb-protocol = { git = "https://github.com/edgedb/edgedb-rust/", features = [
+    "all-types",
+] }
+sha1 = "0.10.1"
+# we need slicing of indexmap, so need version 2.0
+indexmap = { git = "https://github.com/bluss/indexmap", rev = "11ac52c", features = [
+    "serde",
+] }
+hex = { version = "0.4.3", features = ["serde"] }

--- a/tests/shared-client-tests/build.rs
+++ b/tests/shared-client-tests/build.rs
@@ -38,12 +38,12 @@ fn main() {
         (
             "invalid_tls_security",
             "((EDGEDB_CLIENT_TLS_SECURITY|tls_security).*(don't comply|Invalid value)|\
-            Unsupported TLS security)"
+            Unsupported TLS security)",
         ),
         (
             "file_not_found",
             "(No such file or directory)|(cannot find the path)|\
-            (a value is required for)"
+            (a value is required for)",
         ),
         ("invalid_host", "invalid host"),
         (
@@ -59,7 +59,7 @@ fn main() {
         ("invalid_database", "invalid database"),
         (
             "invalid_credentials_file",
-            "(cannot read credentials file)|(a value is required for)"
+            "(cannot read credentials file)|(a value is required for)",
         ),
         (
             "no_options_or_toml",
@@ -69,11 +69,19 @@ fn main() {
             "multiple_compound_opts",
             "(cannot be used with)|(provided more than once)|(cannot be used multiple times)",
         ),
-        ("multiple_compound_env",
+        (
+            "multiple_compound_env",
             "multiple compound env vars found|\
-             [A-Z]+\\s*conflicts\\s*with\\s*[A-Z]+"),
-        ("exclusive_options", "(provided more than once)|(cannot be used multiple times)"),
-        ("credentials_file_not_found", "credentials file.*No such file"),
+             [A-Z]+\\s*conflicts\\s*with\\s*[A-Z]+",
+        ),
+        (
+            "exclusive_options",
+            "(provided more than once)|(cannot be used multiple times)",
+        ),
+        (
+            "credentials_file_not_found",
+            "credentials file.*No such file",
+        ),
         ("project_not_initialised", "project is not initialized"),
         ("secret_key_not_found", "try `edgedb cloud login`"),
         ("invalid_secret_key", "Illegal JWT token"),
@@ -85,9 +93,7 @@ fn main() {
     let mut output = BufWriter::new(out_file);
 
     let root = env::var_os("CARGO_MANIFEST_DIR").unwrap();
-    let testcases = Path::new(&root)
-        .join("tests")
-        .join("shared-client-testcases");
+    let testcases = Path::new(&root).join("..").join("shared-client-testcases");
 
     let connection_testcases = testcases.join("connection_testcases.json");
     println!(
@@ -98,11 +104,14 @@ fn main() {
         .expect("Shared test git submodule is missing: ensure git checkout includes submodules with --recurse-submodules");
     let connection_testcases: Value = serde_json::from_str(&connection_testcases).unwrap();
     let empty_map = Map::new();
-    write!(output, "
+    write!(
+        output,
+        "
 use std::sync::Mutex;
 
 static MUTEX: Mutex<()> = Mutex::new(());
-");
+"
+    );
 
     'testcase: for (i, case) in connection_testcases.as_array().unwrap().iter().enumerate() {
         let mut testcase = Vec::new();
@@ -139,7 +148,6 @@ static MUTEX: Mutex<()> = Mutex::new(());
         write!(
             testcase,
             r#"
-#[cfg(feature="portable_tests")]
 #[test]
 "#
         );
@@ -305,14 +313,20 @@ fn connection_{i}() {{
                     );
                 } else if let Some(d) = value.as_object() {
                     let mut d = d.clone();
-                    let mut project_path =
-                        d.remove("project-path").unwrap().as_str().unwrap().to_string();
+                    let mut project_path = d
+                        .remove("project-path")
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                        .to_string();
                     if matches!(platform, Some(Platform::Windows)) {
                         project_path = project_path.replace("Users\\edgedb", "Users\\runneradmin");
                     }
-                    let values = d.iter().map(|(k, v)| {
-                        format!("{k:?} => {:?}", v.as_str().unwrap())
-                    }).collect::<Vec<_>>().join(",\n        ");
+                    let values = d
+                        .iter()
+                        .map(|(k, v)| format!("{k:?} => {:?}", v.as_str().unwrap()))
+                        .collect::<Vec<_>>()
+                        .join(",\n        ");
                     write!(
                         testcase,
                         r#"
@@ -351,7 +365,12 @@ fn connection_{i}() {{
                 .get("type")
                 .unwrap()
                 .as_str()
-                .map(|e| error_mapping.get(e).map(|e| e.to_string()).unwrap_or(e.to_string()))
+                .map(|e| {
+                    error_mapping
+                        .get(e)
+                        .map(|e| e.to_string())
+                        .unwrap_or(e.to_string())
+                })
                 .unwrap();
             write!(
                 testcase,

--- a/tests/shared-client-tests/tests/portable_shared.rs
+++ b/tests/shared-client-tests/tests/portable_shared.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature="portable_tests"), allow(dead_code, unused_imports))]
+#![cfg(feature="portable_tests")]
 
 use std::fmt::{Display, Formatter};
 use std::fs;


### PR DESCRIPTION
This enables this crate to be built (but not fully tested) without cloning the git submodule.