### PR TITLE
Branching: Fix print order and migration check & apply

### DIFF
--- a/src/branch/rebase.rs
+++ b/src/branch/rebase.rs
@@ -1,5 +1,5 @@
 use colorful::Colorful;
-use indexmap::IndexMap;
+
 use uuid::Uuid;
 use crate::branch::context::Context;
 use crate::branch::option::Rebase;

--- a/src/branch/rebase.rs
+++ b/src/branch/rebase.rs
@@ -31,12 +31,14 @@ pub async fn main(options: &Rebase, context: &Context, connection: &mut Connecti
 }
 
 async fn rebase(branch: &String, source_connection: &mut Connection, target_connection: &mut Connection, context: &Context, cli_opts: &Options) -> anyhow::Result<()> {
-    let migrations = get_diverging_migrations(source_connection, target_connection).await?;
+    let mut migrations = get_diverging_migrations(source_connection, target_connection).await?;
 
     migrations.print_status();
 
     let migration_context = migrations::Context::for_project(&context.project_config)?;
-    do_rebase(&migrations, &migration_context).await?;
+    do_rebase(&mut migrations, &migration_context).await?;
+
+    eprintln!("\n"); // separate 'do_rebase' output from 'write_rebased_migration_files'
 
     write_rebased_migration_files(&migrations, &migration_context, source_connection).await?;
 

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -689,7 +689,7 @@ async fn run_interactive(_ctx: &Context, cli: &mut Connection,
 
 pub async fn write_migration(ctx: &Context, descr: &impl MigrationToText,
     verbose: bool)
-    -> anyhow::Result<()>
+    -> anyhow::Result<PathBuf>
 {
     let filename = match &descr.key() {
         MigrationKey::Index(idx) => {
@@ -701,7 +701,10 @@ pub async fn write_migration(ctx: &Context, descr: &impl MigrationToText,
             dir.join(format!("{}-{}.edgeql", descr.parent()?, target_revision))
         }
     };
-    _write_migration(descr, filename.as_ref(), verbose).await
+
+    _write_migration(descr, filename.as_ref(), verbose).await?;
+
+    Ok(filename)
 }
 
 #[context("could not write migration file {}", filepath.display())]

--- a/src/migrations/rebase.rs
+++ b/src/migrations/rebase.rs
@@ -1,20 +1,20 @@
 use std::collections::HashMap;
-use std::iter::FromIterator;
+
 use fs_err as fs;
 
-use std::ops::Index;
+
 use std::path::PathBuf;
-use anyhow::{anyhow, Context as _};
+use anyhow::{Context as _};
 use colorful::Colorful;
 use indexmap::IndexMap;
 use crate::connect::Connection;
-use crate::migrations::{Context, create, db_migration, migrate, migration};
+use crate::migrations::{Context, create, migrate, migration};
 use crate::migrations::create::{MigrationKey, MigrationToText};
 use crate::migrations::db_migration::{DBMigration, read_all};
-use crate::migrations::dev_mode::rebase_to_schema;
-use crate::migrations::extract::DatabaseMigration;
-use crate::migrations::grammar::parse_migration;
-use crate::migrations::migrate::apply_migrations_inner;
+
+
+
+
 use crate::migrations::migration::MigrationFile;
 use crate::print;
 


### PR DESCRIPTION
- Fixes the order that migrations printed to be sequential
- Fixes calculation of what migration files to apply
- Fixes migration IDs not being update within `RebaseMigrations` (which causes issues with determining what migrations to apply)