### PR TITLE
Add info for install path

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::path::{PathBuf, MAIN_SEPARATOR};
 
 use prettytable::{Table, Row, Cell};
@@ -66,16 +65,6 @@ pub fn info(_options: &Options, info: &Info)-> Result<(), anyhow::Error> {
         Cell::new("Config"),
         Cell::new(&dir_to_str(platform::config_dir()?)),
     ]));
-    if let Ok(current_exe) = env::current_exe() {
-        table.add_row(Row::new(vec![
-            if current_exe == platform::binary_path()? {
-                Cell::new("CLI Binary")
-            } else {
-                Cell::new("Custom Binary")
-            },
-            Cell::new(&current_exe.display().to_string()),
-        ]));
-    }
     if let Some(dir) = platform::binary_path()?.parent() {
         table.add_row(Row::new(vec![
             Cell::new("Install"),

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -16,6 +16,16 @@ fn dir_to_str(path: PathBuf) -> String {
 
 pub fn specific_info(item: &str) -> Result<(), anyhow::Error> {
     match item {
+        "install-dir" => {
+            if let Some(path) = platform::binary_path()?.parent() {
+                println!("{}", dir_to_str(path.to_path_buf()));
+            }
+        }
+        "binary-dir" => {
+            if let Some(path) = env::current_exe()?.parent() {
+                println!("{}", dir_to_str(path.to_path_buf()));
+            }
+        }
         "config-dir" => {
             println!("{}", dir_to_str(platform::config_dir()?));
         }
@@ -69,6 +79,12 @@ pub fn info(_options: &Options, info: &Info)-> Result<(), anyhow::Error> {
                 Cell::new("Custom Binary")
             },
             Cell::new(&current_exe.display().to_string()),
+        ]));
+    }
+    if let Some(dir) = platform::binary_path()?.parent() {
+        table.add_row(Row::new(vec![
+            Cell::new("Install"),
+            Cell::new(&dir_to_str(dir.to_path_buf())),
         ]));
     }
     let data_dir = platform::data_dir()?;

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -21,11 +21,6 @@ pub fn specific_info(item: &str) -> Result<(), anyhow::Error> {
                 println!("{}", dir_to_str(path.to_path_buf()));
             }
         }
-        "binary-dir" => {
-            if let Some(path) = env::current_exe()?.parent() {
-                println!("{}", dir_to_str(path.to_path_buf()));
-            }
-        }
         "config-dir" => {
             println!("{}", dir_to_str(platform::config_dir()?));
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -415,6 +415,8 @@ pub struct UI {
 #[derive(clap::Args, Debug, Clone)]
 pub struct Info {
    #[arg(long, value_parser=[
+        "install-dir",
+        "binary-dir",
         "config-dir",
         "cache-dir",
         "data-dir",
@@ -422,6 +424,8 @@ pub struct Info {
     ])]
     /// Get specific value:
     ///
+    /// * `install-dir` -- Directory where EdgeDB CLI is installed
+    /// * `binary-dir` -- Directory where the current binary is located
     /// * `config-dir` -- Base configuration directory
     /// * `cache-dir` -- Base cache directory
     /// * `data-dir` -- Base data directory (except on Windows)

--- a/src/options.rs
+++ b/src/options.rs
@@ -416,7 +416,6 @@ pub struct UI {
 pub struct Info {
    #[arg(long, value_parser=[
         "install-dir",
-        "binary-dir",
         "config-dir",
         "cache-dir",
         "data-dir",
@@ -425,7 +424,6 @@ pub struct Info {
     /// Get specific value:
     ///
     /// * `install-dir` -- Directory where EdgeDB CLI is installed
-    /// * `binary-dir` -- Directory where the current binary is located
     /// * `config-dir` -- Base configuration directory
     /// * `cache-dir` -- Base cache directory
     /// * `data-dir` -- Base data directory (except on Windows)


### PR DESCRIPTION
This allows getting both the containing path to the currently executing binary under `binary-dir`, but also the path that the self-installer would install the binary to under `install-dir`.

There are some slight naming confusions happening here since we were calling the install path the "binary path". Open to doing a naming refactor here to clean that up.