### PR TITLE
Allow specifying SNI separately from host address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,7 +1048,7 @@ dependencies = [
  "futures-util",
  "gethostname",
  "hex",
- "humantime 2.1.0",
+ "humantime",
  "humantime-serde",
  "immutable-chunkmap",
  "indexmap 2.0.0-pre",
@@ -1091,7 +1091,7 @@ dependencies = [
  "shell-escape",
  "shutdown_hooks",
  "signal-hook",
- "snafu",
+ "snafu 0.7.5",
  "strsim 0.10.0",
  "tar",
  "tempfile",
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.5.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#da9c81b7d06586818fa973bf0f91a9a9e99a48e7"
+source = "git+https://github.com/edgedb/edgedb-rust/#2c5ba183b7d66e57cceaa6822269a9b6972305dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.4.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#da9c81b7d06586818fa973bf0f91a9a9e99a48e7"
+source = "git+https://github.com/edgedb/edgedb-rust/#2c5ba183b7d66e57cceaa6822269a9b6972305dd"
 dependencies = [
  "bytes",
 ]
@@ -1159,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.6.0"
-source = "git+https://github.com/edgedb/edgedb-rust/#da9c81b7d06586818fa973bf0f91a9a9e99a48e7"
+source = "git+https://github.com/edgedb/edgedb-rust/#2c5ba183b7d66e57cceaa6822269a9b6972305dd"
 dependencies = [
  "bigdecimal",
  "bitflags 2.4.2",
@@ -1168,14 +1168,14 @@ dependencies = [
  "edgedb-errors",
  "num-bigint 0.4.4",
  "num-traits",
- "snafu",
+ "snafu 0.8.2",
  "uuid",
 ]
 
 [[package]]
 name = "edgedb-tokio"
 version = "0.5.0"
-source = "git+https://github.com/edgedb/edgedb-rust/#da9c81b7d06586818fa973bf0f91a9a9e99a48e7"
+source = "git+https://github.com/edgedb/edgedb-rust/#2c5ba183b7d66e57cceaa6822269a9b6972305dd"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1223,7 +1223,7 @@ dependencies = [
  "phf",
  "serde_json",
  "sha2",
- "snafu",
+ "snafu 0.7.5",
  "thiserror",
  "unicode-width",
 ]
@@ -1262,16 +1262,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
-name = "env_logger"
-version = "0.5.13"
+name = "env_filter"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
- "atty",
- "humantime 1.3.0",
  "log",
  "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1280,11 +1277,24 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
- "humantime 2.1.0",
+ "humantime",
  "is-terminal",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -1771,15 +1781,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -1790,7 +1791,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
- "humantime 2.1.0",
+ "humantime",
  "serde",
 ]
 
@@ -1811,7 +1812,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2089,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "value-bag",
 ]
@@ -2755,12 +2756,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3334,7 +3329,16 @@ checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
 dependencies = [
  "backtrace",
  "doc-comment",
- "snafu-derive",
+ "snafu-derive 0.7.5",
+]
+
+[[package]]
+name = "snafu"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75976f4748ab44f6e5332102be424e7c2dc18daeaf7e725f2040c3ebb133512e"
+dependencies = [
+ "snafu-derive 0.8.2",
 ]
 
 [[package]]
@@ -3347,6 +3351,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b19911debfb8c2fb1107bc6cb2d61868aaf53a988449213959bb1b5b1ed95f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3556,7 +3572,7 @@ dependencies = [
 [[package]]
 name = "test-cert-gen"
 version = "0.10.0-pre"
-source = "git+https://github.com/elprans/rust-tls-api.git?branch=rustls-22#93aec28296dde657826f9bfb5bc75bddfe5b5d08"
+source = "git+https://github.com/elprans/rust-tls-api.git?branch=rustls-22#b73652c53e1cbdc676f4f1cd3645cab00be514e5"
 dependencies = [
  "once_cell",
  "pem",
@@ -3632,7 +3648,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tls-api"
 version = "0.10.0-pre"
-source = "git+https://github.com/elprans/rust-tls-api.git?branch=rustls-22#93aec28296dde657826f9bfb5bc75bddfe5b5d08"
+source = "git+https://github.com/elprans/rust-tls-api.git?branch=rustls-22#b73652c53e1cbdc676f4f1cd3645cab00be514e5"
 dependencies = [
  "anyhow",
  "pem",
@@ -3644,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "tls-api-not-tls"
 version = "0.10.0-pre"
-source = "git+https://github.com/elprans/rust-tls-api.git?branch=rustls-22#93aec28296dde657826f9bfb5bc75bddfe5b5d08"
+source = "git+https://github.com/elprans/rust-tls-api.git?branch=rustls-22#b73652c53e1cbdc676f4f1cd3645cab00be514e5"
 dependencies = [
  "anyhow",
  "thiserror",
@@ -3656,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "tls-api-rustls"
 version = "0.10.0-pre"
-source = "git+https://github.com/elprans/rust-tls-api.git?branch=rustls-22#93aec28296dde657826f9bfb5bc75bddfe5b5d08"
+source = "git+https://github.com/elprans/rust-tls-api.git?branch=rustls-22#b73652c53e1cbdc676f4f1cd3645cab00be514e5"
 dependencies = [
  "anyhow",
  "rustls",
@@ -3671,10 +3687,10 @@ dependencies = [
 [[package]]
 name = "tls-api-test"
 version = "0.10.0-pre"
-source = "git+https://github.com/elprans/rust-tls-api.git?branch=rustls-22#93aec28296dde657826f9bfb5bc75bddfe5b5d08"
+source = "git+https://github.com/elprans/rust-tls-api.git?branch=rustls-22#b73652c53e1cbdc676f4f1cd3645cab00be514e5"
 dependencies = [
  "anyhow",
- "env_logger 0.5.13",
+ "env_logger 0.11.3",
  "log",
  "pem",
  "rustls-webpki",

--- a/src/options.rs
+++ b/src/options.rs
@@ -195,6 +195,16 @@ pub struct ConnectionOptions {
     #[arg(global=true)]
     tls_security: Option<String>,
 
+    /// Override server name used for TLS connections and certificate
+    /// verification.
+    ///
+    /// Useful when the server hostname cannot be used as it
+    /// does not resolve, or resolves to a wrong IP address,
+    /// and a different name or IP address is used in `--host`.
+    #[arg(long)]
+    #[arg(global=true)]
+    pub tls_server_name: Option<String>,
+
     /// Retry up to WAIT_TIME (e.g. '30s') in case EdgeDB connection
     /// cannot be established.
     #[arg(
@@ -955,6 +965,9 @@ pub fn load_tls_options(options: &ConnectionOptions, builder: &mut Builder)
     }
     if let Some(s) = security {
         builder.tls_security(s);
+    }
+    if let Some(tls_server_name) = &options.tls_server_name {
+        builder.tls_server_name(tls_server_name)?;
     }
     Ok(())
 }

--- a/tests/shared-client-tests/build.rs
+++ b/tests/shared-client-tests/build.rs
@@ -29,6 +29,7 @@ fn main() {
         ("tlsSecurity", "--tls-security"),
         ("tlsCA", "--tls-ca-file"),
         ("tlsCAFile", "--tls-ca-file"),
+        ("tlsServerName", "--tls-server-name"),
         ("waitUntilAvailable", "--wait-until-available"),
         ("secretKey", "--secret-key"),
     ]);


### PR DESCRIPTION
Make the CLI recognize the `EDGEDB_TLS_SERVER_NAME` environment variable
and the `--tls-server-name` command line argument as the SNI override.
Useful for when the target instance address cannot be resolved correctly
from a hostname, but the SNI is still desirable for TLS verification
and/or tenant selection reasons.
