### PR TITLE
Branches: Fix migration file calculation

### DIFF
--- a/src/branch/rebase.rs
+++ b/src/branch/rebase.rs
@@ -31,12 +31,12 @@ pub async fn main(options: &Rebase, context: &Context, source_connection: &mut C
 }
 
 async fn rebase(branch: &String, source_connection: &mut Connection, target_connection: &mut Connection, context: &Context, cli_opts: &Options, apply_migrations: bool) -> anyhow::Result<()> {
-    let migrations = get_diverging_migrations(source_connection, target_connection).await?;
+    let mut migrations = get_diverging_migrations(source_connection, target_connection).await?;
 
     migrations.print_status();
 
     let migration_context = migrations::Context::for_project(&context.project_config)?;
-    do_rebase(&migrations, &migration_context).await?;
+    do_rebase(&mut migrations, &migration_context).await?;
 
     if apply_migrations {
         write_rebased_migration_files(&migrations, &migration_context, target_connection).await?;


### PR DESCRIPTION
Since `rebase_migrations` were never updated by `rebase_migration_ids`, the check for what migration files to apply would always produce incorrect results since the the ID of the migration file didn't match anything within `rebase_migration`. This PR fixes that by updating `rebase_migrations` in `rebase_migration_ids`