### PR TITLE
Branching: fix migration order and swap target and source connections

### DIFF
--- a/src/migrations/rebase.rs
+++ b/src/migrations/rebase.rs
@@ -241,7 +241,9 @@ pub async fn do_rebase(rebase_migrations: &RebaseMigrations, context: &Context) 
 
     // move the new migrations from temp to schema dir
     let mut last: Option<&RebaseMigrationKind> = None;
-    for (index, from) in migration::read_names(&temp_ctx).await?.iter().enumerate() {
+    let mut new_migration_files = migration::read_names(&temp_ctx).await?;
+    new_migration_files.sort();
+    for (index, from) in new_migration_files.iter().enumerate() {
         let rebase_migration = flattened_migrations.get(index);
         let to = context
             .schema_dir


### PR DESCRIPTION
Edit: I didn't see you had something similar up in #1235

This PR does two things:
- sorts the list of migration files that are read from the temp dir, so they are printed in order
- swaps target and source connections - I think you had this double swapped so it worked, but printed incorrectly.

One thing I noticed was that we definitively need tests for this.