### PR TITLE
Optimize syscalls

### DIFF
--- a/src/branch/main.rs
+++ b/src/branch/main.rs
@@ -6,7 +6,7 @@ use crate::options::Options;
 
 use edgedb_tokio::get_project_dir;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn branch_main(options: &Options, cmd: &BranchCommand) -> anyhow::Result<()> {
     let context = create_context().await?;
 

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -38,7 +38,7 @@ pub fn login(_c: &options::Login, options: &CloudOptions) -> anyhow::Result<()> 
     do_login(&mut client)
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn do_login(client: &mut CloudClient) -> anyhow::Result<()> {
     _do_login(client).await
 }

--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -190,7 +190,7 @@ pub struct CloudOperation {
     pub subsequent_id: Option<String>,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn get_current_region(
     client: &CloudClient,
 ) -> anyhow::Result<Region> {
@@ -203,7 +203,7 @@ pub async fn get_current_region(
         })
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn get_versions(
     client: &CloudClient,
 ) -> anyhow::Result<Vec<Version>> {
@@ -216,7 +216,7 @@ pub async fn get_versions(
         })
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn get_prices(
     client: &CloudClient,
 ) -> anyhow::Result<Prices> {
@@ -244,7 +244,7 @@ pub async fn get_prices(
     Ok(resp.prices)
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn find_cloud_instance_by_name(
     inst: &str,
     org: &str,
@@ -260,7 +260,7 @@ pub async fn find_cloud_instance_by_name(
         })
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn get_org(
     org: &str,
     client: &CloudClient,
@@ -311,7 +311,7 @@ async fn wait_for_operation(
     anyhow::bail!("Operation is taking too long, stopping monitor.")
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn create_cloud_instance(
     client: &CloudClient,
     request: &CloudInstanceCreate,
@@ -330,7 +330,7 @@ pub async fn create_cloud_instance(
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn resize_cloud_instance(
     client: &CloudClient,
     request: &CloudInstanceResize,
@@ -350,7 +350,7 @@ pub async fn resize_cloud_instance(
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn upgrade_cloud_instance(
     client: &CloudClient,
     request: &CloudInstanceUpgrade,
@@ -377,7 +377,7 @@ pub fn prompt_cloud_login(client: &mut CloudClient) -> anyhow::Result<()> {
     }
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn destroy_cloud_instance(
     name: &str,
     org: &str,
@@ -422,7 +422,7 @@ pub async fn list(
     Ok(rv)
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn get_status(
     client: &CloudClient,
     instance: &CloudInstance,

--- a/src/cloud/secret_keys.rs
+++ b/src/cloud/secret_keys.rs
@@ -59,7 +59,7 @@ pub fn list(c: &options::ListSecretKeys, options: &CloudOptions) -> anyhow::Resu
     do_list(c, &CloudClient::new(options)?)
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn do_list(c: &options::ListSecretKeys, client: &CloudClient) -> anyhow::Result<()> {
     _do_list(c, client).await
 }
@@ -107,7 +107,7 @@ pub fn create(c: &options::CreateSecretKey, options: &CloudOptions) -> anyhow::R
     do_create(c, &CloudClient::new(options)?)
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn do_create(c: &options::CreateSecretKey, client: &CloudClient) -> anyhow::Result<()> {
     _do_create(c, client).await
 }
@@ -163,7 +163,7 @@ pub fn revoke(c: &options::RevokeSecretKey, options: &CloudOptions) -> anyhow::R
     do_revoke(c, &CloudClient::new(options)?)
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn do_revoke(c: &options::RevokeSecretKey, client: &CloudClient) -> anyhow::Result<()> {
     _do_revoke(c, client).await
 }

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -13,7 +13,7 @@ use crate::portable;
 use crate::print::style::Styler;
 use crate::watch;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn common_cmd(_options: &Options, cmdopt: commands::Options, cmd: &Common)
     -> Result<(), anyhow::Error>
 {

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -163,7 +163,7 @@ fn _get_local_ui_secret_key(cfg: &edgedb_tokio::Config) -> anyhow::Result<Option
     }
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn open_url(url: &str) -> Result<reqwest::Response, reqwest::Error> {
     reqwest::Client::builder()
         .danger_accept_invalid_certs(true)

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -45,7 +45,7 @@ pub fn all_instance_names() -> anyhow::Result<BTreeSet<String>> {
     Ok(result)
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 #[context("cannot write credentials file {}", path.display())]
 pub async fn write(path: &Path, credentials: &Credentials)
     -> anyhow::Result<()>

--- a/src/migrations/edit.rs
+++ b/src/migrations/edit.rs
@@ -68,7 +68,7 @@ fn print_diff(path1: &Path, data1: &str, path2: &Path, data2: &str) {
     }
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn edit_no_check(_common: &Options, options: &MigrationEdit)
     -> Result<(), anyhow::Error>
 {

--- a/src/migrations/log.rs
+++ b/src/migrations/log.rs
@@ -46,7 +46,7 @@ async fn _log_db(cli: &mut Connection, _common: &Options,
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn log_fs(common: &Options, options: &MigrationLog)
     -> Result<(), anyhow::Error>
 {

--- a/src/non_interactive.rs
+++ b/src/non_interactive.rs
@@ -27,7 +27,7 @@ use crate::repl::OutputFormat;
 use crate::statement::{read_statement, EndOfFile};
 
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn noninteractive_main(q: &Query, options: &Options)
     -> Result<(), anyhow::Error>
 {
@@ -73,7 +73,7 @@ pub async fn noninteractive_main(q: &Query, options: &Options)
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn interpret_stdin(options: &Options, fmt: OutputFormat)
     -> Result<(), anyhow::Error>
 {

--- a/src/options.rs
+++ b/src/options.rs
@@ -842,7 +842,7 @@ impl Options {
         }
     }
 
-    #[tokio::main]
+    #[tokio::main(flavor = "current_thread")]
     pub async fn block_on_create_connector(&self) -> anyhow::Result<Connector>
     {
         self.create_connector().await

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -339,8 +339,7 @@ impl InstanceInfo {
         -> anyhow::Result<InstanceInfo>
     {
         let f = io::BufReader::new(fs::File::open(path)?);
-        let reader = std::io::BufReader::new(f);
-        let mut data: InstanceInfo = serde_json::from_reader(reader)?;
+        let mut data: InstanceInfo = serde_json::from_reader(f)?;
         data.name = name.into();
         Ok(data)
     }

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -339,7 +339,8 @@ impl InstanceInfo {
         -> anyhow::Result<InstanceInfo>
     {
         let f = io::BufReader::new(fs::File::open(path)?);
-        let mut data: InstanceInfo = serde_json::from_reader(f)?;
+        let reader = std::io::BufReader::new(f);
+        let mut data: InstanceInfo = serde_json::from_reader(reader)?;
         data.name = name.into();
         Ok(data)
     }

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -1106,7 +1106,7 @@ fn start(handle: &Handle) -> anyhow::Result<()> {
     }
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn create_database(inst: &Handle<'_>) -> anyhow::Result<()> {
     create_database_async(inst).await
 }
@@ -1133,7 +1133,7 @@ async fn create_database_async(inst: &Handle<'_>) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn migrate(inst: &Handle<'_>, ask_for_running: bool)
     -> anyhow::Result<()>
 {

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -176,7 +176,7 @@ async fn _get_json<T>(url: &Url) -> Result<T, anyhow::Error>
 }
 
 #[context("failed to fetch JSON at URL: {}", url)]
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn get_json<T>(url: &Url, timeo: Duration) -> Result<T, anyhow::Error>
     where T: serde::de::DeserializeOwned,
 {
@@ -366,7 +366,7 @@ pub fn get_specific_package(version: &ver::Specific)
 }
 
 #[context("failed to download file at URL: {}", url)]
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn download(dest: impl AsRef<Path>, url: &Url, quiet: bool)
     -> Result<blake2b_simd::Hash, anyhow::Error>
 {

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -301,7 +301,7 @@ pub async fn try_connect(creds: &Credentials) -> (Option<String>, ConnectionStat
     }
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn remote_status_with_feedback(name: &str, quiet: bool)
     -> anyhow::Result<RemoteStatus>
 {
@@ -477,7 +477,7 @@ async fn get_remote_and_cloud(
     }
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn get_remote(
     visited: &BTreeSet<String>,
     opts: &crate::options::Options,

--- a/src/portable/upgrade.rs
+++ b/src/portable/upgrade.rs
@@ -348,7 +348,7 @@ pub fn dump_and_stop(inst: &InstanceInfo, path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn block_on_dump_instance(inst: &InstanceInfo, destination: &Path)
     -> anyhow::Result<()>
 {

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -267,7 +267,8 @@ pub fn destroy(options: &options::Destroy, name: &str) -> anyhow::Result<()> {
 #[context("cannot read {:?}", path)]
 fn read_wsl(path: &Path) -> anyhow::Result<WslInfo> {
     let file = io::BufReader::new(fs::File::open(path)?);
-    Ok(serde_json::from_reader(file)?)
+    let reader = std::io::BufReader::new(file);
+    Ok(serde_json::from_reader(reader)?)
 }
 
 #[context("cannot unpack debian distro from {:?}", zip_path)]

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -266,8 +266,7 @@ pub fn destroy(options: &options::Destroy, name: &str) -> anyhow::Result<()> {
 
 #[context("cannot read {:?}", path)]
 fn read_wsl(path: &Path) -> anyhow::Result<WslInfo> {
-    let file = io::BufReader::new(fs::File::open(path)?);
-    let reader = std::io::BufReader::new(file);
+    let reader = io::BufReader::new(fs::File::open(path)?);
     Ok(serde_json::from_reader(reader)?)
 }
 

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -43,13 +43,15 @@ impl Cache {
 
 fn read_cache(dir: &Path) -> anyhow::Result<Cache> {
     let file = fs::File::open(dir.join("version_check.json"))?;
-    Ok(serde_json::from_reader(file)?)
+    let reader = std::io::BufReader::new(file);
+    Ok(serde_json::from_reader(reader)?)
 }
 
 #[context("error writing {}/version_check.json", dir.display())]
 fn write_cache(dir: &Path, data: &Cache) -> anyhow::Result<()> {
     let file = fs::File::create(dir.join("version_check.json"))?;
-    Ok(serde_json::to_writer_pretty(file, data)?)
+    let writer = std::io::BufWriter::new(file);
+    Ok(serde_json::to_writer_pretty(writer, data)?)
 }
 
 fn newer_warning(ver: &ver::Semver) {


### PR DESCRIPTION
- use current-thread tokio runtime instead of multi-threaded default
- use buffered reader in a few places

I've looked at syscalls produced by our CLI and there were two obvious inefficiencies:
- we were sometimes reading files byte-by-byte,
- everywhere we use `tokio::main`, we first spawned 16 (one for each cpu) threads and then joined them back together after the call ended.
