### PR TITLE
Branches: Actually use the cached current database in REPL state

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -300,8 +300,6 @@ impl State {
             return Ok(None);
         }
 
-        eprintln!("GCD");
-
         Ok(
             self.connection.as_mut().unwrap()
                 .query_required_single("select sys::get_current_database()", &()).await?

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -181,7 +181,7 @@ impl State {
         self.connection = Some(conn);
         self.read_state();
         self.set_idle_transaction_timeout().await?;
-        self.current_database = Some(database.to_string());
+        self.current_database = Some(self.try_get_current_database().await?.unwrap_or(database.to_string()));
         Ok(())
     }
     pub async fn soft_reconnect(&mut self) -> anyhow::Result<()> {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -181,7 +181,7 @@ impl State {
         self.connection = Some(conn);
         self.read_state();
         self.set_idle_transaction_timeout().await?;
-        self.current_database = self.try_get_current_database().await?;
+        self.current_database = Some(database.to_string());
         Ok(())
     }
     pub async fn soft_reconnect(&mut self) -> anyhow::Result<()> {
@@ -292,9 +292,15 @@ impl State {
     }
 
     pub async fn try_get_current_database(&mut self) -> anyhow::Result<Option<String>> {
+        if let Some(current_database) = &self.current_database {
+            return Ok(Some(current_database.clone()))
+        }
+
         if self.connection.is_none() {
             return Ok(None);
         }
+
+        eprintln!("GCD");
 
         Ok(
             self.connection.as_mut().unwrap()


### PR DESCRIPTION
Fixes a bug with the REPL to _not_ query the current connected database every time the prompt for edgeql input is presented by using the cached `current_database` field.