### PR TITLE
Branches: project init writes correct branch in credentials.json & prompts for branch

### DIFF
--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -26,6 +26,7 @@ use crate::process;
 use crate::question;
 
 use edgedb_tokio::credentials::Credentials;
+use crate::portable::project::get_default_branch_name;
 
 fn ask_name(
     cloud_client: &mut cloud::client::CloudClient
@@ -149,12 +150,13 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
             || anyhow::Ok(Query::stable()),
         )?;
         let inst = install::version(&query).context("error installing EdgeDB")?;
+        let specific_version = &inst.version.specific();
         let info = InstanceInfo {
             name: name.clone(),
             installation: Some(inst),
             port,
         };
-        bootstrap(&paths, &info, &cmd.default_user)?;
+        bootstrap(&paths, &info, &cmd.default_user, cmd.default_branch.as_ref().unwrap_or(&get_default_branch_name(specific_version)))?;
         info
     };
 
@@ -363,7 +365,7 @@ fn bootstrap_script(user: &str, password: &str) -> String {
 }
 
 #[context("cannot bootstrap EdgeDB instance")]
-pub fn bootstrap(paths: &Paths, info: &InstanceInfo, user: &str)
+pub fn bootstrap(paths: &Paths, info: &InstanceInfo, user: &str, database: &String)
     -> anyhow::Result<()>
 {
     let server_path = info.server_path()?;
@@ -401,7 +403,7 @@ pub fn bootstrap(paths: &Paths, info: &InstanceInfo, user: &str)
     let mut creds = Credentials::default();
     creds.port = info.port;
     creds.user = user.into();
-    creds.database = Some("edgedb".into());
+    creds.database = Some(database.clone());
     creds.password = Some(password.into());
     creds.tls_ca = Some(cert);
     credentials::write(&paths.credentials, &creds)?;

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -156,7 +156,13 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
             installation: Some(inst),
             port,
         };
-        bootstrap(&paths, &info, &cmd.default_user, cmd.default_branch.as_ref().unwrap_or(&get_default_branch_name(specific_version)))?;
+        bootstrap(
+            &paths,
+            &info,
+            &cmd.default_user,
+            &cmd.default_branch.clone()
+                .unwrap_or_else(||get_default_branch_name(specific_version))
+        )?;
         info
     };
 

--- a/src/portable/credentials.rs
+++ b/src/portable/credentials.rs
@@ -38,12 +38,12 @@ pub fn show_credentials(options: &Options, c: &ShowCredentials) -> anyhow::Resul
         Some(url.to_string())
     } else {
         crate::table::settings(&[
-            ("Host", creds.host.as_deref().unwrap_or("localhost")),
-            ("Port", creds.port.to_string().as_str()),
-            ("User", creds.user.as_str()),
-            ("Password", creds.password.map(|_| "<hidden>").unwrap_or("<none>")),
-            ("Database", creds.database.as_deref().unwrap_or("<default>")),
-            ("TLS Security", format!("{:?}", creds.tls_security).as_str()),
+            ("Host", creds.host.unwrap_or("localhost".to_string())),
+            ("Port", creds.port.to_string()),
+            ("User", creds.user),
+            ("Password", creds.password.map(|_| "<hidden>".to_string()).unwrap_or("<none>".to_string())),
+            ("Database", creds.database.unwrap_or("<default>".to_string())),
+            ("TLS Security", format!("{:?}", creds.tls_security)),
         ]);
         None
     } {

--- a/src/portable/info.rs
+++ b/src/portable/info.rs
@@ -65,8 +65,8 @@ pub fn info(options: &Info) -> anyhow::Result<()> {
         })?)
     } else {
         table::settings(&[
-            ("Version", &inst.version.to_string()),
-            ("Binary path", &inst.server_path()?.display().to_string()),
+            ("Version", inst.version.to_string()),
+            ("Binary path", inst.server_path()?.display().to_string()),
         ]);
     }
     Ok(())

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -231,6 +231,10 @@ pub struct Create {
     #[arg(long, default_value="edgedb")]
     pub default_user: String,
 
+    /// The default branch name. This defaults to 'main' on EdgeDB >=5.x; otherwise
+    /// 'edgedb' is used.
+    pub default_branch: Option<String>,
+
     /// Do not ask questions, assume user wants to upgrade instance
     #[arg(long)]
     pub non_interactive: bool,

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -41,7 +41,7 @@ use crate::portable::windows;
 use crate::options::CloudOptions;
 use crate::portable::ver::Specific;
 use crate::print::{self, echo, Highlight};
-use crate::prompt::variable::Str;
+
 use crate::question;
 use crate::table;
 

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -699,7 +699,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
             ver::print_version_hint(specific_version, &ver_query);
 
             let mut branch: Option<String> = None;
-            if specific_version.major >= 5 {
+            if !options.non_interactive && specific_version.major >= 5 {
                 branch = Some(ask_branch()?);
             }
 
@@ -739,7 +739,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
                 &stash_dir,
                 &project_dir,
                 &schema_dir,
-                &branch.unwrap_or(get_default_branch_or_database(specific_version, project_dir)),
+                &branch.unwrap_or(get_default_branch_name(specific_version)),
                 options
             )
         }
@@ -977,7 +977,7 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
             ver::print_version_hint(specific_version, &ver_query);
 
             let mut branch: Option<String> = None;
-            if specific_version.major >= 5 {
+            if !options.non_interactive && specific_version.major >= 5 {
                 branch = Some(ask_branch()?);
             }
 
@@ -1018,7 +1018,7 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
                 &stash_dir,
                 &project_dir,
                 &schema_dir,
-                &branch.unwrap_or(get_default_branch_or_database(specific_version, project_dir)),
+                &branch.unwrap_or(get_default_branch_name(specific_version)),
                 options
             )
         }

--- a/src/table.rs
+++ b/src/table.rs
@@ -32,7 +32,7 @@ pub fn header_cell(title: &str) -> Cell {
         .with_style(Attr::Dim)
 }
 
-pub fn settings(rows: &[(&str, &str)]) {
+pub fn settings(rows: &[(&str, String)]) {
     let mut table = Table::new();
     for (title, value) in rows {
         table.add_row(Row::new(vec![


### PR DESCRIPTION
This PR fixes issues with newer projects still containing `edgedb` as the `database` in `credentials.json` by writing the correct database/branch information into the credentials for bot `edgedb project init` and `edgedb instance create`.

This also adds the correct prompt text for EdgeDB >=5.x on project init for branch names, as well as adds a prompt when creating a new project for the default branch name if the project version is >=5.x