### PR TITLE
Update flake for macOS silicon (aarch64-darwin)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
   outputs = inputs@{ flake-parts, fenix, edgedb, ... }:
     flake-parts.lib.mkFlake {inherit inputs;} {
-      systems = ["x86_64-linux" "x86_64-darwin"];
+      systems = ["x86_64-linux" "x86_64-darwin" "aarch64-darwin"];
       perSystem = { config, system, pkgs, ... }:
         let
           fenix_pkgs = fenix.packages.${system};
@@ -41,6 +41,11 @@
 
               # needed for running tests
               edgedb.packages.${system}.edgedb-server
+            ]
+            ++ pkgs.lib.optional pkgs.stdenv.isDarwin [
+              pkgs.libiconv
+              pkgs.darwin.apple_sdk.frameworks.CoreServices
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
             ];
           };
         };


### PR DESCRIPTION
Also include missing Apple frameworks needed to build the CLI on Apple devices.

BTW, I get a hash mismatch on the `edgedb-server` derivation for `aarch64-darwin`, so we'll want to update that flake as well.