### PR TITLE
Branches: Feedback items

### DIFF
--- a/src/branch/create.rs
+++ b/src/branch/create.rs
@@ -5,12 +5,12 @@ use crate::print;
 
 pub async fn main(
     options: &Create,
-    _context: &Context,
+    context: &Context,
     connection: &mut Connection,
 ) -> anyhow::Result<()> {
-    eprintln!("Creating branch '{}'...", options.branch);
+    eprintln!("Creating branch '{}'...", options.name);
 
-    create_branch(connection, &options.branch, options.from.as_ref(), options.empty, options.copy_data).await?;
+    create_branch(connection, &options.name, options.from.as_ref().or(Some(&context.branch)), options.empty, options.copy_data).await?;
     Ok(())
 }
 

--- a/src/branch/option.rs
+++ b/src/branch/option.rs
@@ -93,7 +93,7 @@ pub struct Rename {
     /// The new name of the branch.
     pub new_name: String,
 
-    /// Whether to force rename the branch, this will close any existing connection to the branch 
+    /// Whether to force rename the branch, this will close any existing connection to the branch
     /// before renaming it.
     #[arg(long)]
     pub force: bool,
@@ -111,8 +111,7 @@ pub struct Rebase {
     /// The branch to rebase the current branch to.
     pub target_branch: String,
 
-    /// Whether to apply migrations generated from the rebase, by default, all generated migrations
-    /// are applied automatically.
+    /// Skip applying migrations generated from the rebase
     #[arg(long)]
     pub no_apply: bool,
 }

--- a/src/branch/option.rs
+++ b/src/branch/option.rs
@@ -19,33 +19,33 @@ pub enum Command {
 #[derive(clap::Args, Debug, Clone)]
 pub struct Create {
     /// The name of the branch to create.
-    pub branch: String,
+    pub name: String,
 
     /// The optional 'base' of the branch to create.
     #[arg(long)]
     pub from: Option<String>,
 
-    /// Whether or not the new branch should contain no data.
+    /// Whether the new branch should contain no data.
     #[arg(short='e', long, conflicts_with = "copy_data")]
     pub empty: bool,
 
-    /// Whether or not to copy data from the 'base' branch.
+    /// Whether to copy data from the 'base' branch.
     #[arg(alias="cp", long)]
     pub copy_data: bool,
 }
 
-/// Drops an existing branch, removing it and it's data.
+/// Drops an existing branch, removing it and its data.
 #[derive(clap::Args, Debug, Clone)]
 pub struct Drop {
     /// The branch to drop.
     pub branch: String,
 
-    /// Whether or not to drop the branch non-interactively.
+    /// Whether to drop the branch non-interactively.
     #[arg(long)]
     pub non_interactive: bool,
 
-    /// Whether or not to force drop the branch, this will close any existing connections to the branch before dropping
-    /// it.
+    /// Whether to force drop the branch, this will close any existing connections to the branch
+    /// before dropping it.
     #[arg(long)]
     pub force: bool,
 }
@@ -56,7 +56,7 @@ pub struct Wipe {
     /// The branch to wipe.
     pub branch: String,
 
-    /// Whether or not to wipe it non-interactively.
+    /// Whether to wipe it non-interactively.
     #[arg(long)]
     pub non_interactive: bool,
 }
@@ -67,11 +67,11 @@ pub struct Switch {
     /// The branch to switch to.
     pub branch: String,
 
-    /// Whether or not to create the branch if it doesn't exist.
+    /// Whether to create the branch if it doesn't exist.
     #[arg(short='c', long)]
     pub create: bool,
 
-    /// If creating a new branch: whether or not the new branch should be empty.
+    /// If creating a new branch: whether the new branch should be empty.
     #[arg(short='e', long, conflicts_with = "copy_data")]
     pub empty: bool,
 
@@ -79,7 +79,7 @@ pub struct Switch {
     #[arg(long)]
     pub from: Option<String>,
 
-    /// If creating a new branch: whether or not to copy data from the 'base' branch.
+    /// If creating a new branch: whether to copy data from the 'base' branch.
     #[arg(alias="cp", long)]
     pub copy_data: bool,
 }
@@ -93,8 +93,8 @@ pub struct Rename {
     /// The new name of the branch.
     pub new_name: String,
 
-    /// Whether or not to force rename the branch, this will close any existing connection to the branch before renaming
-    /// it.
+    /// Whether to force rename the branch, this will close any existing connection to the branch 
+    /// before renaming it.
     #[arg(long)]
     pub force: bool,
 }
@@ -111,7 +111,8 @@ pub struct Rebase {
     /// The branch to rebase the current branch to.
     pub target_branch: String,
 
-    /// Whether or not to apply migrations generated from the rebase.
+    /// Whether to apply migrations generated from the rebase, by default, all generated migrations
+    /// are applied automatically.
     #[arg(long)]
     pub no_apply: bool,
 }

--- a/src/branch/rebase.rs
+++ b/src/branch/rebase.rs
@@ -10,6 +10,10 @@ use crate::{migrations, print};
 use crate::branch::connections::get_connection_to_modify;
 
 pub async fn main(options: &Rebase, context: &Context, source_connection: &mut Connection, cli_opts: &Options) -> anyhow::Result<()> {
+    if options.target_branch == context.branch {
+        anyhow::bail!("Cannot rebase the current branch on top of itself");
+    }
+
     let temp_branch = clone_target_branch(&options.target_branch, source_connection).await?;
 
     let mut temp_branch_connection = cli_opts.create_connector().await?.database(&temp_branch)?.connect().await?;


### PR DESCRIPTION
- `it's` -> `its`.
- `BRANCH` -> `NAME` in `edgedb branch create`.
- Add better description to `--no-apply`,
- Fix issue with `edgedb branch create` with no args erroring.
- Exit early if trying to rebase the current branch on top of itself