### PR TITLE
Don't print server backtraces when database doesn't exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
                 err = arc.inner();
             }
             if let Some(e) = err.downcast_ref::<edgedb_errors::Error>() {
-                print::edgedb_error(e, true);
+                print::edgedb_error(e, false);
             } else {
                 print::error(err);
             }


### PR DESCRIPTION
We were just always printing a stack trace for top level errors. No
reason to do that; we should only print stack traces on ISEs
typically.

Fixes #1218.