### PR TITLE
Apply lints suggested by cargo clippy

### DIFF
--- a/edgedb-cli-derive/src/attrib.rs
+++ b/edgedb-cli-derive/src/attrib.rs
@@ -43,13 +43,13 @@ pub enum SubcommandAttr {
 }
 
 pub enum Case {
-    CamelCase,
-    SnakeCase,
-    KebabCase,
-    ShoutySnakeCase,
-    MixedCase,
-    TitleCase,
-    ShoutyKebabCase,
+    Camel,
+    Snake,
+    Kebab,
+    ShoutySnake,
+    Mixed,
+    Title,
+    ShoutyKebab,
 }
 
 pub struct ContainerAttrs {
@@ -117,9 +117,7 @@ impl Parse for ContainerAttr {
             let _eq: syn::Token![=] = input.parse()?;
             let value: syn::Expr = input.parse()?;
             Ok(Value { name, value })
-        } else if lookahead.peek(syn::Token![,]) {
-            Ok(Default(name))
-        } else if input.cursor().eof() {
+        } else if lookahead.peek(syn::Token![,]) || input.cursor().eof() {
             Ok(Default(name))
         } else {
             Err(lookahead.error())
@@ -187,9 +185,7 @@ impl Parse for FieldAttr {
                 let _eq: syn::Token![=] = input.parse()?;
                 let value: syn::Expr = input.parse()?;
                 Ok(Value { name, value })
-            } else if lookahead.peek(syn::Token![,]) {
-                Ok(Default(name))
-            } else if input.cursor().eof() {
+            } else if lookahead.peek(syn::Token![,]) || input.cursor().eof() {
                 Ok(Default(name))
             } else {
                 Err(lookahead.error())
@@ -222,9 +218,7 @@ impl Parse for SubcommandAttr {
                 let _eq: syn::Token![=] = input.parse()?;
                 let value: syn::Expr = input.parse()?;
                 Ok(Value { name, value })
-            } else if lookahead.peek(syn::Token![,]) {
-                Ok(Default(name))
-            } else if input.cursor().eof() {
+            } else if lookahead.peek(syn::Token![,]) || input.cursor().eof() {
                 Ok(Default(name))
             } else {
                 Err(lookahead.error())
@@ -257,7 +251,7 @@ impl ContainerAttrs {
 
         let mut res = ContainerAttrs {
             main: false,
-            rename_all: Case::KebabCase,
+            rename_all: Case::Kebab,
         };
         for attr in attrs {
             if matches!(attr.style, syn::AttrStyle::Outer) &&
@@ -414,13 +408,13 @@ impl TryFrom<syn::Expr> for Case {
         match val {
             syn::Expr::Lit(syn::ExprLit { lit: syn::Lit::Str(s), ..}) => {
                 let case = match &s.value()[..] {
-                    "CamelCase" => Case::CamelCase,
-                    "snake_case" => Case::SnakeCase,
-                    "kebab-case" => Case::KebabCase,
-                    "SHOUTY_SNAKE_CASE" => Case::ShoutySnakeCase,
-                    "mixedCase" => Case::MixedCase,
-                    "Title Case" => Case::TitleCase,
-                    "SHOUTY-KEBAB-CASE" => Case::ShoutyKebabCase,
+                    "CamelCase" => Case::Camel,
+                    "snake_case" => Case::Snake,
+                    "kebab-case" => Case::Kebab,
+                    "SHOUTY_SNAKE_CASE" => Case::ShoutySnake,
+                    "mixedCase" => Case::Mixed,
+                    "Title Case" => Case::Title,
+                    "SHOUTY-KEBAB-CASE" => Case::ShoutyKebab,
                     _ => {
                         return Err(syn::Error::new_spanned(s,
                             format!("undefined case conversion")));
@@ -437,16 +431,14 @@ impl TryFrom<syn::Expr> for Case {
 
 impl Case {
     pub fn convert(&self, s: &str) -> String {
-        use Case::*;
-
         match self {
-            CamelCase => heck::ToUpperCamelCase::to_upper_camel_case(s),
-            SnakeCase => heck::ToSnakeCase::to_snake_case(s),
-            KebabCase => heck::ToKebabCase::to_kebab_case(s),
-            ShoutySnakeCase => heck::ToShoutySnakeCase::to_shouty_snake_case(s),
-            MixedCase => heck::ToLowerCamelCase::to_lower_camel_case(s),
-            TitleCase => heck::ToTitleCase::to_title_case(s),
-            ShoutyKebabCase => heck::ToShoutyKebabCase::to_shouty_kebab_case(s),
+            Case::Camel => heck::ToUpperCamelCase::to_upper_camel_case(s),
+            Case::Snake => heck::ToSnakeCase::to_snake_case(s),
+            Case::Kebab => heck::ToKebabCase::to_kebab_case(s),
+            Case::ShoutySnake => heck::ToShoutySnakeCase::to_shouty_snake_case(s),
+            Case::Mixed => heck::ToLowerCamelCase::to_lower_camel_case(s),
+            Case::Title => heck::ToTitleCase::to_title_case(s),
+            Case::ShoutyKebab => heck::ToShoutyKebabCase::to_shouty_kebab_case(s),
         }
     }
 }

--- a/edgedb-cli-derive/src/attrib.rs
+++ b/edgedb-cli-derive/src/attrib.rs
@@ -423,7 +423,7 @@ impl TryFrom<syn::Expr> for Case {
                     "SHOUTY-KEBAB-CASE" => Case::ShoutyKebabCase,
                     _ => {
                         return Err(syn::Error::new_spanned(s,
-                            &format!("undefined case conversion")));
+                            format!("undefined case conversion")));
                     }
                 };
                 Ok(case)

--- a/edgedb-cli-derive/src/into_app.rs
+++ b/edgedb-cli-derive/src/into_app.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use crate::types;
 
 pub (crate) fn mk_setting_impl(e: &types::Enum) -> TokenStream {
-    let ref ident = e.ident;
+    let ident = &e.ident;
     let (impl_gen, ty_gen, where_cl) = e.generics.split_for_impl();
     let to_string = e.subcommands.iter().map(|sub| {
         let variant = &sub.ident;

--- a/edgedb-cli-derive/src/into_args.rs
+++ b/edgedb-cli-derive/src/into_args.rs
@@ -9,7 +9,7 @@ use crate::types;
 pub fn structure(s: &types::Struct) -> TokenStream {
     use ParserKind::*;
 
-    let ref ident = s.ident;
+    let ident = &s.ident;
     let (impl_gen, ty_gen, where_cl) = s.generics.split_for_impl();
 
     let mut args = Vec::new();

--- a/edgedb-cli-derive/src/lib.rs
+++ b/edgedb-cli-derive/src/lib.rs
@@ -23,7 +23,7 @@ fn derive_edb_settings(item: syn::Item) -> proc_macro2::TokenStream {
         syn::Item::Enum(ref e) => &e.attrs,
         _ => abort!(item, "can only derive EdbSettings for enums"),
     };
-    let attrs = attrib::ContainerAttrs::from_syn(&attrs);
+    let attrs = attrib::ContainerAttrs::from_syn(attrs);
     match item {
         syn::Item::Enum(e) => {
             let mut subcommands = Vec::new();
@@ -56,7 +56,7 @@ fn derive_edb_settings(item: syn::Item) -> proc_macro2::TokenStream {
                 subcommands,
             };
 
-            let setting = into_app::mk_setting_impl(&e);
+            let setting = into_app::mk_setting_impl(e);
             quote! {
                 #setting
             }
@@ -78,7 +78,7 @@ fn derive_args(item: syn::Item) -> proc_macro2::TokenStream {
         syn::Item::Enum(ref e) => &e.attrs,
         _ => abort!(item, "can only derive EdbClap for structs and enums"),
     };
-    let attrs = attrib::ContainerAttrs::from_syn(&attrs);
+    let attrs = attrib::ContainerAttrs::from_syn(attrs);
     match item {
         syn::Item::Struct(s) => {
             let fields = match s.fields {

--- a/edgedb-cli-derive/src/lib.rs
+++ b/edgedb-cli-derive/src/lib.rs
@@ -2,7 +2,7 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use proc_macro_error::abort;
-use syn::{self, parse_macro_input};
+use syn::parse_macro_input;
 use quote::quote;
 
 mod attrib;

--- a/edgedb-cli-derive/src/types.rs
+++ b/edgedb-cli-derive/src/types.rs
@@ -50,7 +50,7 @@ pub fn unwrap_type<'x>(ty: &'x syn::Type, name: &str) -> (bool, &'x syn::Type)
                         if ang.args.len() == 1 {
                             match &ang.args[0] {
                                 syn::GenericArgument::Type(typ) => {
-                                    return (true, typ);
+                                    (true, typ)
                                 }
                                 _ => (false, ty),
                             }

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -124,14 +124,14 @@ pub async fn command(cli: &mut Connection, options: &Analyze)
             let mut out = io::stdout();
             out.write_all(data.as_bytes()).await?;
             out.flush().await?;
-        } else if is_special(&out_path).await? {
+        } else if is_special(out_path).await? {
             async {
                 let mut out = fs::File::create(&out_path).await?;
                 out.write_all(data.as_bytes()).await?;
                 out.flush().await
             }.await.with_context(|| format!("error writing to {out_path:?}"))?;
         } else {
-            let tmp = tmp_file_path(&out_path);
+            let tmp = tmp_file_path(out_path);
             async {
                 let mut out = fs::File::create(&tmp).await?;
                 out.write_all(data.as_bytes()).await?;

--- a/src/analyze/model.rs
+++ b/src/analyze/model.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::default::Default;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/src/analyze/table.rs
+++ b/src/analyze/table.rs
@@ -79,7 +79,7 @@ struct TextPrinter<'a, 'b: 'a> {
 
 pub fn render(
     title: Option<impl fmt::Display>,
-    table: &Vec<Vec<Box<dyn Contents+'_>>>
+    table: &[Vec<Box<dyn Contents+'_>>]
 ) {
     let width = terminal_size().map(|(Width(w), _h)| w.into()).unwrap_or(200);
     let cols = table.iter().map(|r| r.len()).max().unwrap_or(1);
@@ -169,10 +169,10 @@ pub fn render(
                     col = next_col;
                 }
                 next_col = col + width + 1;
-                iter.next().map(|line| {
+                if let Some(line) = iter.next() {
                     col += str_width(line);
                     line_buf.push_str(line);
-                });
+                }
             }
             println!("{}", line_buf);
             line_buf.truncate(0);

--- a/src/analyze/tree.rs
+++ b/src/analyze/tree.rs
@@ -11,12 +11,6 @@ use crate::print::Highlight;
 struct Opt<'a, T>(&'a Option<T>);
 struct Border;
 
-#[derive(Clone, Copy, Debug)]
-struct Wide;
-
-#[derive(Clone, Copy, Debug)]
-struct Narrow;
-
 #[derive(Debug, Clone)]
 pub struct WideMarker {
     columns: bitvec::vec::BitVec,

--- a/src/analyze/tree.rs
+++ b/src/analyze/tree.rs
@@ -81,7 +81,7 @@ pub fn print_debug_plan(explain: &Analysis) {
             let mut rows = vec![header, row];
 
             for (child, ch) in marker.children(&node.plans) {
-                visit_debug_tree(&mut rows, &explain, child, ch);
+                visit_debug_tree(&mut rows, explain, child, ch);
             }
 
             table::render(Some("Debug Plan"), &rows);
@@ -107,11 +107,11 @@ pub fn print_shape(explain: &Analysis) {
         for (child, ch) in WideMarker::new().children(&shape.children) {
             match &ch.name {
                 ChildName::Pointer { name } => {
-                    visit_subshape(&mut rows, &explain,
+                    visit_subshape(&mut rows, explain,
                                    child, Some(name), &ch.node);
                 }
                 _ => {
-                    visit_subshape(&mut rows, &explain,
+                    visit_subshape(&mut rows, explain,
                                    child, None, &ch.node);
                 }
             }
@@ -177,7 +177,7 @@ pub fn print_expanded_tree(explain: &Analysis) {
         }
 
         for (child, ch) in marker.children(&node.subplans) {
-            visit_expanded_tree(&mut rows, &explain, child, ch);
+            visit_expanded_tree(&mut rows, explain, child, ch);
         }
 
         table::render(Some("Fine-grained Query Plan"), &rows);
@@ -206,7 +206,7 @@ fn visit_expanded_tree<'x>(
     }
 
     for (child, ch) in marker.children(&node.subplans) {
-        visit_expanded_tree(result, &explain, child, ch);
+        visit_expanded_tree(result, explain, child, ch);
     }
 }
 
@@ -226,7 +226,7 @@ fn visit_debug_tree<'x>(
     result.push(row);
 
     for (child, ch) in marker.children(&node.plans) {
-        visit_debug_tree(result, &explain, child, ch);
+        visit_debug_tree(result, explain, child, ch);
     }
 }
 
@@ -267,13 +267,13 @@ impl<T: HasChildren> HasChildren for &T {
 
 impl HasChildren for Plan {
     fn has_children(&self) -> bool {
-        return !self.subplans.is_empty()
+        !self.subplans.is_empty()
     }
 }
 
 impl HasChildren for DebugNode {
     fn has_children(&self) -> bool {
-        return !self.plans.is_empty()
+        !self.plans.is_empty()
     }
 }
 
@@ -365,7 +365,7 @@ impl WideMarker {
         -> fmt::Result
     {
         for _ in 1..height {
-            write!(f, "\n")?;
+            writeln!(f)?;
             let mut iter = self.columns.iter();
             if let Some(first) = iter.next() {
                 if *first {
@@ -428,7 +428,7 @@ impl table::Contents for NarrowMarker {
 
 impl table::Contents for ShapeNode<'_> {
     fn width_bounds(&self) -> (usize, usize) {
-        let mwidth = self.marker.width() + table::display_width(&self.context);
+        let mwidth = self.marker.width() + table::display_width(self.context);
         let alen = if let Some(attr) = self.attribute {
             " .".len() + attr.len()
         } else {
@@ -463,7 +463,7 @@ impl table::Contents for Border {
         -> fmt::Result
     {
         for _ in 0..height {
-            write!(f, "{}\n", "│".emphasize())?;
+            writeln!(f, "{}", "│".emphasize())?;
         }
         Ok(())
     }

--- a/src/async_util.rs
+++ b/src/async_util.rs
@@ -16,7 +16,8 @@ macro_rules! async_try {
     ($block:expr, finally $finally:expr) => {
         {
             let result = $block.await;
-            match ($finally.await, result) {
+            let finally = $finally.await;
+            match (finally, result) {
                 (Ok(()), Ok(res)) => Ok(res),
                 (Err(e), Ok(_)) => Err(e.into()),
                 (Ok(()), Err(e)) => Err(e),
@@ -29,7 +30,8 @@ macro_rules! async_try {
     };
     ($block:expr, except $except:expr, else $else:expr) => {
         {
-            match $block.await {
+            let block = $block.await;
+            match block {
                 Ok(result) => {
                     $else.await.map_err(Into::into).and(Ok(result))
                 }

--- a/src/branch/connections.rs
+++ b/src/branch/connections.rs
@@ -54,7 +54,7 @@ pub async fn connect_if_branch_exists(connector: &Connector) -> anyhow::Result<O
     }
 }
 
-pub async fn get_connection_to_modify<'a>(branch: &String, options: &'a Options, connection: &mut Connection) -> anyhow::Result<BranchConnection<'a>> {
+pub async fn get_connection_to_modify<'a>(branch: &str, options: &'a Options, connection: &mut Connection) -> anyhow::Result<BranchConnection<'a>> {
     match get_connection_that_is_not(branch, options, connection).await {
         Ok(connection) => Ok(connection),
         Err(_) => {
@@ -70,7 +70,7 @@ pub async fn get_connection_to_modify<'a>(branch: &String, options: &'a Options,
     }
 }
 
-pub async fn get_connection_that_is_not<'a>(target_branch: &String, options: &'a Options, connection: &mut Connection) -> anyhow::Result<BranchConnection<'a>> {
+pub async fn get_connection_that_is_not<'a>(target_branch: &str, options: &'a Options, connection: &mut Connection) -> anyhow::Result<BranchConnection<'a>> {
     let branches: Vec<String> = connection.query(
         "SELECT (SELECT sys::Database FILTER NOT .builtin).name",
         &(),

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -49,7 +49,7 @@ impl Context {
         })
     }
 
-    pub async fn update_branch(&self, branch: &String) -> anyhow::Result<()> {
+    pub async fn update_branch(&self, branch: &str) -> anyhow::Result<()> {
         let instance_name = match self.get_instance_name()? {
             Some(i) => i,
             None => return Ok(())
@@ -59,7 +59,7 @@ impl Context {
 
         let mut credentials = credentials::read(&path).await?;
 
-        credentials.database = Some(branch.clone());
+        credentials.database = Some(branch.to_string());
 
         credentials::write_async(&path, &credentials).await
     }

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -21,7 +21,7 @@ impl Context {
         };
 
         let credentials = match project_dir {
-            Some(path) => Some(credentials::read(&credentials::path(&get_instance_name(&path)?)?).await?),
+            Some(path) => Some(credentials::read(&credentials::path(&get_instance_name(path)?)?).await?),
             None => None
         };
 
@@ -44,7 +44,7 @@ impl Context {
 
     pub fn get_instance_name(&self) -> anyhow::Result<Option<String>> {
         Ok(match &self.project_dir {
-            Some(dir) => Some(get_instance_name(&dir)?),
+            Some(dir) => Some(get_instance_name(dir)?),
             None => None
         })
     }

--- a/src/branch/create.rs
+++ b/src/branch/create.rs
@@ -21,20 +21,19 @@ pub async fn main(
 
 pub async fn create_branch(connection: &mut Connection, name: &String, from: &String, empty: bool, copy_data: bool) -> anyhow::Result<()> {
     let branch_name = edgeql_parser::helpers::quote_name(name);
-    let query: String;
-
-    if empty {
-        query = format!("create empty branch {}", branch_name)
+    
+    let query = if empty {
+        format!("create empty branch {}", branch_name)
     } else {
         let branch_type = if copy_data { "data" } else { "schema" };
 
-        query = format!(
+        format!(
             "create {} branch {} from {}",
             branch_type,
             branch_name,
             edgeql_parser::helpers::quote_name(from)
         )
-    }
+    };
 
     let status = connection.execute(&query, &()).await?;
 

--- a/src/branch/create.rs
+++ b/src/branch/create.rs
@@ -32,7 +32,7 @@ pub async fn create_branch(connection: &mut Connection, name: &String, from: &St
             "create {} branch {} from {}",
             branch_type,
             branch_name,
-            edgeql_parser::helpers::quote_name(&from)
+            edgeql_parser::helpers::quote_name(from)
         )
     }
 

--- a/src/branch/create.rs
+++ b/src/branch/create.rs
@@ -19,7 +19,7 @@ pub async fn main(
 }
 
 
-pub async fn create_branch(connection: &mut Connection, name: &String, from: &String, empty: bool, copy_data: bool) -> anyhow::Result<()> {
+pub async fn create_branch(connection: &mut Connection, name: &str, from: &str, empty: bool, copy_data: bool) -> anyhow::Result<()> {
     let branch_name = edgeql_parser::helpers::quote_name(name);
     
     let query = if empty {

--- a/src/branch/current.rs
+++ b/src/branch/current.rs
@@ -1,7 +1,7 @@
 use crossterm::style::Stylize;
 use crate::branch::context::Context;
 use crate::branch::option::Current;
-use crate::connect::Connection;
+
 
 pub async fn main(
     options: &Current,

--- a/src/branch/main.rs
+++ b/src/branch/main.rs
@@ -18,9 +18,9 @@ pub async fn run_branch_command(cmd: &Command, options: &Options, context: &Cont
     let mut connector: Connector = options.conn_params.clone();
 
     match &cmd {
-        Command::Switch(switch) => switch::main(switch, &context, &mut connector).await,
-        Command::Wipe(wipe) => wipe::main(wipe, &context, &mut connector).await,
-        Command::Current(current) => current::main(current, &context).await,
+        Command::Switch(switch) => switch::main(switch, context, &mut connector).await,
+        Command::Wipe(wipe) => wipe::main(wipe, context, &mut connector).await,
+        Command::Current(current) => current::main(current, context).await,
         command => {
             match connection {
                 Some(conn) => run_branch_command1(command, conn, context, options).await,
@@ -37,12 +37,12 @@ async fn run_branch_command1(command: &Command, connection: &mut Connection, con
     verify_server_can_use_branches(connection).await?;
 
     match command {
-        Command::Create(create) => create::main(create, &context, connection).await,
-        Command::Drop(drop) => drop::main(drop, &context, connection).await,
-        Command::List(list) => list::main(list, &context, connection).await,
-        Command::Rename(rename) => rename::main(rename, &context, connection, &options).await,
-        Command::Rebase(rebase) => rebase::main(rebase, &context, connection, &options).await,
-        Command::Merge(merge) => merge::main(merge, &context, connection, &options).await,
+        Command::Create(create) => create::main(create, context, connection).await,
+        Command::Drop(drop) => drop::main(drop, context, connection).await,
+        Command::List(list) => list::main(list, context, connection).await,
+        Command::Rename(rename) => rename::main(rename, context, connection, options).await,
+        Command::Rebase(rebase) => rebase::main(rebase, context, connection, options).await,
+        Command::Merge(merge) => merge::main(merge, context, connection, options).await,
         unhandled => anyhow::bail!("unimplemented branch command '{:?}'", unhandled)
     }
 }

--- a/src/branch/main.rs
+++ b/src/branch/main.rs
@@ -25,9 +25,9 @@ pub async fn branch_main(options: &Options, cmd: &BranchCommand) -> anyhow::Resu
                 Command::Create(create) => create::main(create, &context, &mut connection).await,
                 Command::Drop(drop) => drop::main(drop, &context, &mut connection).await,
                 Command::List(list) => list::main(list, &context, &mut connection).await,
-                Command::Rename(rename) => rename::main(rename, &context, &mut connection, &options).await,
-                Command::Rebase(rebase) => rebase::main(rebase, &context, &mut connection, &options).await,
-                Command::Merge(merge) => merge::main(merge, &context, &mut connection, &options).await,
+                Command::Rename(rename) => rename::main(rename, &context, &mut connection, options).await,
+                Command::Rebase(rebase) => rebase::main(rebase, &context, &mut connection, options).await,
+                Command::Merge(merge) => merge::main(merge, &context, &mut connection, options).await,
                 unhandled => anyhow::bail!("unimplemented branch command '{:?}'", unhandled)
             }
         }

--- a/src/branch/rebase.rs
+++ b/src/branch/rebase.rs
@@ -63,7 +63,7 @@ async fn rebase(branch: &String, source_connection: &mut Connection, target_conn
     anyhow::Ok(())
 }
 
-async fn rename_temp_to_source(temp_branch: &String, source_branch: &String, options: &Options, connection: &mut Connection) -> anyhow::Result<()> {
+async fn rename_temp_to_source(temp_branch: &str, source_branch: &str, options: &Options, connection: &mut Connection) -> anyhow::Result<()> {
     let mut rename_connection = get_connection_to_modify(temp_branch, options, connection).await?;
 
     let status = rename_connection.connection.execute(&format!(
@@ -79,8 +79,8 @@ async fn rename_temp_to_source(temp_branch: &String, source_branch: &String, opt
     Ok(())
 }
 
-async fn clone_target_branch(branch: &String, connection: &mut Connection) -> anyhow::Result<String> {
-    eprintln!("Cloning target branch '{}' for rebase...", branch.clone().green());
+async fn clone_target_branch(branch: &str, connection: &mut Connection) -> anyhow::Result<String> {
+    eprintln!("Cloning target branch '{}' for rebase...", branch.green());
 
     let temp_branch_name = Uuid::new_v4().to_string();
 

--- a/src/branch/rebase.rs
+++ b/src/branch/rebase.rs
@@ -40,7 +40,7 @@ pub async fn main(options: &Rebase, context: &Context, source_connection: &mut C
     }
 }
 
-async fn rebase(branch: &String, source_connection: &mut Connection, target_connection: &mut Connection, context: &Context, cli_opts: &Options, apply_migrations: bool) -> anyhow::Result<()> {
+async fn rebase(branch: &str, source_connection: &mut Connection, target_connection: &mut Connection, context: &Context, cli_opts: &Options, apply_migrations: bool) -> anyhow::Result<()> {
     let mut migrations = get_diverging_migrations(source_connection, target_connection).await?;
     let current_branch = context.branch.as_ref().unwrap();
     let project_config = context.project_config.as_ref().unwrap();

--- a/src/branch/rebase.rs
+++ b/src/branch/rebase.rs
@@ -64,12 +64,12 @@ async fn rebase(branch: &String, source_connection: &mut Connection, target_conn
 }
 
 async fn rename_temp_to_source(temp_branch: &String, source_branch: &String, options: &Options, connection: &mut Connection) -> anyhow::Result<()> {
-    let mut rename_connection = get_connection_to_modify(&temp_branch, options, connection).await?;
+    let mut rename_connection = get_connection_to_modify(temp_branch, options, connection).await?;
 
     let status = rename_connection.connection.execute(&format!(
         "alter branch {} force rename to {}",
-        edgeql_parser::helpers::quote_name(&temp_branch),
-        edgeql_parser::helpers::quote_name(&source_branch)
+        edgeql_parser::helpers::quote_name(temp_branch),
+        edgeql_parser::helpers::quote_name(source_branch)
     ), &()).await?;
 
     print::completion(status);

--- a/src/branch/rename.rs
+++ b/src/branch/rename.rs
@@ -12,12 +12,12 @@ pub async fn main(
     cli_opts: &Options,
 ) -> anyhow::Result<()> {
     if Some(&options.old_name) == context.branch.as_ref() || connection.database() == options.old_name {
-        let mut modify_connection = get_connection_to_modify(&options.old_name, &cli_opts, connection).await?;
-        rename(&mut modify_connection.connection, &options).await?;
+        let mut modify_connection = get_connection_to_modify(&options.old_name, cli_opts, connection).await?;
+        rename(&mut modify_connection.connection, options).await?;
         modify_connection.clean().await?;
         context.update_branch(&options.new_name).await?;
     } else {
-        rename(connection, &options).await?;
+        rename(connection, options).await?;
     }
 
     eprintln!("Renamed branch {} to {}", options.old_name, options.new_name);

--- a/src/branch/switch.rs
+++ b/src/branch/switch.rs
@@ -43,7 +43,7 @@ pub async fn main(
     } else {
         // try to connect to the target branch
         let target_branch_connector = connector.branch(&options.branch)?;
-        match connect_if_branch_exists(&target_branch_connector).await? {
+        match connect_if_branch_exists(target_branch_connector).await? {
             Some(mut connection) => {
                 verify_server_can_use_branches(&mut connection).await?;
             },

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -2,7 +2,7 @@ use edgeql_parser::keywords::Keyword;
 use edgeql_parser::tokenizer::{Kind, Token, Tokenizer};
 
 pub fn is_analyze(query: &str) -> bool {
-    match (&mut Tokenizer::new(query)).next() {
+    match Tokenizer::new(query).next() {
         Some(Ok(Token {
             kind: Kind::Keyword(Keyword("analyze")),
             ..

--- a/src/cli/directory_check.rs
+++ b/src/cli/directory_check.rs
@@ -42,7 +42,7 @@ pub fn check_and_error() -> anyhow::Result<()> {
                 edgedb cli migrate\n\
                 ```
             ");
-            return Err(ExitCode::new(11).into());
+            Err(ExitCode::new(11).into())
         }
         None => Ok(())
     }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -157,14 +157,14 @@ pub fn no_dir_in_path(dir: &Path) -> bool {
             }
         }
     }
-    return true;
+    true
 }
 
 fn is_zsh() -> bool {
     if let Ok(shell) = env::var("SHELL") {
         return shell.contains("zsh");
     }
-    return false;
+    false
 }
 
 pub fn get_rc_files() -> anyhow::Result<Vec<PathBuf>> {
@@ -249,7 +249,7 @@ fn print_post_install_message(settings: &Settings,
         let func_dir = home_dir().ok().map(|p| p.join(".zfunc"));
         let func_dir = func_dir.as_ref().and_then(|p| p.to_str());
         if let Some((fpath, func_dir)) = fpath.zip(func_dir) {
-            if !fpath.split(" ").any(|s| s == func_dir) {
+            if !fpath.split(' ').any(|s| s == func_dir) {
                 print_markdown!("\n\
                     To enable zsh completion, add:\n\
                     ```\n\
@@ -521,15 +521,15 @@ fn _main(options: &CliInstall) -> anyhow::Result<()> {
             let line = format!("\nexport PATH=\"{}:$PATH\"",
                                settings.installation_path.display());
             for path in &settings.rc_files {
-                ensure_line(&path, &line)
+                ensure_line(path, &line)
                     .with_context(|| format!(
                         "failed to update profile file {:?}", path))?;
             }
             if let Some(dir) = settings.env_file.parent() {
-                fs::create_dir_all(&dir)
+                fs::create_dir_all(dir)
                     .with_context(|| format!("failed to create {:?}", dir))?;
             }
-            fs::write(&settings.env_file, &(line + "\n"))
+            fs::write(&settings.env_file, line + "\n")
                 .with_context(|| format!("failed to write env file {:?}",
                                          settings.env_file))?;
         }
@@ -696,9 +696,9 @@ pub fn windows_augment_path<F: FnOnce(&[PathBuf]) -> Option<std::ffi::OsString>>
 #[context("writing completion file {:?}", path)]
 fn write_completion(path: &Path, shell: Shell) -> anyhow::Result<()> {
     if let Some(dir) = path.parent() {
-        fs::create_dir_all(&dir)?;
+        fs::create_dir_all(dir)?;
     }
-    shell.generate(&mut BufWriter::new(fs::File::create(&path)?));
+    shell.generate(&mut BufWriter::new(fs::File::create(path)?));
     Ok(())
 }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::fs;
 use std::io::{Write, stdout, BufWriter};
 use std::path::{PathBuf, Path};
-use std::process::{exit};
+use std::process::exit;
 use std::str::FromStr;
 
 use anyhow::Context;
@@ -16,7 +16,7 @@ use prettytable::{Table, Row, Cell};
 use crate::cli::{migrate, upgrade};
 use crate::commands::ExitCode;
 use crate::options::Options;
-use crate::platform::{current_exe};
+use crate::platform::current_exe;
 use crate::platform::{home_dir, config_dir, binary_path};
 use crate::portable::project::{self, Init};
 use crate::portable::platform;
@@ -61,6 +61,7 @@ pub struct CliInstall {
 #[derive(Debug, Clone, Copy)]
 #[derive(clap::ValueEnum)]
 #[value(rename_all="kebab-case")]
+#[allow(clippy::enum_variant_names)]
 pub enum Shell {
     Bash,
     Elvish,

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -64,7 +64,7 @@ fn dir_is_non_empty(path: &Path) -> anyhow::Result<bool> {
 fn move_file(src: &Path, dest: &Path, dry_run: bool) -> anyhow::Result<()> {
     use ConfirmOverwrite::*;
 
-    if file_is_non_empty(&dest)? {
+    if file_is_non_empty(dest)? {
         if dry_run {
             log::warn!("File {:?} exists in both locations, \
                         will prompt for overwrite", dest);
@@ -83,13 +83,11 @@ fn move_file(src: &Path, dest: &Path, dry_run: bool) -> anyhow::Result<()> {
             Skip => return Ok(()),
             Quit => anyhow::bail!("Canceled by user"),
         }
-    } else {
-        if dry_run {
-            log::info!("Would move {:?} -> {:?}", src, dest);
-            return Ok(());
-        }
+    } else if dry_run {
+        log::info!("Would move {:?} -> {:?}", src, dest);
+        return Ok(());
     }
-    let tmp = tmp_file_path(&dest);
+    let tmp = tmp_file_path(dest);
     fs::copy(src, &tmp)?;
     fs::rename(tmp, dest)?;
     fs::remove_file(src)?;
@@ -99,7 +97,7 @@ fn move_file(src: &Path, dest: &Path, dry_run: bool) -> anyhow::Result<()> {
 fn move_dir(src: &Path, dest: &Path, dry_run: bool) -> anyhow::Result<()> {
     use ConfirmOverwrite::*;
 
-    if dir_is_non_empty(&dest)? {
+    if dir_is_non_empty(dest)? {
         if dry_run {
             log::warn!("Directory {:?} exists in both locations, \
                         will prompt for overwrite", dest);
@@ -118,16 +116,14 @@ fn move_dir(src: &Path, dest: &Path, dry_run: bool) -> anyhow::Result<()> {
             Skip => return Ok(()),
             Quit => anyhow::bail!("Canceled by user"),
         }
-    } else {
-        if dry_run {
-            log::info!("Would move {:?} -> {:?}", src, dest);
-            return Ok(());
-        }
+    } else if dry_run {
+        log::info!("Would move {:?} -> {:?}", src, dest);
+        return Ok(());
     }
     fs::create_dir_all(dest)?;
     for item in fs::read_dir(src)? {
         let item = item?;
-        let ref dest_path = dest.join(item.file_name());
+        let dest_path = &dest.join(item.file_name());
         match item.file_type()? {
             typ if typ.is_file() => {
                 let tmp = tmp_file_path(dest_path);
@@ -156,9 +152,9 @@ fn move_dir(src: &Path, dest: &Path, dry_run: bool) -> anyhow::Result<()> {
 fn try_move_bin(exe_path: &Path, bin_path: &Path) -> anyhow::Result<()> {
     let bin_dir = bin_path.parent().unwrap();
     if !bin_dir.exists() {
-        fs::create_dir_all(&bin_dir)?;
+        fs::create_dir_all(bin_dir)?;
     }
-    fs::rename(&exe_path, &bin_path)?;
+    fs::rename(exe_path, bin_path)?;
     Ok(())
 }
 
@@ -233,7 +229,7 @@ fn update_path(base: &Path, new_bin_path: &Path) -> anyhow::Result<()> {
         );
         let mut modified = false;
         for path in &rc_files {
-            if replace_line(&path, &old_line, &new_line)? {
+            if replace_line(path, &old_line, &new_line)? {
                 modified = true;
             }
         }
@@ -244,11 +240,11 @@ fn update_path(base: &Path, new_bin_path: &Path) -> anyhow::Result<()> {
         fs::create_dir_all(&cfg_dir)
             .with_context(
                 || format!("failed to create {:?}", cfg_dir))?;
-        fs::write(&env_file, &(new_line + "\n"))
+        fs::write(&env_file, new_line + "\n")
             .with_context(
                 || format!("failed to write env file {:?}", env_file))?;
 
-        if modified && no_dir_in_path(&new_bin_dir) {
+        if modified && no_dir_in_path(new_bin_dir) {
             print::success("The `edgedb` executable has moved!");
             print_markdown!("\
                 \n\
@@ -368,7 +364,7 @@ pub fn migrate(base: &Path, dry_run: bool) -> anyhow::Result<()> {
             return Err(ExitCode::new(2).into());
         }
     }
-    remove_dir_all(&base, dry_run)?;
+    remove_dir_all(base, dry_run)?;
     print::success("Directory layout migration successful!");
 
     Ok(())

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -170,9 +170,9 @@ fn replace_line(path: &PathBuf, old_line: &str, new_line: &str)
     if let Some(idx) = text.find(old_line) {
         log::info!("File {:?} contains old path, replacing", path);
         let mut file = fs::File::create(path)?;
-        file.write(text[..idx].as_bytes())?;
-        file.write(new_line.as_bytes())?;
-        file.write(text[idx+old_line.len()..].as_bytes())?;
+        file.write_all(text[..idx].as_bytes())?;
+        file.write_all(new_line.as_bytes())?;
+        file.write_all(text[idx+old_line.len()..].as_bytes())?;
         Ok(true)
     } else {
         log::info!("File {:?} has no old path, skipping", path);

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -76,11 +76,11 @@ pub fn unpack_file(src: &Path, tgt: &Path,
                compression: Option<repository::Compression>)
     -> anyhow::Result<()>
 {
-    fs::remove_file(&tgt).ok();
+    fs::remove_file(tgt).ok();
     match compression {
         Some(repository::Compression::Zstd) => {
-            fs::remove_file(&tgt).ok();
-            let src_f = fs::File::open(&src)?;
+            fs::remove_file(tgt).ok();
+            let src_f = fs::File::open(src)?;
 
             let mut opt = fs::OpenOptions::new();
             opt.write(true).create_new(true);
@@ -88,7 +88,7 @@ pub fn unpack_file(src: &Path, tgt: &Path,
                 use fs_err::os::unix::fs::OpenOptionsExt;
                 opt.mode(0o755);
             }
-            let mut tgt_f = opt.open(&tgt)?;
+            let mut tgt_f = opt.open(tgt)?;
 
             let bar = ProgressBar::new(src.metadata()?.len());
             bar.set_style(
@@ -100,15 +100,15 @@ pub fn unpack_file(src: &Path, tgt: &Path,
                 bar.wrap_read(src_f)
             ))?;
             io::copy(&mut decoded, &mut tgt_f)?;
-            fs::remove_file(&src).ok();
+            fs::remove_file(src).ok();
             Ok(())
         }
         None => {
             #[cfg(unix)] {
                 use std::os::unix::fs::PermissionsExt;
-                fs::set_permissions(&src, PermissionsExt::from_mode(0o755))?;
+                fs::set_permissions(src, PermissionsExt::from_mode(0o755))?;
             }
-            fs::rename(&src, &tgt)?;
+            fs::rename(src, tgt)?;
             Ok(())
         }
     }
@@ -118,7 +118,7 @@ pub fn unpack_file(src: &Path, tgt: &Path,
 pub fn channel_of(ver: &str) -> repository::Channel {
     if ver.contains("-dev.") {
         Channel::Nightly
-    } else if ver.contains("-") {
+    } else if ver.contains('-') {
         Channel::Testing
     } else {
         Channel::Stable

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -176,7 +176,7 @@ pub fn logout(c: &options::Logout, options: &CloudOptions) -> anyhow::Result<()>
             let item = item?;
             let sub_dir = item.path();
             let stem = sub_dir.file_stem().and_then(|s| s.to_str());
-            if stem.map(|n| n.starts_with(".")).unwrap_or(true) {
+            if stem.map(|n| n.starts_with('.')).unwrap_or(true) {
                 // skip hidden files, most likely .DS_Store
                 continue;
             }
@@ -256,7 +256,7 @@ pub fn logout(c: &options::Logout, options: &CloudOptions) -> anyhow::Result<()>
             print::warn(message);
         } else {
             print::error(message);
-            return Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
+            Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
         }
     }
     if !skipped {
@@ -274,8 +274,7 @@ fn make_project_warning(profile: &str, projects: Vec<PathBuf>) -> String {
         profile,
         projects
             .iter()
-            .map(|p| p.to_str())
-            .flatten()
+            .filter_map(|p| p.to_str())
             .collect::<Vec<_>>()
             .join("\n    "),
     )

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -94,10 +94,7 @@ impl CloudClient {
         let is_logged_in;
         let dns_zone;
         if let Some(secret_key) = secret_key.clone() {
-            let claims_b64 = secret_key
-                .splitn(3, ".")
-                .skip(1)
-                .next()
+            let claims_b64 = secret_key.split('.').nth(1)
                 .context("malformed secret key: invalid JWT format")?;
             let claims = URL_SAFE_NO_PAD.decode(claims_b64)
                 .context("malformed secret key: invalid base64 data")?;

--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -198,8 +198,8 @@ pub async fn get_current_region(
     client
         .get(url)
         .await
-        .or_else(|e| match e.downcast_ref::<ErrorResponse>() {
-            _ => Err(e),
+        .map_err(|e| match e.downcast_ref::<ErrorResponse>() {
+            _ => e,
         })
 }
 
@@ -211,8 +211,8 @@ pub async fn get_versions(
     client
         .get(url)
         .await
-        .or_else(|e| match e.downcast_ref::<ErrorResponse>() {
-            _ => Err(e),
+        .map_err(|e| match e.downcast_ref::<ErrorResponse>() {
+            _ => e,
         })
 }
 
@@ -224,8 +224,8 @@ pub async fn get_prices(
     let mut resp: PricesResponse = client
         .get(url)
         .await
-        .or_else(|e| match e.downcast_ref::<ErrorResponse>() {
-            _ => Err(e),
+        .map_err(|e| match e.downcast_ref::<ErrorResponse>() {
+            _ => e,
         })?;
 
     let billable_id_to_name: HashMap<String, String> = resp.billables

--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -198,9 +198,6 @@ pub async fn get_current_region(
     client
         .get(url)
         .await
-        .map_err(|e| match e.downcast_ref::<ErrorResponse>() {
-            _ => e,
-        })
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -211,9 +208,6 @@ pub async fn get_versions(
     client
         .get(url)
         .await
-        .map_err(|e| match e.downcast_ref::<ErrorResponse>() {
-            _ => e,
-        })
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -223,16 +217,13 @@ pub async fn get_prices(
     let url = "pricing";
     let mut resp: PricesResponse = client
         .get(url)
-        .await
-        .map_err(|e| match e.downcast_ref::<ErrorResponse>() {
-            _ => e,
-        })?;
+        .await?;
 
     let billable_id_to_name: HashMap<String, String> = resp.billables
         .iter().map(|billable| (billable.id.clone(), billable.name.clone())).collect();
 
-    for (_, tier_prices) in &mut resp.prices {
-        for (_, region_prices) in tier_prices {
+    for tier_prices in resp.prices.values_mut() {
+        for region_prices in tier_prices.values_mut() {
             for price in region_prices {
                 price.billable = billable_id_to_name.get(&price.billable)
                     .context(format!("could not map billable {} to name", price.billable))?

--- a/src/cloud/secret_keys.rs
+++ b/src/cloud/secret_keys.rs
@@ -96,7 +96,7 @@ fn print_table(items: impl Iterator<Item=SecretKey>) {
             Cell::new(&key.scopes.join(", ")),
         ]));
     }
-    if table.len() > 0 {
+    if !table.is_empty() {
         table.printstd();
     } else {
         println!("No secret keys present.")

--- a/src/cloud/versions.rs
+++ b/src/cloud/versions.rs
@@ -37,7 +37,7 @@ pub fn get_version(query: &Query, client: &CloudClient) -> anyhow::Result<ver::S
         },
     }
 
-    if versions.len() == 0 {
+    if versions.is_empty() {
         anyhow::bail!(
             "no EdgeDB versions matching '{}' supported by EdgeDB Cloud",
             query.display(),

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::{BTreeSet, BTreeMap};
 use std::str::FromStr;
 
-use clap::{self, FromArgMatches, CommandFactory};
+use clap::{FromArgMatches, CommandFactory};
 use once_cell::sync::Lazy;
 use prettytable::{Table, Row, Cell};
 use regex::Regex;

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -22,7 +22,7 @@ use crate::repl;
 use crate::table;
 
 
-pub static CMD_CACHE: Lazy<CommandCache> = Lazy::new(|| CommandCache::new());
+pub static CMD_CACHE: Lazy<CommandCache> = Lazy::new(CommandCache::new);
 
 pub enum ExecuteResult {
     Skip,
@@ -255,7 +255,7 @@ impl<'a> Parser<'a> {
         } else {
             Item::Argument(value)
         };
-        return Some(Token {
+        Some(Token {
             item,
             span: (offset, offset+end),
         })
@@ -272,7 +272,7 @@ impl<'a> Iterator for Parser<'a> {
             }
             self.offset = tok.span.1;
         }
-        return result;
+        result
     }
 }
 
@@ -348,12 +348,10 @@ impl CommandCache {
         let mut setting_cmd: BTreeMap<_, _> = setting_cmd.get_subcommands()
             .map(|cmd| (cmd.get_name(), cmd))
             .collect();
-        let settings = Setting::all_items().into_iter().map(|setting| {
+        let settings = Setting::all_items().iter().map(|setting| {
             let cmd = setting_cmd.remove(&setting.name())
                 .expect("all settings have cmd");
-            let arg = cmd.get_arguments()
-                .filter(|a| a.get_id() != "help" && a.get_id() != "version")
-                .next()
+            let arg = cmd.get_arguments().find(|a| a.get_id() != "help" && a.get_id() != "version")
                 .expect("setting has argument");
             let values = arg.get_value_parser().possible_values()
                 .map(|v| v.map(|x| x.get_name().to_owned()).collect());
@@ -375,7 +373,7 @@ impl CommandCache {
         CommandCache {
             settings,
             top_commands: commands.keys().map(|x| &x[..])
-                .chain(aliases.keys().map(|x| *x))
+                .chain(aliases.keys().copied())
                 .map(|n| String::from("\\") + n)
                 .collect(),
             commands,
@@ -391,10 +389,10 @@ pub fn full_statement(s: &str) -> usize {
             _ => {}
         }
     }
-    return s.len();
+    s.len()
 }
 
-pub fn backslashify_help<'x>(text: &'x str) -> Cow<'x, str> {
+pub fn backslashify_help(text: &str) -> Cow<'_, str> {
     pub static USAGE: Lazy<Regex> = Lazy::new(|| {
         Regex::new(r"(USAGE:\s*)(\w)").unwrap()
     });
@@ -473,7 +471,7 @@ fn unquote_argument(s: &str) -> String {
             _ => buf.push(c),
         }
     }
-    return buf;
+    buf
 }
 
 pub fn bool_str(val: bool) -> &'static str {
@@ -539,8 +537,8 @@ fn list_settings(prompt: &mut repl::State) {
         .iter().map(|x| table::header_cell(x)).collect()));
     for setting in CMD_CACHE.settings.values() {
         table.add_row(Row::new(vec![
-            Cell::new(&setting.name),
-            Cell::new(&get_setting(&setting.setting, prompt)),
+            Cell::new(setting.name),
+            Cell::new(&get_setting(setting.setting, prompt)),
             Cell::new(&textwrap::fill(&setting.description, 40)),
         ]));
     }
@@ -577,7 +575,7 @@ pub async fn execute(cmd: &BackslashCmd, prompt: &mut repl::State)
             Ok(Skip)
         }
         Set(SetCommand {setting: Some(ref cmd)}) if cmd.is_show() => {
-            println!("{}: {}", cmd.name(), get_setting(&cmd, prompt));
+            println!("{}: {}", cmd.name(), get_setting(cmd, prompt));
             Ok(Skip)
         }
         Set(SetCommand {setting: Some(ref cmd)}) => {
@@ -712,7 +710,7 @@ mod test {
     use super::Parser;
     use super::Item::{self, *};
 
-    fn tok_values<'x>(s: &'x str) -> Vec<Item<'x>> {
+    fn tok_values(s: &str) -> Vec<Item<'_>> {
         Parser::new(s).map(|tok| tok.item).collect::<Vec<_>>()
     }
 

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -42,12 +42,12 @@ pub fn main(options: &Options) -> Result<(), anyhow::Error> {
                 Common::Migration(
                     Migration { subcommand: M::Log(mlog), .. }
                 ) if mlog.from_fs => {
-                    migrations::log_fs(&cmdopt, &mlog).into()
+                    migrations::log_fs(&cmdopt, mlog)
                 }
                 Common::Migration(
                     Migration { subcommand: M::Edit(params), .. }
                 ) if params.no_check => {
-                    migrations::edit_no_check(&cmdopt, &params).into()
+                    migrations::edit_no_check(&cmdopt, params)
                 }
                 Common::Migration(
                     Migration { subcommand: M::UpgradeCheck(params), .. }
@@ -72,7 +72,7 @@ pub fn main(options: &Options) -> Result<(), anyhow::Error> {
         }
         Command::Query(q) => {
             directory_check::check_and_warn();
-            non_interactive::noninteractive_main(&q, options).into()
+            non_interactive::noninteractive_main(q, options)
         }
         Command::_SelfInstall(s) => {
             cli::install::main(s)
@@ -84,7 +84,7 @@ pub fn main(options: &Options) -> Result<(), anyhow::Error> {
             cli::main(c)
         },
         Command::Info(info) => {
-            commands::info(options, info).into()
+            commands::info(options, info)
         }
         Command::UI(c) => {
             commands::show_ui(c, options)

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -80,7 +80,7 @@ pub fn main(options: &Options) -> Result<(), anyhow::Error> {
         Command::_GenCompletions(s) => {
             cli::install::gen_completions(s)
         }
-        Command::CliCommand(c) => {
+        Command::Cli(c) => {
             cli::main(c)
         },
         Command::Info(info) => {

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -37,25 +37,21 @@ pub fn main(options: &Options) -> Result<(), anyhow::Error> {
                 conn_params: options.block_on_create_connector()?,
             };
             directory_check::check_and_warn();
-            match cmd {
+            match cmd.as_migration() {
                 // Process commands that don't need connection first
-                Common::Migration(
-                    Migration { subcommand: M::Log(mlog), .. }
-                ) if mlog.from_fs => {
+                Some(Migration { subcommand: M::Log(mlog), .. })
+                if mlog.from_fs => {
                     migrations::log_fs(&cmdopt, mlog)
                 }
-                Common::Migration(
-                    Migration { subcommand: M::Edit(params), .. }
-                ) if params.no_check => {
+                Some(Migration { subcommand: M::Edit(params), .. })
+                if params.no_check => {
                     migrations::edit_no_check(&cmdopt, params)
                 }
-                Common::Migration(
-                    Migration { subcommand: M::UpgradeCheck(params), .. }
-                ) => {
+                Some(Migration { subcommand: M::UpgradeCheck(params), .. }) => {
                     migrations::upgrade_check(&cmdopt, params)
                 }
                 // Otherwise connect
-                cmd => common_cmd(options, cmdopt, cmd),
+                _ => common_cmd(options, cmdopt, cmd),
             }
         },
         Command::Server(cmd) => {

--- a/src/commands/dump.rs
+++ b/src/commands/dump.rs
@@ -38,7 +38,7 @@ impl Guard {
             Ok((Box::new(file), Guard { filenames: None }))
         } else {
             let tmp_path = filename.with_file_name(
-                tmp_file_name(filename.as_ref()));
+                tmp_file_name(filename));
             if fs::metadata(&tmp_path).await.is_ok() {
                 fs::remove_file(&tmp_path).await.ok();
             }

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -1,7 +1,7 @@
 use crate::connect::Connection;
 use edgedb_tokio::server_params::PostgresAddress;
 
-use crate::{analyze, options};
+use crate::{analyze};
 use crate::commands::parser::{Common, DatabaseCmd, ListCmd, DescribeCmd};
 use crate::commands::{self, branching, Options};
 use crate::migrations::options::{MigrationCmd};
@@ -28,10 +28,10 @@ pub async fn common(cli: &mut Connection, cmd: &Common, options: &Options)
                     &c.pattern, c.system, c.case_sensitive, c.verbose).await?;
             }
             ListCmd::Databases => {
-                commands::list_databases(cli, &options).await?;
+                commands::list_databases(cli, options).await?;
             },
             ListCmd::Branches => {
-                commands::list_branches(cli, &options).await?;
+                commands::list_branches(cli, options).await?;
             }
             ListCmd::Scalars(c) => {
                 commands::list_scalar_types(cli, options,
@@ -96,7 +96,7 @@ pub async fn common(cli: &mut Connection, cmd: &Common, options: &Options)
             }
         },
         Branching(branching) => {
-            branching::main(cli, &branching.subcommand, &options).await?
+            branching::main(cli, &branching.subcommand, options).await?
         }
         Migrate(params) => {
             migrations::migrate(cli, options, params).await?;

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -4,7 +4,7 @@ use edgedb_tokio::server_params::PostgresAddress;
 use crate::analyze;
 use crate::commands::parser::{Common, DatabaseCmd, ListCmd, DescribeCmd};
 use crate::commands::{self, Options};
-use crate::migrations::options::{MigrationCmd};
+use crate::migrations::options::MigrationCmd;
 use crate::migrations;
 use crate::print;
 

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -16,34 +16,34 @@ pub async fn common(cli: &mut Connection, cmd: &Common, options: &Options)
     match cmd {
         List(c) => match &c.subcommand {
             ListCmd::Aliases(c) => {
-                commands::list_aliases(cli, &options,
+                commands::list_aliases(cli, options,
                     &c.pattern, c.system, c.case_sensitive, c.verbose).await?;
             }
             ListCmd::Casts(c) => {
-                commands::list_casts(cli, &options,
+                commands::list_casts(cli, options,
                     &c.pattern, c.case_sensitive).await?;
             }
             ListCmd::Indexes(c) => {
-                commands::list_indexes(cli, &options,
+                commands::list_indexes(cli, options,
                     &c.pattern, c.system, c.case_sensitive, c.verbose).await?;
             }
             ListCmd::Databases => {
-                commands::list_databases(cli, &options).await?;
+                commands::list_databases(cli, options).await?;
             }
             ListCmd::Scalars(c) => {
-                commands::list_scalar_types(cli, &options,
+                commands::list_scalar_types(cli, options,
                     &c.pattern, c.system, c.case_sensitive).await?;
             }
             ListCmd::Types(c) => {
-                commands::list_object_types(cli, &options,
+                commands::list_object_types(cli, options,
                     &c.pattern, c.system, c.case_sensitive).await?;
             }
             ListCmd::Modules(c) => {
-                commands::list_modules(cli, &options,
+                commands::list_modules(cli, options,
                     &c.pattern, c.case_sensitive).await?;
             }
             ListCmd::Roles(c) => {
-                commands::list_roles(cli, &options,
+                commands::list_roles(cli, options,
                     &c.pattern, c.case_sensitive).await?;
             }
         }
@@ -61,64 +61,64 @@ pub async fn common(cli: &mut Connection, cmd: &Common, options: &Options)
             }
         }
         Psql => {
-            commands::psql(cli, &options).await?;
+            commands::psql(cli, options).await?;
         }
         Describe(c) => match &c.subcommand {
             DescribeCmd::Object(c) => {
-                commands::describe(cli, &options, &c.name, c.verbose).await?;
+                commands::describe(cli, options, &c.name, c.verbose).await?;
             }
             DescribeCmd::Schema(_) => {
-                commands::describe_schema(cli, &options).await?;
+                commands::describe_schema(cli, options).await?;
             }
         },
         Dump(c) => {
-            commands::dump(cli, &options, c).await?;
+            commands::dump(cli, options, c).await?;
         }
         Restore(params) => {
-            commands::restore(cli, &options, params)
+            commands::restore(cli, options, params)
             .await?;
         }
         Configure(c) => {
-            commands::configure(cli, &options, c).await?;
+            commands::configure(cli, options, c).await?;
         }
         Database(c) => match &c.subcommand {
             DatabaseCmd::Create(c) => {
-                commands::database::create(cli, c, &options).await?;
+                commands::database::create(cli, c, options).await?;
             }
             DatabaseCmd::Drop(d) => {
-                commands::database::drop(cli, d, &options).await?;
+                commands::database::drop(cli, d, options).await?;
             }
             DatabaseCmd::Wipe(w) => {
-                commands::database::wipe(cli, w, &options).await?;
+                commands::database::wipe(cli, w, options).await?;
             }
         }
         Migrate(params) => {
-            migrations::migrate(cli, &options, params).await?;
+            migrations::migrate(cli, options, params).await?;
         }
         Migration(m) => match &m.subcommand {
             MigrationCmd::Apply(params) => {
-                migrations::migrate(cli, &options, params).await?;
+                migrations::migrate(cli, options, params).await?;
             }
             MigrationCmd::Create(params) => {
-                migrations::create(cli, &options, params).await?;
+                migrations::create(cli, options, params).await?;
             }
             MigrationCmd::Status(params) => {
-                migrations::status(cli, &options, params).await?;
+                migrations::status(cli, options, params).await?;
             }
             MigrationCmd::Log(params) => {
-                migrations::log(cli, &options, params).await?;
+                migrations::log(cli, options, params).await?;
             }
             MigrationCmd::Edit(params) => {
-                migrations::edit(cli, &options, params).await?;
+                migrations::edit(cli, options, params).await?;
             }
             MigrationCmd::UpgradeCheck(_) => {
                 anyhow::bail!("cannot be run in REPL mode");
             }
             MigrationCmd::Extract(params) => {
-                migrations::extract(cli, &options, params).await?;
+                migrations::extract(cli, options, params).await?;
             }
             MigrationCmd::UpgradeFormat(params) => {
-                migrations::upgrade_format(cli, &options, params).await?;
+                migrations::upgrade_format(cli, options, params).await?;
             }
         }
     }

--- a/src/commands/filter.rs
+++ b/src/commands/filter.rs
@@ -17,8 +17,8 @@ pub async fn query<R>(cli: &mut Connection, query: &str,
         } else {
             Cow::Owned(String::from("(?i)") + pat)
         };
-        cli.query(&query, &(&pat[..],)).await
+        cli.query(query, &(&pat[..],)).await
     } else {
-        cli.query(&query, &()).await
+        cli.query(query, &()).await
     }
 }

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 pub use edgeql_parser::helpers::quote_name;
 
 
-pub fn quote_namespaced<'x>(name: &'x str) -> Cow<'x, str> {
+pub fn quote_namespaced(name: &str) -> Cow<'_, str> {
     if name.contains("::") {
         let mut buf = String::with_capacity(name.len());
         let mut iter = name.split("::");
@@ -12,7 +12,7 @@ pub fn quote_namespaced<'x>(name: &'x str) -> Cow<'x, str> {
             buf.push_str("::");
             buf.push_str(&quote_name(chunk));
         }
-        return buf.into();
+        buf.into()
     } else {
         return quote_name(name);
     }

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -53,7 +53,7 @@ pub fn specific_info(item: &str) -> Result<(), anyhow::Error> {
 
 pub fn info(_options: &Options, info: &Info)-> Result<(), anyhow::Error> {
     if let Some(ref item) = info.get {
-        return specific_info(&item);
+        return specific_info(item);
     }
     let mut table = Table::new();
 

--- a/src/commands/list_aliases.rs
+++ b/src/commands/list_aliases.rs
@@ -56,7 +56,7 @@ pub async fn list_aliases(cli: &mut Connection, options: &Options,
         ORDER BY .name;
     "###, filter=filter);
     let items = filter::query::<Alias>(cli,
-        &query, &pattern, case_sensitive).await?;
+        query, pattern, case_sensitive).await?;
     if !options.command_line || std::io::stdout().is_terminal() {
         let mut table = Table::new();
         table.set_format(*table::FORMAT);
@@ -93,15 +93,13 @@ pub async fn list_aliases(cli: &mut Connection, options: &Options,
         } else {
             table.printstd();
         }
+    } else if verbose {
+        for item in items {
+            println!("{}\t{}\t{}", item.name, item.klass, item.expr);
+        }
     } else {
-        if verbose {
-            for item in items {
-                println!("{}\t{}\t{}", item.name, item.klass, item.expr);
-            }
-        } else {
-            for item in items {
-                println!("{}\t{}", item.name, item.klass);
-            }
+        for item in items {
+            println!("{}\t{}", item.name, item.klass);
         }
     }
     Ok(())

--- a/src/commands/list_casts.rs
+++ b/src/commands/list_casts.rs
@@ -45,7 +45,7 @@ pub async fn list_casts<'x>(cli: &mut Connection, options: &Options,
         ORDER BY .kind THEN .from_type.name THEN .to_type.name;
     "###, filter=filter);
     let items = filter::query::<Cast>(cli,
-        &query, &pattern, case_sensitive).await?;
+        query, pattern, case_sensitive).await?;
     if !options.command_line || std::io::stdout().is_terminal() {
         let mut table = Table::new();
         table.set_format(*table::FORMAT);

--- a/src/commands/list_indexes.rs
+++ b/src/commands/list_indexes.rs
@@ -69,7 +69,7 @@ pub async fn list_indexes(cli: &mut Connection, options: &Options,
         ORDER BY .subject_name;
     "###, filter=filter);
     let items = filter::query::<Index>(cli,
-        &query, &pattern, case_sensitive).await?;
+        query, pattern, case_sensitive).await?;
     if !options.command_line || std::io::stdout().is_terminal() {
         let mut table = Table::new();
         table.set_format(*table::FORMAT);
@@ -110,16 +110,14 @@ pub async fn list_indexes(cli: &mut Connection, options: &Options,
         } else {
             table.printstd();
         }
+    } else if verbose {
+        for item in items {
+            println!("{}\t{}\t{}",
+                item.expr, item.is_implicit, item.subject_name);
+        }
     } else {
-        if verbose {
-            for item in items {
-                println!("{}\t{}\t{}",
-                    item.expr, item.is_implicit, item.subject_name);
-            }
-        } else {
-            for item in items {
-                println!("{}\t{}", item.expr, item.subject_name);
-            }
+        for item in items {
+            println!("{}\t{}", item.expr, item.subject_name);
         }
     }
     Ok(())

--- a/src/commands/list_modules.rs
+++ b/src/commands/list_modules.rs
@@ -18,7 +18,7 @@ pub async fn list_modules(cli: &mut Connection, options: &Options,
         {filter}
         ORDER BY name
     "###, filter=filter);
-    let items = filter::query(cli, &query, &pattern, case_sensitive).await?;
+    let items = filter::query(cli, &query, pattern, case_sensitive).await?;
     list::print(items, "List of modules", options).await?;
     Ok(())
 }

--- a/src/commands/list_object_types.rs
+++ b/src/commands/list_object_types.rs
@@ -45,7 +45,7 @@ pub async fn list_object_types(cli: &mut Connection, options: &Options,
     "###, filter=filter.join(") AND ("));
 
     let items = filter::query::<TypeRow>(cli,
-        &query, pattern, case_sensitive).await?;
+        query, pattern, case_sensitive).await?;
     if !options.command_line || std::io::stdout().is_terminal() {
         let term_width = terminal_size()
             .map(|(Width(w), _h)| w.into()).unwrap_or(80);

--- a/src/commands/list_roles.rs
+++ b/src/commands/list_roles.rs
@@ -18,7 +18,7 @@ pub async fn list_roles<'x>(cli: &mut Connection, options: &Options,
         {filter}
         ORDER BY name
     "###, filter=filter);
-    let items = filter::query(cli, &query, &pattern, case_sensitive).await?;
+    let items = filter::query(cli, &query, pattern, case_sensitive).await?;
     list::print(items, "List of roles", options).await?;
     Ok(())
 }

--- a/src/commands/list_scalar_types.rs
+++ b/src/commands/list_scalar_types.rs
@@ -56,7 +56,7 @@ pub async fn list_scalar_types<'x>(cli: &mut Connection, options: &Options,
     "###, filter=filter);
 
     let items = filter::query::<ScalarType>(cli,
-        &query, &pattern, case_sensitive).await?;
+        query, pattern, case_sensitive).await?;
     if !options.command_line || std::io::stdout().is_terminal() {
         let term_width = terminal_size()
             .map(|(Width(w), _h)| w).unwrap_or(80);

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -19,7 +19,7 @@ pub enum Common {
     Configure(Configure),
 
     /// Migration management subcommands
-    Migration(Migration),
+    Migration(Box<Migration>),
     /// Apply migration (alias for `edgedb migration apply`)
     Migrate(Migrate),
 
@@ -38,6 +38,16 @@ pub enum Common {
     /// Run psql shell. Works on dev-mode database only.
     #[command(hide=true)]
     Psql,
+}
+
+impl Common {
+    pub fn as_migration(&self) -> Option<&Migration> {
+        if let Common::Migration(m) = self {
+            Some(m.as_ref())
+        } else {
+            None
+        }
+    }
 }
 
 
@@ -144,7 +154,7 @@ pub struct Backslash {
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum BackslashCmd {
     #[command(flatten)]
-    Common(Common),
+    Common(Box<Common>),
     Help,
     LastError,
     Expand,

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{ValueHint};
+use clap::ValueHint;
 
 use crate::repl::{self, VectorLimit};
 use crate::migrations::options::{Migration, Migrate};

--- a/src/commands/psql.rs
+++ b/src/commands/psql.rs
@@ -54,7 +54,7 @@ pub async fn psql<'x>(cli: &mut Connection, _options: &Options)
             }
 
 
-            let _trap = interrupt::Trap::trap(&[interrupt::Signal::Interrupt]);
+            let _trap = interrupt::Trap::new(&[interrupt::Signal::Interrupt]);
             cmd.status().with_context(|| {
                 format!("Error running {:?} (path: {:?})", cmd,
                         path.unwrap_or_else(OsString::new))

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -51,7 +51,7 @@ async fn read_packet(input: &mut Input, buf: &mut BytesMut,
         let n = input.read_buf(buf).await
             .context("Cannot read packet header")?;
         if n == 0 {  // EOF
-            if buf.len() == 0 {
+            if buf.is_empty() {
                 return Ok(None)
             } else {
                 return Err(io::Error::from(io::ErrorKind::UnexpectedEof))
@@ -100,7 +100,7 @@ impl Stream for Packets<'_> {
     {
         let next = self.next();
         tokio::pin!(next);
-        return next.poll(cx);
+        next.poll(cx)
     }
 }
 
@@ -203,7 +203,7 @@ async fn apply_init(cli: &mut Connection, path: &Path) -> anyhow::Result<()> {
             .context("can't decode statement")?;
         if !is_empty(stmt) {
             log::trace!("Executing {:?}", stmt);
-            cli.execute(&stmt, &()).await
+            cli.execute(stmt, &()).await
                 .with_context(|| format!("failed statement {:?}", stmt))?;
         }
     }
@@ -243,7 +243,7 @@ pub async fn restore_all<'x>(cli: &mut Connection, options: &Options,
         conn_params.branch(&database)?;
         let mut db_conn = conn_params.connect().await.with_context(||
              format!("cannot connect to database {:?}", database))?;
-        params.path = path.into();
+        params.path = path;
         restore_db(&mut db_conn, options, &params).await
             .with_context(|| format!("restoring database {:?}", database))?;
     }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -274,7 +274,7 @@ fn hint_command(input: &str) -> Option<Hint> {
                     let mut output = String::from(&matching[input.len()..]);
                     let complete = output.len() + 1;
                     output.push_str(" {");
-                    for (cmd, _) in sub {
+                    for cmd in sub.keys() {
                         if !output.ends_with('{') {
                             output.push(',');
                         }
@@ -498,7 +498,7 @@ impl BackslashFsm {
 
         match self {
             Command => match token.item {
-                T::Command(x) if x == "\\set" => Setting,
+                T::Command("\\set") => Setting,
                 T::Command(name) => {
                     let name = &name[1..];
                     let name_slice = &[name];

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -59,7 +59,7 @@ trait MapRangeStrExt<K, V> {
         -> std::collections::btree_map::Range<'x, K, V>;
 }
 
-pub fn current<'x>(data: &'x str, pos: usize) -> (usize, Current<'x>) {
+pub fn current(data: &str, pos: usize) -> (usize, Current<'_>) {
     let mut offset = 0;
     loop {
         if preparser::is_empty(&data[offset..]) {
@@ -73,7 +73,7 @@ pub fn current<'x>(data: &'x str, pos: usize) -> (usize, Current<'x>) {
             }
             offset += bytes;
         } else {
-            match preparser::full_statement(&data[offset..].as_bytes(), None) {
+            match preparser::full_statement(data[offset..].as_bytes(), None) {
                 Ok(bytes) => {
                     if offset + bytes > pos {
                         return (offset, Current::Edgeql(
@@ -177,18 +177,18 @@ pub fn complete(input: &str, cursor: usize)
             }
             match &fsm {
                 Fsm::Command => {
-                    return Some((cursor, complete_command("")));
+                    Some((cursor, complete_command("")))
                 }
                 Fsm::Subcommands(s) => {
-                    return Some((cursor, complete_subcommand("", s)));
+                    Some((cursor, complete_subcommand("", s)))
                 }
                 Fsm::Setting => {
-                    return Some((cursor, complete_setting("")));
+                    Some((cursor, complete_setting("")))
                 }
                 Fsm::SetValue(cfg) => {
-                    return Some((cursor, complete_setting_value("", cfg)));
+                    Some((cursor, complete_setting_value("", cfg)))
                 }
-                _ => return None,
+                _ => None,
             }
         }
     }
@@ -227,7 +227,7 @@ fn hint_command(input: &str) -> Option<Hint> {
         .take_while(|x| x.starts_with(input));
     if let Some(matching) = rng.next() {
         let full_match = input.len() == matching.len();
-        if full_match || !rng.next().is_some() {
+        if full_match || rng.next().is_none() {
             let aliased = CMD_CACHE.aliases.get(&matching[1..]);
             let cmd = if let Some(aliased) = aliased {
                 let cmd = CMD_CACHE.commands.get(aliased[0]);
@@ -254,7 +254,7 @@ fn hint_command(input: &str) -> Option<Hint> {
                 Some(Command::Normal(cinfo)) => {
                     let mut output = String::from(&matching[input.len()..]);
                     let complete = output.len() + 1;
-                    add_cmd_info(&mut output, aliased.map(|x| *x), cinfo);
+                    add_cmd_info(&mut output, aliased.copied(), cinfo);
                     return Some(Hint::new(output, complete));
                 }
                 Some(Command::Settings) => {
@@ -262,12 +262,12 @@ fn hint_command(input: &str) -> Option<Hint> {
                     let complete = output.len() + 1;
                     output.push_str(" {");
                     for (cmd, _) in &CMD_CACHE.settings {
-                        if !output.ends_with("{") {
+                        if !output.ends_with('{') {
                             output.push(',');
                         }
                         output.push_str(cmd);
                     }
-                    output.push_str("}");
+                    output.push('}');
                     return Some(Hint::new(output, complete));
                 }
                 Some(Command::Subcommands(sub)) => {
@@ -275,12 +275,12 @@ fn hint_command(input: &str) -> Option<Hint> {
                     let complete = output.len() + 1;
                     output.push_str(" {");
                     for (cmd, _) in sub {
-                        if !output.ends_with("{") {
+                        if !output.ends_with('{') {
                             output.push(',');
                         }
                         output.push_str(cmd);
                     }
-                    output.push_str("}");
+                    output.push('}');
                     return Some(Hint::new(output, complete));
                 }
                 None => return None,
@@ -317,7 +317,7 @@ fn hint_subcommand(cmd: &str, cmds: &BTreeMap<String, backslash::CommandInfo>)
         .take_while(|(name, _)| name.starts_with(cmd));
     if let Some((matching, cinfo)) = rng.next() {
         let full_match = cmd.len() == matching.len();
-        if full_match || !rng.next().is_some() {
+        if full_match || rng.next().is_none() {
             let mut output = String::from(&matching[cmd.len()..]);
             let complete = output.len() + 1;
             if !cinfo.options.is_empty() {
@@ -366,7 +366,7 @@ fn hint_setting_name(sname: &str) -> Option<Hint> {
 
     if let Some((matching, setting)) = rng.next() {
         let full_match = sname.len() == matching.len();
-        if full_match || !rng.next().is_some() {
+        if full_match || rng.next().is_none() {
             let mut output = String::from(&matching[sname.len()..]);
             let complete = output.len()+1;
             if let Some(ref values) = setting.values {
@@ -385,16 +385,14 @@ fn hint_setting_name(sname: &str) -> Option<Hint> {
             return None
         }
     }
-    let mut candidates: Vec<(f64, &str)> = backslash::CMD_CACHE.settings
-        .iter()
-        .map(|(pv, _)| (strsim::jaro_winkler(sname, pv), *pv))
+    let mut candidates: Vec<(f64, &str)> = backslash::CMD_CACHE.settings.keys().map(|pv| (strsim::jaro_winkler(sname, pv), *pv))
         .filter(|(confidence, _pv)| *confidence > 0.8)
         .collect();
     candidates.sort_by(|a, b| {
         b.0.partial_cmp(&a.0).unwrap_or(Ordering::Equal)
     });
     let options: Vec<_> = candidates.into_iter()
-        .map(|(_c, pv)| &pv[..])
+        .map(|(_c, pv)| pv)
         .collect();
     let text = match options.len() {
         0 => "  ← unknown setting".into(),
@@ -411,7 +409,7 @@ fn hint_setting_value(input: &str, val: &SettingValue) -> Option<Hint> {
             let mut matches = variants.iter().filter(|v| v.starts_with(input));
             if let Some(matching) = matches.next() {
                 let full_match = input.len() == matching.len();
-                if full_match || !matches.next().is_some() {
+                if full_match || matches.next().is_none() {
                     // TODO(tailhook) describe setting
                     return Some(Hint::new(&matching[input.len()..], 1000));
                 } else  { // multiple choices possible
@@ -504,7 +502,7 @@ impl BackslashFsm {
                 T::Command(name) => {
                     let name = &name[1..];
                     let name_slice = &[name];
-                    let path = CMD_CACHE.aliases.get(&name).map(|x| *x)
+                    let path = CMD_CACHE.aliases.get(&name).copied()
                         .unwrap_or(name_slice);
                     match CMD_CACHE.commands.get(path[0])
                     {
@@ -541,7 +539,7 @@ impl BackslashFsm {
             }
             Final => Final,
             Arguments(cmd, args) => match token.item {
-                T::Argument(x) if x.starts_with("-") => Arguments(cmd, args),
+                T::Argument(x) if x.starts_with('-') => Arguments(cmd, args),
                 T::Argument(_) if args.len() <= 1 => Final,
                 T::Argument(_) => Arguments(cmd, &args[1..]),
                 _ => Final,
@@ -551,7 +549,7 @@ impl BackslashFsm {
                     match backslash::CMD_CACHE.settings.get(name) {
                         Some(setting) => {
                             if let Some(values) = &setting.values {
-                                SetValue(SettingValue::Variants(&values))
+                                SetValue(SettingValue::Variants(values))
                             } else {
                                 // TODO(tailhook) unhardcode \limit
                                 SetValue(SettingValue::Usize)
@@ -599,7 +597,7 @@ impl BackslashFsm {
                 }
             }
             (SetValue(SettingValue::Usize), T::Argument(arg)) => {
-                if let Ok(_) = usize::from_str(arg) {
+                if usize::from_str(arg).is_ok() {
                     ValidationResult::Valid
                 } else {
                     ValidationResult::Invalid

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -261,7 +261,7 @@ fn hint_command(input: &str) -> Option<Hint> {
                     let mut output = String::from(&matching[input.len()..]);
                     let complete = output.len() + 1;
                     output.push_str(" {");
-                    for (cmd, _) in &CMD_CACHE.settings {
+                    for cmd in CMD_CACHE.settings.keys() {
                         if !output.ends_with('{') {
                             output.push(',');
                         }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -385,11 +385,12 @@ fn make_ignore_error_state(desc: &RawTypedesc) -> State {
     _make_ignore_error_state(desc).unwrap_or(State::empty())
 }
 
+#[derive(edgedb_derive::ConfigDelta)]
+struct ErrorState {
+    force_database_error: &'static str,
+}
+
 fn _make_ignore_error_state(desc: &RawTypedesc) -> Option<State> {
-    #[derive(edgedb_derive::ConfigDelta)]
-    struct ErrorState {
-        force_database_error: &'static str,
-    }
     PoolState::default()
         .with_config(&ErrorState { force_database_error: "false" })
         .encode(desc).ok()

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -103,7 +103,7 @@ impl<'a, T: QueryResult> Stream for ResponseStream<'a, T>
     {
         let next = self.get_mut().next();
         tokio::pin!(next);
-        return next.poll(cx);
+        next.poll(cx)
     }
 }
 
@@ -130,7 +130,7 @@ impl Stream for DumpStream<'_> {
     {
         let next = self.get_mut().next();
         tokio::pin!(next);
-        return next.poll(cx);
+        next.poll(cx)
     }
 }
 
@@ -165,7 +165,7 @@ impl Connector {
     async fn _connect(&self, interactive: bool) -> Result<Connection, anyhow::Error> {
         let cfg = self.config.as_ref().map_err(Clone::clone)?;
         let conn = tokio::select!(
-            conn = Connection::connect(&cfg) => conn?,
+            conn = Connection::connect(cfg) => conn?,
             _ = self.print_warning(cfg, interactive) => unreachable!(),
         );
         Ok(conn)
@@ -203,7 +203,7 @@ impl Connector {
 impl Connection {
     pub async fn connect(cfg: &Config) -> Result<Connection, Error> {
         Ok(Connection {
-            inner: raw::Connection::connect(&cfg).await?,
+            inner: raw::Connection::connect(cfg).await?,
             state: State::empty(),
             server_version: None,
             config: cfg.clone(),
@@ -214,7 +214,7 @@ impl Connection {
     }
     pub fn set_ignore_error_state(&mut self) -> State {
         let new_state = make_ignore_error_state(self.inner.state_descriptor());
-        return mem::replace(&mut self.state, new_state);
+        mem::replace(&mut self.state, new_state)
     }
     pub fn restore_state(&mut self, state: State) {
         self.state = state;
@@ -241,7 +241,7 @@ impl Connection {
             query, arguments, &self.state, Capabilities::ALL,
         ).await?;
         update_state(&mut self.state, &resp)?;
-        return Ok(resp.data);
+        Ok(resp.data)
     }
     pub async fn query_single<R, A>(&mut self, query: &str, arguments: &A)
         -> Result<Option<R>, Error>
@@ -252,7 +252,7 @@ impl Connection {
             query, arguments, &self.state, Capabilities::ALL,
         ).await?;
         update_state(&mut self.state, &resp)?;
-        return Ok(resp.data);
+        Ok(resp.data)
     }
     pub async fn query_required_single<R, A>(
         &mut self, query: &str, arguments: &A)
@@ -261,8 +261,8 @@ impl Connection {
               R: QueryResult,
     {
         let res = self.query_single(query, arguments).await?;
-        return res.ok_or_else(|| NoDataError::with_message(
-            "query row returned zero results"));
+        res.ok_or_else(|| NoDataError::with_message(
+            "query row returned zero results"))
     }
     pub async fn execute<A>(&mut self, query: &str, arguments: &A)
         -> Result<Bytes, Error>
@@ -272,7 +272,7 @@ impl Connection {
             query, arguments, &self.state, Capabilities::ALL
         ).await?;
         update_state(&mut self.state, &resp)?;
-        return Ok(resp.status_data);
+        Ok(resp.status_data)
     }
     pub async fn execute_stream<R, A>(&mut self,
         opts: &CompilationOptions, query: &str,
@@ -285,10 +285,10 @@ impl Connection {
         let stream = self.inner.execute_stream(
             opts, query, &self.state, desc, arguments,
         ).await?;
-        return Ok(ResponseStream {
+        Ok(ResponseStream {
             inner: stream,
             state: &mut self.state,
-        });
+        })
     }
     pub async fn try_execute_stream<R, A>(&mut self,
         opts: &CompilationOptions,
@@ -304,10 +304,10 @@ impl Connection {
         let stream = self.inner.try_execute_stream(
             opts, query, &self.state, input_desc, output_desc, arguments,
         ).await?;
-        return Ok(ResponseStream {
+        Ok(ResponseStream {
             inner: stream,
             state: &mut self.state,
-        });
+        })
     }
     pub fn get_server_param<T: ServerParam>(&self) -> Option<&T::Value> {
         self.inner.get_server_param::<T>()

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -53,9 +53,6 @@ pub struct DumpStream<'a> {
     state: &'a mut State,
 }
 
-trait AssertConn: Send + 'static {}
-impl AssertConn for Connection {}
-
 fn update_state<T>(state: &mut State, resp: &raw::Response<T>)
     -> Result<(), Error>
 {

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -20,7 +20,7 @@ pub fn print_query_error(err: &Error, query: &str, verbose: bool,
     let (pstart, pend) = match (pstart, pend) {
         (Some(s), Some(e)) => (s, e),
         _ => {
-            print::edgedb_error(&err, verbose);
+            print::edgedb_error(err, verbose);
             return Ok(());
         }
     };
@@ -31,11 +31,11 @@ pub fn print_query_error(err: &Error, query: &str, verbose: bool,
         .contexts()
         .rev()
         .collect::<Vec<_>>();
-    if context_error.len() > 0 {
+    if !context_error.is_empty() {
         print::error(context_error.join(": "));
     }
     let diag = Diagnostic::error()
-        .with_message(&format!(
+        .with_message(format!(
             "{}{}",
             err.kind_name(),
             err

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -1,9 +1,8 @@
-use std::default::Default;
 use std::str;
 
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::diagnostic::{Diagnostic, Label, LabelStyle};
-use codespan_reporting::term::{emit};
+use codespan_reporting::term::emit;
 use termcolor::{StandardStream, ColorChoice};
 
 use edgedb_errors::{Error, InternalServerError};

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -9,7 +9,7 @@ use crate::completion::{BackslashFsm, ValidationResult};
 
 
 static UNRESERVED_KEYWORDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
-    keywords::UNRESERVED_KEYWORDS.iter().map(|x| *x).collect()
+    keywords::UNRESERVED_KEYWORDS.iter().copied().collect()
 });
 
 
@@ -25,7 +25,7 @@ pub fn edgeql(outbuf: &mut String, text: &str, styler: &Styler) {
             }
         };
         if tok.span.start as usize > pos {
-            emit_insignificant(outbuf, &styler,
+            emit_insignificant(outbuf, styler,
                 &text[pos..tok.span.start as usize]);
         }
         if let Some(st) = token_style(tok.kind, &tok.text)
@@ -36,7 +36,7 @@ pub fn edgeql(outbuf: &mut String, text: &str, styler: &Styler) {
         }
         pos = tok.span.end as usize;
     }
-    emit_insignificant(outbuf, &styler, &text[pos..]);
+    emit_insignificant(outbuf, styler, &text[pos..]);
 }
 
 pub fn backslash(outbuf: &mut String, text: &str, styler: &Styler) {
@@ -47,7 +47,7 @@ pub fn backslash(outbuf: &mut String, text: &str, styler: &Styler) {
     let mut fsm = BackslashFsm::Command;
     for token in &mut tokens {
         if token.span.0 > pos {
-            emit_insignificant(outbuf, &styler, &text[pos..token.span.0]);
+            emit_insignificant(outbuf, styler, &text[pos..token.span.0]);
         }
         let style = match fsm.validate(&token) {
             ValidationResult::Valid => Some(Style::BackslashCommand),
@@ -60,10 +60,10 @@ pub fn backslash(outbuf: &mut String, text: &str, styler: &Styler) {
         } else {
             outbuf.push_str(value);
         }
-        pos = token.span.1 as usize;
+        pos = token.span.1;
         fsm = fsm.advance(token);
     }
-    emit_insignificant(outbuf, &styler, &text[pos..]);
+    emit_insignificant(outbuf, styler, &text[pos..]);
 }
 
 fn emit_insignificant(buf: &mut String, styler: &Styler, mut chunk: &str) {

--- a/src/hint.rs
+++ b/src/hint.rs
@@ -71,7 +71,7 @@ impl fmt::Display for HintedError {
 
 impl ArcError {
     pub fn inner(&self) -> &anyhow::Error {
-        &*self.0
+        &self.0
     }
 }
 

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -2,7 +2,7 @@
 use std::str;
 use std::time::Instant;
 
-use anyhow::{self, Context};
+use anyhow::Context;
 use colorful::Colorful;
 use is_terminal::IsTerminal;
 use terminal_size::{Width, terminal_size};
@@ -11,10 +11,10 @@ use tokio::sync::mpsc::channel;
 use tokio_stream::StreamExt;
 
 use edgedb_errors::{StateMismatchError,  ParameterTypeMismatchError};
-use edgedb_protocol::client_message::{CompilationOptions};
+use edgedb_protocol::client_message::CompilationOptions;
 use edgedb_protocol::client_message::{IoFormat, Cardinality};
 use edgedb_protocol::common::{Capabilities, State};
-use edgedb_protocol::common::{RawTypedesc};
+use edgedb_protocol::common::RawTypedesc;
 use edgedb_protocol::descriptors::Typedesc;
 use edgedb_protocol::model::Duration;
 use edgedb_protocol::value::Value;

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,4 +1,4 @@
-use std::mem::replace;
+
 use std::str;
 use std::time::Instant;
 
@@ -72,14 +72,14 @@ impl<'a> Iterator for ToDo<'a> {
     fn next(&mut self) -> Option<ToDoItem<'a>> {
         loop {
             let tail = self.tail.trim_start();
-            if tail.starts_with("\\") {
-                let len = backslash::full_statement(&tail);
+            if tail.starts_with('\\') {
+                let len = backslash::full_statement(tail);
                 self.tail = &tail[len..];
                 return Some(ToDoItem::Backslash(&tail[..len]));
             } else if preparser::is_empty(tail) {
                 return None;
             } else {
-                let len = full_statement(&tail.as_bytes(), None)
+                let len = full_statement(tail.as_bytes(), None)
                     .unwrap_or(tail.len());
                 let query = &tail[..len];
                 self.tail = &tail[len..];
@@ -120,7 +120,7 @@ pub fn main(options: Options, cfg: Config) -> Result<(), anyhow::Error> {
         verbose_errors: cfg.shell.verbose_errors.unwrap_or(false),
         last_error: None,
         last_analyze: None,
-        implicit_limit: implicit_limit,
+        implicit_limit,
         idle_transaction_timeout: idle_tx_timeout,
         output_format: options.output_format
             .or(cfg.shell.output_format)
@@ -160,12 +160,12 @@ pub async fn _main(options: Options, mut state: repl::State, cfg: Config)
     echo!(r#"Type \help for help, \quit to quit."#.light_gray());
     state.set_history_limit(state.history_limit).await?;
     match _interactive_main(&options, &mut state).await {
-        Ok(()) => return Ok(()),
+        Ok(()) => Ok(()),
         Err(e) => {
             if e.is::<CleanShutdown>() {
                 return Ok(());
             }
-            return Err(e);
+            Err(e)
         }
     }
 }
@@ -197,7 +197,7 @@ fn _check_json_limit(json: &serde_json::Value, path: &mut String, limit: usize)
         }
         _ => {}
     }
-    return true;
+    true
 }
 
 fn print_json_limit_error(path: &str) {
@@ -214,10 +214,10 @@ fn check_json_limit(json: &serde_json::Value, path: &str, limit: usize) -> bool
         print_json_limit_error(&path_buf);
         return false;
     }
-    return true;
+    true
 }
 
-async fn execute_backslash(mut state: &mut repl::State, text: &str)
+async fn execute_backslash(state: &mut repl::State, text: &str)
     -> anyhow::Result<()>
 {
     use backslash::ExecuteResult::*;
@@ -236,7 +236,7 @@ async fn execute_backslash(mut state: &mut repl::State, text: &str)
             return Ok(());
         }
     };
-    let res = backslash::execute(&cmd.command, &mut state).await;
+    let res = backslash::execute(&cmd.command, state).await;
     match res {
         Ok(Skip) => {},
         Ok(Quit) => {
@@ -441,8 +441,8 @@ async fn execute_query(options: &Options, state: &mut repl::State,
                     _ => return Err(anyhow::anyhow!(
                         "the server returned a non-string value in JSON mode")),
                 };
-                let jitems: serde_json::Value;
-                jitems = serde_json::from_str(&text)
+                
+                let jitems: serde_json::Value = serde_json::from_str(&text)
                     .context("cannot decode json result")?;
                 if let Some(limit) = state.implicit_limit {
                     if !check_json_limit(&jitems, "", limit) {
@@ -474,8 +474,8 @@ async fn execute_query(options: &Options, state: &mut repl::State,
                     _ => return Err(anyhow::anyhow!(
                         "server returned a non-string value in JSON mode")),
                 };
-                let value: serde_json::Value;
-                value = serde_json::from_str(&text)
+                
+                let value: serde_json::Value = serde_json::from_str(&text)
                     .context("cannot decode json result")?;
                 let path = format!(".[{}]", index);
                 if let Some(limit) = state.implicit_limit {
@@ -512,7 +512,7 @@ async fn execute_query(options: &Options, state: &mut repl::State,
         );
     }
     state.last_error = None;
-    return Ok(());
+    Ok(())
 }
 
 async fn _interactive_main(options: &Options, state: &mut repl::State)
@@ -524,7 +524,7 @@ async fn _interactive_main(options: &Options, state: &mut repl::State)
             _ = state.ensure_connection() => {}
             res = ctrlc.wait_result() => res?,
         );
-        let cur_initial = replace(&mut state.initial_text, String::new());
+        let cur_initial = std::mem::take(&mut state.initial_text);
         let inp = match state.edgeql_input(&cur_initial).await? {
             prompt::Input::Eof => {
                 tokio::select!(

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -92,7 +92,7 @@ impl Event {
         self.waker.wake()
     }
     fn wait(&self) -> EventWait {
-        EventWait(&*self)
+        EventWait(self)
     }
     fn clear(&self) {
         self.first.store(None);
@@ -159,7 +159,7 @@ fn signal_message(signal: Signal) -> i32 {
         log::warn!("Exiting on signal {}",
             signal_hook::low_level::signal_name(id).unwrap_or("<unknown>"));
     }
-    return id;
+    id
 }
 
 #[cfg(windows)]
@@ -170,7 +170,7 @@ fn signal_message(_signal: Signal) -> i32 {
 
 fn exit_on(signal: Signal) -> ! {
     if let Some(sentinel) = &*CUR_TERM.load() {
-        reset_terminal(&*sentinel);
+        reset_terminal(sentinel);
     }
     let id = signal_message(signal);
     process::exit(128 + id);
@@ -191,7 +191,7 @@ pub fn init_signals() {
         use signal_hook::iterator::Signals;
         use signal_hook::consts::signal::{SIGINT, SIGHUP, SIGTERM};
 
-        let mut signals = Signals::new(&[SIGINT, SIGHUP, SIGTERM])
+        let mut signals = Signals::new([SIGINT, SIGHUP, SIGTERM])
             .expect("signals initialized");
         for signal in signals.into_iter() {
             if let Some(state) = CUR_INTERRUPT.load_full()  {
@@ -279,7 +279,7 @@ impl Future for EventWait<'_> {
 
 impl Signal {
     fn all_bits() -> SigMask {
-        return 0b111;
+        0b111
     }
     fn as_bit(&self) -> SigMask {
         match self {
@@ -354,8 +354,8 @@ impl Trap {
                 ));
             }
             Trap {
-                oldset: oldset,
-                oldsigs: oldsigs,
+                oldset,
+                oldsigs,
             }
         }
     }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -292,7 +292,7 @@ impl Signal {
 
 #[cfg(unix)]
 impl Signal {
-    fn to_unix(&self) -> i32 {
+    fn to_unix(self) -> i32 {
         use signal_hook::consts::signal::*;
 
         match self {
@@ -301,7 +301,7 @@ impl Signal {
             Signal::Hup => SIGHUP,
         }
     }
-    fn to_nix(&self) -> nix::sys::signal::Signal {
+    fn to_nix(self) -> nix::sys::signal::Signal {
         use nix::sys::signal::Signal::*;
 
         match self {

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -326,7 +326,7 @@ impl Trap {
     /// Create and activate the signal trap for specified signals. Signals not
     /// in list will be delivered asynchronously as always.
     #[cfg(unix)]
-    pub fn trap(signals: &[Signal]) -> Trap {
+    pub fn new(signals: &[Signal]) -> Trap {
         use nix::sys::signal::{SigSet, SigmaskHow};
         use nix::sys::signal::{sigaction, SigAction, SaFlags, SigHandler};
 
@@ -361,7 +361,7 @@ impl Trap {
     }
 
     #[cfg(not(unix))]
-    pub fn trap(_: &[Signal]) -> Trap {
+    pub fn new(_: &[Signal]) -> Trap {
         Trap {}
     }
 }

--- a/src/log_levels.rs
+++ b/src/log_levels.rs
@@ -13,7 +13,7 @@ pub fn init(builder: &mut env_logger::Builder, opt: &Options) {
                               log::LevelFilter::Debug);
     }
     match &opt.subcommand {
-        Some(Command::CliCommand(c)) => match &c.subcommand {
+        Some(Command::Cli(c)) => match &c.subcommand {
             Cli::Upgrade(s) if s.verbose => {
                 builder.filter_module("edgedb::self_upgrade",
                     log::LevelFilter::Info);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@
 
 use clap::Parser;
 
-use std::default::Default;
 use std::env;
 use std::path::Path;
 use std::process::exit;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ fn main() {
 }
 
 fn is_cli_upgrade(cmd: &Option<options::Command>) -> bool {
-    use options::Command::CliCommand as Cli;
+    use options::Command::Cli as Cli;
     use cli::options::CliCommand;
     use cli::options::Command::Upgrade;
     matches!(cmd, Some(Cli(CliCommand { subcommand: Upgrade(..) })))

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -25,7 +25,7 @@ fn prepare_markdown(text: &str) -> String {
         }
         buf.push('\n');
     }
-    return buf;
+    buf
 }
 
 static MADSKIN: Lazy<termimad::MadSkin> = Lazy::new(|| {
@@ -51,11 +51,11 @@ fn parse_markdown(text: &str) -> minimad::Text {
     use minimad::Line::*;
     use minimad::CompositeStyle::*;
 
-    let lines = Text::from(&text[..]).lines;
+    let lines = Text::from(text).lines;
     let mut text = Text { lines: Vec::with_capacity(lines.len()) };
     for line in lines.into_iter() {
         if let Normal(Composite { style, compounds: cmps }) = line {
-            if cmps.len() == 0  {
+            if cmps.is_empty()  {
                 text.lines.push(
                     Normal(Composite { style, compounds: cmps })
                 );
@@ -63,7 +63,7 @@ fn parse_markdown(text: &str) -> minimad::Text {
             }
             match (style, text.lines.last_mut()) {
                 (_, Some(&mut Normal(Composite { ref compounds , ..})))
-                    if compounds.len() == 0
+                    if compounds.is_empty()
                 => {
                     text.lines.push(
                         Normal(Composite { style, compounds: cmps })
@@ -87,11 +87,11 @@ fn parse_markdown(text: &str) -> minimad::Text {
             }
         }
     }
-    return text;
+    text
 }
 
 pub fn format_title(text: &str) -> String {
-    let text = prepare_markdown(&text);
+    let text = prepare_markdown(text);
     let mut text = parse_markdown(&text);
     if !text.lines.is_empty() {
         text.lines.drain(1..);

--- a/src/migrations/context.rs
+++ b/src/migrations/context.rs
@@ -44,7 +44,7 @@ impl Context {
     pub fn for_watch(project_dir: &Path) -> anyhow::Result<Context> {
         let config_path = project_dir.join("edgedb.toml");
         let config = config::read(&config_path)?;
-        return Context::for_project(&config);
+        Context::for_project(&config)
     }
     pub fn for_project(config: &config::Config) -> anyhow::Result<Context> {
         Ok(Context {

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -727,15 +727,15 @@ async fn _write_migration(descr: &impl MigrationToText, filepath: &Path,
     }
     fs::remove_file(&tmp_file).await.ok();
     let mut file = io::BufWriter::new(fs::File::create(&tmp_file).await?);
-    file.write(format!("CREATE MIGRATION {}\n", id).as_bytes()).await?;
-    file.write(format!("    ONTO {}\n", descr.parent()?).as_bytes()).await?;
-    file.write(b"{\n").await?;
+    file.write_all(format!("CREATE MIGRATION {}\n", id).as_bytes()).await?;
+    file.write_all(format!("    ONTO {}\n", descr.parent()?).as_bytes()).await?;
+    file.write_all(b"{\n").await?;
     for statement in descr.statements() {
         for line in statement.lines() {
-            file.write(format!("  {}\n", line).as_bytes()).await?;
+            file.write_all(format!("  {}\n", line).as_bytes()).await?;
         }
     }
-    file.write(b"};\n").await?;
+    file.write_all(b"};\n").await?;
     file.flush().await?;
     drop(file);
     fs::rename(&tmp_file, &filepath).await?;

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -111,7 +111,7 @@ pub trait MigrationToText {
     fn key(&self) -> &MigrationKey;
     fn parent(&self) -> anyhow::Result<&str>;
     fn id(&self) -> anyhow::Result<&str>;
-    fn statements<'a>(&'a self) -> Self::StatementsIter<'a>;
+    fn statements(&self) -> Self::StatementsIter<'_>;
 }
 
 #[derive(Debug)]
@@ -181,14 +181,14 @@ impl MigrationToText for FutureMigration {
         id.get_or_try_init(|| {
             let mut hasher = Hasher::start_migration(parent);
             for statement in statements {
-                hasher.add_source(&statement)
+                hasher.add_source(statement)
                     .map_err(|e| migration::hashing_error(statement, e))?;
             }
             Ok(hasher.make_migration_id())
         }).map(|s| &s[..])
     }
 
-    fn statements<'a>(&'a self) -> Self::StatementsIter<'a> {
+    fn statements(&self) -> Self::StatementsIter<'_> {
         self.statements.iter()
     }
 }
@@ -252,7 +252,7 @@ async fn gen_start_migration(ctx: &Context)
     while let Some(item) = dir.next_entry().await? {
         let fname = item.file_name();
         let lossy_name = fname.to_string_lossy();
-        if !lossy_name.starts_with(".") && lossy_name.ends_with(".esdl")
+        if !lossy_name.starts_with('.') && lossy_name.ends_with(".esdl")
             && item.file_type().await?.is_file() { paths.push(item.path())}
     }
 
@@ -271,12 +271,12 @@ async fn gen_start_migration(ctx: &Context)
 pub async fn execute_start_migration(ctx: &Context, cli: &mut Connection)
     -> anyhow::Result<()>
 {
-    let (text, source_map) = gen_start_migration(&ctx).await?;
+    let (text, source_map) = gen_start_migration(ctx).await?;
     match execute(cli, text).await {
         Ok(_) => Ok(()),
         Err(e) if e.is::<QueryError>() => {
             print_migration_error(&e, &source_map)?;
-            return Err(EsdlError)?;
+            Err(EsdlError)?
         }
         Err(e) => Err(e)?,
     }
@@ -286,7 +286,7 @@ pub async fn first_migration(cli: &mut Connection, ctx: &Context,
                          options: &CreateMigration)
     -> anyhow::Result<FutureMigration>
 {
-    execute_start_migration(&ctx, cli).await?;
+    execute_start_migration(ctx, cli).await?;
     async_try! {
         async {
             execute(cli, "POPULATE MIGRATION").await?;
@@ -377,7 +377,7 @@ pub async fn unsafe_populate(_ctx: &Context, cli: &mut Connection)
                     placeholders.insert(input.placeholder.clone(), expr);
                 }
             }
-            if !apply_proposal(cli, &proposal, &placeholders).await? {
+            if !apply_proposal(cli, proposal, &placeholders).await? {
                 execute(cli, "ALTER CURRENT MIGRATION REJECT PROPOSED").await?;
             }
         } else {
@@ -397,7 +397,7 @@ async fn apply_proposal(cli: &mut Connection, proposal: &Proposal,
         async {
             for statement in &proposal.statements {
                 let statement = substitute_placeholders(
-                    &statement.text, &placeholders)?;
+                    &statement.text, placeholders)?;
                 if let Err(e) = execute(cli, &statement).await {
                     if e.is::<InvalidSyntaxError>() {
                         log::error!("Error executing: {}", statement);
@@ -555,7 +555,7 @@ impl InteractiveMigration<'_> {
                         // TODO(tailhook) ask if we want to rollback or quit
                         continue;
                     }
-                    Err(e) => return Err(e.into()),
+                    Err(e) => return Err(e),
                 };
             };
         } else {
@@ -575,7 +575,7 @@ impl InteractiveMigration<'_> {
                         match input_res {
                             Ok(data) => input = data,
                             Err(e) if e.is::<Refused>() => continue,
-                            Err(e) => return Err(e.into()),
+                            Err(e) => return Err(e),
                         };
                         break;
                     }
@@ -634,17 +634,15 @@ impl InteractiveMigration<'_> {
                 Err(e) => {
                     if e.is::<QueryError>() {
                         print_query_error(&e, &text, false, "<statement>")?;
+                    } else if print::use_color() {
+                        eprintln!(
+                            "{}: {:#}",
+                            "Error applying statement"
+                                .bold().light_red(),
+                            e.to_string().bold().white(),
+                        );
                     } else {
-                        if print::use_color() {
-                            eprintln!(
-                                "{}: {:#}",
-                                "Error applying statement"
-                                    .bold().light_red(),
-                                e.to_string().bold().white(),
-                            );
-                        } else {
-                            eprintln!("Error applying statement: {:#}", e);
-                        }
+                        eprintln!("Error applying statement: {:#}", e);
                     }
                     if self.cli.is_consistent() {
                         eprintln!("Rolling back last operation...");
@@ -723,8 +721,8 @@ async fn _write_migration(descr: &impl MigrationToText, filepath: &Path,
 {
     let id = descr.id()?;
     let dir = filepath.parent().unwrap();
-    let tmp_file = filepath.with_file_name(tmp_file_name(&filepath.as_ref()));
-    if !fs::metadata(filepath).await.is_ok() {
+    let tmp_file = filepath.with_file_name(tmp_file_name(filepath));
+    if fs::metadata(filepath).await.is_err() {
         fs::create_dir_all(&dir).await?;
     }
     fs::remove_file(&tmp_file).await.ok();
@@ -734,7 +732,7 @@ async fn _write_migration(descr: &impl MigrationToText, filepath: &Path,
     file.write(b"{\n").await?;
     for statement in descr.statements() {
         for line in statement.lines() {
-            file.write(&format!("  {}\n", line).as_bytes()).await?;
+            file.write(format!("  {}\n", line).as_bytes()).await?;
         }
     }
     file.write(b"};\n").await?;
@@ -766,7 +764,7 @@ pub async fn create(cli: &mut Connection, options: &Options,
         let old_state = cli.set_ignore_error_state();
         let res = _create(cli, options, create).await;
         cli.restore_state(old_state);
-        return res;
+        res
     }
 }
 
@@ -794,7 +792,7 @@ async fn _create(cli: &mut Connection, options: &Options,
             // This decision must be done early on because
             // of the bug in EdgeDB:
             //   https://github.com/edgedb/edgedb/issues/3958
-            if migrations.len() == 0 {
+            if migrations.is_empty() {
                 first_migration(cli, &ctx, create).await
             } else {
                 let key = MigrationKey::Index((migrations.len() + 1) as u64);
@@ -816,7 +814,7 @@ pub async fn normal_migration(cli: &mut Connection, ctx: &Context,
                               create: &CreateMigration)
     -> anyhow::Result<FutureMigration>
 {
-    execute_start_migration(&ctx, cli).await?;
+    execute_start_migration(ctx, cli).await?;
     async_try! {
         async {
             let descr = query_row::<CurrentMigration>(cli,
@@ -834,13 +832,13 @@ pub async fn normal_migration(cli: &mut Connection, ctx: &Context,
             }
 
             if create.non_interactive {
-                run_non_interactive(&ctx, cli, key, &create).await
+                run_non_interactive(ctx, cli, key, create).await
             } else {
                 if create.allow_unsafe {
                     log::warn!("The `--allow-unsafe` flag is unused \
                                 in interactive mode");
                 }
-                run_interactive(&ctx, cli, key, &create).await
+                run_interactive(ctx, cli, key, create).await
             }
         },
         finally async {
@@ -868,7 +866,7 @@ fn add_newline_after_comment(value: &mut String) -> Result<(), anyhow::Error> {
 
 fn get_input(req: &RequiredUserInput) -> Result<String, anyhow::Error> {
     let prompt = format!("{}> ", req.placeholder);
-    let mut prev = make_default_expression(req).unwrap_or(String::new());
+    let mut prev = make_default_expression(req).unwrap_or_default();
     loop {
         println!("{}:", req.prompt);
         let mut value = match prompt::expression(&prompt, &req.placeholder, &prev) {
@@ -920,7 +918,7 @@ fn substitute_placeholders<'x>(input: &'x str,
         if token.kind == TokenKind::Substitution {
             output.push_str(&input[start..token.span.start as usize]);
             let name = token.text.strip_prefix(r"\(")
-                .and_then(|item| item.strip_suffix(")"))
+                .and_then(|item| item.strip_suffix(')'))
                 .ok_or_else(|| bug::error(format!("bad substitution token")))?;
             let expr = placeholders.get(name)
                 .ok_or_else(|| bug::error(format!(
@@ -953,7 +951,7 @@ fn add_newline() {
     fn wrapper(s: &str) -> String {
         let mut data = s.to_string();
         add_newline_after_comment(&mut data).unwrap();
-        return data;
+        data
     }
     assert_eq!(wrapper("1+1"), "1+1");
     assert_eq!(wrapper("1    "), "1    ");

--- a/src/migrations/db_migration.rs
+++ b/src/migrations/db_migration.rs
@@ -14,7 +14,7 @@ pub(crate) trait SortableMigration {
     type ParentsIter<'a>: Iterator<Item = &'a String> where Self: 'a;
     fn name(&self) -> &str;
     fn is_root(&self) -> bool;
-    fn iter_parents<'a>(&'a self) -> Self::ParentsIter<'a>;
+    fn iter_parents(&self) -> Self::ParentsIter<'_>;
 }
 
 // Database migration record
@@ -37,7 +37,7 @@ impl SortableMigration for DBMigration {
         self.parent_names.is_empty()
     }
 
-    fn iter_parents<'a>(&'a self) -> Self::ParentsIter<'a> {
+    fn iter_parents(&self) -> Self::ParentsIter<'_> {
         self.parent_names.iter()
     }
 }
@@ -56,8 +56,7 @@ pub(crate) fn linearize_db_migrations<M>(
     let mut output = IndexMap::new();
     let mut visited = BTreeSet::new();
     let mut queue = migrations.iter()
-        .filter(|item| item.is_root())
-        .map(|item| item.clone())
+        .filter(|item| item.is_root()).cloned()
         .collect::<Vec<_>>();
     while let Some(item) = queue.pop() {
         output.insert(item.name().to_owned(), item.clone());
@@ -70,7 +69,7 @@ pub(crate) fn linearize_db_migrations<M>(
             }
         }
     }
-    return output
+    output
 }
 
 pub(crate) async fn read_all(
@@ -162,5 +161,5 @@ pub(crate) async fn find_by_prefix(
     if all_similar.len() > 1 {
         anyhow::bail!("more than one migration matches prefix {:?}", prefix);
     }
-    return Ok(all_similar.pop())
+    Ok(all_similar.pop())
 }

--- a/src/migrations/dev_mode.rs
+++ b/src/migrations/dev_mode.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use anyhow::Context as _;
 use indicatif::ProgressBar;
 use once_cell::sync::Lazy;
-use edgedb_errors::{QueryError};
+use edgedb_errors::QueryError;
 
 use crate::async_try;
 use crate::bug;
@@ -26,7 +26,7 @@ enum Mode {
     Rebase,
 }
 
-const MINIMUM_VERSION: Lazy<ver::Build> =
+static MINIMUM_VERSION: Lazy<ver::Build> =
     Lazy::new(|| "3.0-alpha.1+05474ea".parse().unwrap());
 
 mod ddl {  // Just for nice log filter

--- a/src/migrations/dev_mode.rs
+++ b/src/migrations/dev_mode.rs
@@ -48,7 +48,7 @@ mod ddl {  // Just for nice log filter
 }
 
 pub async fn check_client(cli: &mut Connection) -> anyhow::Result<bool> {
-    ver::check_client(cli, &*MINIMUM_VERSION).await
+    ver::check_client(cli, &MINIMUM_VERSION).await
 }
 
 pub async fn migrate(cli: &mut Connection, ctx: &Context, bar: &ProgressBar)
@@ -59,7 +59,7 @@ pub async fn migrate(cli: &mut Connection, ctx: &Context, bar: &ProgressBar)
             "Dev mode is not supported on EdgeDB {}. Please upgrade.",
             cli.get_version().await?);
     }
-    let migrations = migration::read_all(&ctx, true).await?;
+    let migrations = migration::read_all(ctx, true).await?;
     let db_migration = get_db_migration(cli).await?;
     match select_mode(cli, &migrations, db_migration.as_deref()).await? {
         Mode::Normal { skip } => {
@@ -68,19 +68,19 @@ pub async fn migrate(cli: &mut Connection, ctx: &Context, bar: &ProgressBar)
                 .ok_or_else(|| bug::error("`skip` is out of range"))?;
             if !migrations.is_empty() {
                 bar.set_message("applying migrations");
-                apply_migrations(cli, migrations, &ctx, false).await?;
+                apply_migrations(cli, migrations, ctx, false).await?;
             }
             bar.set_message("calculating diff");
             log::info!("Calculating schema diff.");
-            migrate_to_schema(cli, &ctx).await?;
+            migrate_to_schema(cli, ctx).await?;
         }
         Mode::Rebase => {
             log::info!("Calculating schema diff.");
             bar.set_message("calculating diff");
-            migrate_to_schema(cli, &ctx).await?;
+            migrate_to_schema(cli, ctx).await?;
             log::info!("Now rebasing on top of filesystem migrations.");
             bar.set_message("rebasing migrations");
-            rebase_to_schema(cli, &ctx, &migrations).await?;
+            rebase_to_schema(cli, ctx, &migrations).await?;
         }
     }
     Ok(())
@@ -157,7 +157,7 @@ async fn _migrate_to_schema(cli: &mut Connection, ctx: &Context)
     execute(cli, "DECLARE SAVEPOINT migrate_to_schema").await?;
     let descr = async_try! {
         async {
-            execute_start_migration(&ctx, cli).await?;
+            execute_start_migration(ctx, cli).await?;
             if let Err(e) = execute(cli, "POPULATE MIGRATION").await {
                 if e.is::<QueryError>() {
                     return Ok(None)
@@ -185,7 +185,7 @@ async fn _migrate_to_schema(cli: &mut Connection, ctx: &Context)
     let descr = if let Some(descr) = descr {
         descr
     } else {
-        execute_start_migration(&ctx, cli).await?;
+        execute_start_migration(ctx, cli).await?;
         async_try! {
             async {
                 unsafe_populate(ctx, cli).await
@@ -235,8 +235,8 @@ async fn create_in_rewrite(ctx: &Context, cli: &mut Connection,
     -> anyhow::Result<FutureMigration>
 {
     apply_migrations_inner(cli, migrations, true).await?;
-    if migrations.len() == 0 {
-        first_migration(cli, &ctx, create).await
+    if migrations.is_empty() {
+        first_migration(cli, ctx, create).await
     } else {
         let key = MigrationKey::Index((migrations.len() + 1) as u64);
         let parent = migrations.keys().last().map(|x| &x[..]);
@@ -248,7 +248,7 @@ pub async fn create(cli: &mut Connection, ctx: &Context, _options: &Options,
     create: &CreateMigration)
     -> anyhow::Result<()>
 {
-    let migrations = migration::read_all(&ctx, true).await?;
+    let migrations = migration::read_all(ctx, true).await?;
 
     let old_timeout = timeout::inhibit_for_transaction(cli).await?;
     let migration = async_try! {
@@ -268,6 +268,6 @@ pub async fn create(cli: &mut Connection, ctx: &Context, _options: &Options,
             timeout::restore_for_transaction(cli, old_timeout).await
         }
     }?;
-    write_migration(&ctx, &migration, !create.non_interactive).await?;
+    write_migration(ctx, &migration, !create.non_interactive).await?;
     Ok(())
 }

--- a/src/migrations/edb.rs
+++ b/src/migrations/edb.rs
@@ -36,7 +36,7 @@ pub async fn query_row<R>(cli: &mut Connection, text: &str)
     -> Result<R, Error>
     where R: Queryable
 {
-    let text = text.as_ref();
+    let text = text;
     log::debug!(target: "edgedb::migrations::query", "Executing `{}`", text);
     cli.query_required_single(text, &()).await
 }

--- a/src/migrations/edb.rs
+++ b/src/migrations/edb.rs
@@ -36,7 +36,6 @@ pub async fn query_row<R>(cli: &mut Connection, text: &str)
     -> Result<R, Error>
     where R: Queryable
 {
-    let text = text;
     log::debug!(target: "edgedb::migrations::query", "Executing `{}`", text);
     cli.query_required_single(text, &()).await
 }

--- a/src/migrations/edit.rs
+++ b/src/migrations/edit.rs
@@ -44,23 +44,23 @@ fn print_diff(path1: &Path, data1: &str, path2: &Path, data2: &str) {
     println!("--- {}", path1.display());
     println!("+++ {}", path2.display());
     let changeset = diff(data1, data2);
-    let n1 = data1.split("\n").count();
-    let n2 = data2.split("\n").count();
+    let n1 = data1.split('\n').count();
+    let n2 = data2.split('\n').count();
     println!("@@ -1,{} +1,{}", n1, n2);
     for item in &changeset {
         match item {
             Chunk::Equal(block) => {
-                for line in block.split("\n") {
+                for line in block.split('\n') {
                     println!(" {}", line);
                 }
             }
             Chunk::Insert(block) => {
-                for line in block.split("\n") {
+                for line in block.split('\n') {
                     println!("+{}", line.added());
                 }
             }
             Chunk::Delete(block) => {
-                for line in block.split("\n") {
+                for line in block.split('\n') {
                     println!("-{}", line.deleted());
                 }
             }
@@ -108,9 +108,9 @@ async fn check_migration(cli: &mut Connection, text: &str, path: &Path)
     -> anyhow::Result<()>
 {
     cli.execute("START TRANSACTION", &()).await?;
-    let res = cli.execute(&text, &()).await.map_err(|err| {
+    let res = cli.execute(text, &()).await.map_err(|err| {
         let fname = path.display().to_string();
-        match print_query_error(&err, &text, false, &fname) {
+        match print_query_error(&err, text, false, &fname) {
             Ok(()) => err.into(),
             Err(err) => err,
         }
@@ -118,7 +118,7 @@ async fn check_migration(cli: &mut Connection, text: &str, path: &Path)
     cli.execute("ROLLBACK", &()).await
         .map_err(|e| log::warn!("Error rolling back the transaction: {:#}", e))
         .ok();
-    return res.map(|_| ());
+    res.map(|_| ())
 }
 
 pub async fn edit(cli: &mut Connection,
@@ -128,7 +128,7 @@ pub async fn edit(cli: &mut Connection,
     let old_state = cli.set_ignore_error_state();
     let res = _edit(cli, common, options).await;
     cli.restore_state(old_state);
-    return res;
+    res
 }
 
 async fn _edit(cli: &mut Connection,
@@ -309,9 +309,9 @@ fn default() {
             CREATE TYPE X;
         };
     ";
-    let migration = parse_migration(&original).unwrap();
-    let new_id = migration.expected_id(&original).unwrap();
-    assert_eq!(migration.replace_id(&original, &new_id), "
+    let migration = parse_migration(original).unwrap();
+    let new_id = migration.expected_id(original).unwrap();
+    assert_eq!(migration.replace_id(original, &new_id), "
         CREATE MIGRATION m1uaw5ik4wg4w33jj35sjgdgg3pai23ysqy5pi7xmxqnd3gtneb57q
         ONTO m1e5vq3h4oizlsp4a3zge5bqhu7yeoorc27k3yo2aaenfqgfars6uq
         {
@@ -329,9 +329,9 @@ fn space() {
             CREATE TYPE X;
         };
     ";
-    let migration = parse_migration(&original).unwrap();
-    let new_id = migration.expected_id(&original).unwrap();
-    assert_eq!(migration.replace_id(&original, &new_id), "
+    let migration = parse_migration(original).unwrap();
+    let new_id = migration.expected_id(original).unwrap();
+    assert_eq!(migration.replace_id(original, &new_id), "
         CREATE MIGRATION \
             m1uaw5ik4wg4w33jj35sjgdgg3pai23ysqy5pi7xmxqnd3gtneb57q \
             ONTO m1e5vq3h4oizlsp4a3zge5bqhu7yeoorc27k3yo2aaenfqgfars6uq

--- a/src/migrations/extract.rs
+++ b/src/migrations/extract.rs
@@ -35,7 +35,7 @@ impl MigrationToText for DatabaseMigration {
         Ok(&self.migration.name)
     }
 
-    fn statements<'a>(&'a self) -> Self::StatementsIter<'a> {
+    fn statements(&self) -> Self::StatementsIter<'_> {
         std::iter::once(&self.migration.script)
     }
 }

--- a/src/migrations/grammar.rs
+++ b/src/migrations/grammar.rs
@@ -48,7 +48,7 @@ pub fn ident<'s>(value: &'static str)
 
 pub fn kind<'x>(kind: Kind) -> TokenMatch<'x> {
     TokenMatch {
-        kind: kind,
+        kind,
         phantom: PhantomData,
     }
 }
@@ -215,7 +215,7 @@ fn migration<'a>()
             match item {
                 SetMessage(text) => {
                     if m.message.is_some() {
-                        return Err(Error::Message(
+                        Err(Error::Message(
                             "duplicate `SET message` statement".into()))?;
                     }
                     m.message = Some(text);

--- a/src/migrations/log.rs
+++ b/src/migrations/log.rs
@@ -10,7 +10,7 @@ pub async fn log(cli: &mut Connection,
     -> Result<(), anyhow::Error>
 {
     if options.from_fs {
-        return log_fs_async(common, options).await;
+        log_fs_async(common, options).await
     } else if options.from_db {
         return log_db(cli, common, options).await;
     } else {
@@ -25,7 +25,7 @@ pub async fn log_db(cli: &mut Connection, common: &Options,
     let old_state = cli.set_ignore_error_state();
     let res = _log_db(cli, common, options).await;
     cli.restore_state(old_state);
-    return res;
+    res
 }
 
 async fn _log_db(cli: &mut Connection, _common: &Options,

--- a/src/migrations/merge.rs
+++ b/src/migrations/merge.rs
@@ -50,7 +50,7 @@ impl MigrationToText for MergeMigration {
         Ok(self.migration.name.as_str())
     }
 
-    fn statements<'a>(&'a self) -> Self::StatementsIter<'a> {
+    fn statements(&self) -> Self::StatementsIter<'_> {
         std::iter::once(&self.migration.script)
     }
 }
@@ -82,7 +82,7 @@ pub async fn get_merge_migrations(base: &mut Connection, target: &mut Connection
         }
     }
 
-    if diverging_migrations.len() > 0 {
+    if !diverging_migrations.is_empty() {
         eprintln!("\nThe migration history of {} diverges from {}:", target.database(), base.database());
 
         for (index, expecting, actual) in &diverging_migrations {

--- a/src/migrations/migrate.rs
+++ b/src/migrations/migrate.rs
@@ -565,7 +565,7 @@ mod test {
             match (other, self) {
                 (Fixup(a), E::Fixup(b))
                 if Some(*a) == b.fixup_target.as_deref() => true,
-                (Normal(a), E::Normal(b)) if a == &&b.data.id => true,
+                (Normal(a), E::Normal(b)) if a == &b.data.id => true,
                 _ => false,
             }
         }
@@ -577,7 +577,7 @@ mod test {
             match (self, other) {
                 (Fixup(a), E::Fixup(b))
                 if Some(*a) == b.fixup_target.as_deref() => true,
-                (Normal(a), E::Normal(b)) if a == &&b.data.id => true,
+                (Normal(a), E::Normal(b)) if a == &b.data.id => true,
                 _ => false,
             }
         }

--- a/src/migrations/migration.rs
+++ b/src/migrations/migration.rs
@@ -42,7 +42,7 @@ pub enum SortKey<'a> {
 pub fn hashing_error(_source: &str, e: hash::Error) -> anyhow::Error {
     match e {
         hash::Error::Tokenizer(msg, pos) => {
-            return anyhow::anyhow!("Tokenizer error at {}: {}", pos, msg);
+            anyhow::anyhow!("Tokenizer error at {}: {}", pos, msg)
         }
     }
 }
@@ -60,7 +60,7 @@ impl Migration {
         s.push_str(&text[..self.id_range.0]);
         s.push_str(new_id);
         s.push_str(&text[self.id_range.1..]);
-        return s;
+        s
     }
 
     pub fn replace_parent_id(&self, text: &str, new_id: &str) -> String {
@@ -68,7 +68,7 @@ impl Migration {
         s.push_str(&text[..self.parent_id_range.0]);
         s.push_str(new_id);
         s.push_str(&text[self.parent_id_range.1..]);
-        return s;
+        s
     }
 }
 
@@ -127,7 +127,7 @@ async fn _read_names(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
     while let Some(item) = dir.next_entry().await? {
         let fname = item.file_name();
         let lossy_name = fname.to_string_lossy();
-        if lossy_name.starts_with(".") || !lossy_name.ends_with(".edgeql")
+        if lossy_name.starts_with('.') || !lossy_name.ends_with(".edgeql")
             || !item.file_type().await?.is_file()
         {
             continue;
@@ -154,7 +154,7 @@ pub fn file_num(path: &Path) -> Option<u64> {
             return spl[0].parse().ok();
         }
 
-        return x.parse().ok();
+        x.parse().ok()
     })
 }
 
@@ -243,7 +243,7 @@ async fn _read_fixups(dir: &Path, validate_hashes: bool)
         let data = read_file(&path, validate_hashes).await?;
         let fixup_target = path.file_stem()
             .and_then(|s| s.to_str())
-            .and_then(|s| s.split("-").skip(1).next());
+            .and_then(|s| s.split('-').nth(1));
         let Some(fixup_target) = fixup_target else {
             log::warn!("Invalid fixup file name {:?}", path);
             continue;

--- a/src/migrations/options.rs
+++ b/src/migrations/options.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{ValueHint};
+use clap::ValueHint;
 
 use crate::options::ConnectionOptions;
 use crate::portable::repository::Channel;
@@ -23,7 +23,7 @@ pub struct Migration {
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum MigrationCmd {
     /// Apply migration from latest migration script.
-    Apply(Migrate),
+    Apply(Box<Migrate>),
     /// Create migration script inside /migrations.
     Create(CreateMigration),
     /// Show current migration status.

--- a/src/migrations/print_error.rs
+++ b/src/migrations/print_error.rs
@@ -22,7 +22,7 @@ fn end_of_last_token(data: &str) -> Option<u64> {
     for tok in &mut tokenizer {
         off = tok.ok()?.span.end;
     }
-    return Some(off);
+    Some(off)
 }
 
 fn get_error_info<'x>(err: &Error, source_map: &'x SourceMap<SourceName>)
@@ -33,17 +33,17 @@ fn get_error_info<'x>(err: &Error, source_map: &'x SourceMap<SourceName>)
     let (src, offset) = source_map.translate_range(pstart, pend).ok()?;
     let res = match src {
         SourceName::File(path) => {
-            let data = fs::read_to_string(&path).ok()?;
+            let data = fs::read_to_string(path).ok()?;
             (path.as_ref(), data, pstart - offset, pend - offset, false)
         }
         SourceName::Semicolon(path) => {
-            let data = fs::read_to_string(&path).ok()?;
+            let data = fs::read_to_string(path).ok()?;
             let tok_offset = end_of_last_token(&data)? as usize;
             (path.as_ref(), data, tok_offset, tok_offset, true)
         }
         _ => return None,
     };
-    return Some(res);
+    Some(res)
 }
 
 pub fn print_migration_error(err: &Error, source_map: &SourceMap<SourceName>)
@@ -61,7 +61,7 @@ pub fn print_migration_error(err: &Error, source_map: &SourceMap<SourceName>)
     let message = if eof {
         "Unexpected end of file"
     } else {
-        &err.initial_message().unwrap_or(err.kind_name())
+        err.initial_message().unwrap_or(err.kind_name())
     };
     let hint = err.hint().unwrap_or("error");
     let detail = err.details().map(|s| s.into());

--- a/src/migrations/print_error.rs
+++ b/src/migrations/print_error.rs
@@ -1,11 +1,10 @@
-use std::default::Default;
 use std::fs;
 use std::path::Path;
 use std::str;
 
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::diagnostic::{Diagnostic, Label, LabelStyle};
-use codespan_reporting::term::{emit};
+use codespan_reporting::term::emit;
 use termcolor::{StandardStream, ColorChoice};
 
 use edgedb_errors::{Error, InternalServerError};

--- a/src/migrations/prompt.rs
+++ b/src/migrations/prompt.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use anyhow::Context as _;
 use colorful::Colorful;
-use rustyline::{self, error::ReadlineError, KeyEvent, Modifiers, Cmd};
+use rustyline::{error::ReadlineError, KeyEvent, Modifiers, Cmd};
 use rustyline::{Editor, Config, Helper};
 use rustyline::config::EditMode;
 use rustyline::hint::Hinter;

--- a/src/migrations/prompt.rs
+++ b/src/migrations/prompt.rs
@@ -29,22 +29,22 @@ impl Highlighter for ExpressionHelper {
         -> Cow<'b, str>
     {
         if info.line_no() > 0 {
-            return format!("{0:.>1$}", " ", prompt.len()).into();
+            format!("{0:.>1$}", " ", prompt.len()).into()
         } else {
-            return prompt.into();
+            prompt.into()
         }
     }
     fn highlight<'l>(&self, line: &'l str, _pos: usize) -> Cow<'l, str> {
         let mut buf = String::with_capacity(line.len() + 8);
         highlight::edgeql(&mut buf, line, &self.styler);
-        return buf.into();
+        buf.into()
     }
-    fn highlight_char<'l>(&self, _line: &'l str, _pos: usize) -> bool {
+    fn highlight_char(&self, _line: &str, _pos: usize) -> bool {
         // TODO(tailhook) optimize: only need to return true on insert
         true
     }
     fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
-        return hint.light_gray().to_string().into()
+        hint.light_gray().to_string().into()
     }
     fn has_continuation_prompt(&self) -> bool {
         true
@@ -86,7 +86,7 @@ pub fn expression(prompt: &str, history_name: &str, default: &str)
     editor.set_helper(Some(ExpressionHelper {
         styler: Styler::dark_256(),
     }));
-    let text = editor.readline_with_initial(&prompt, (default, ""))
+    let text = editor.readline_with_initial(prompt, (default, ""))
         .context("readline error")?;
     editor.add_history_entry(&text);
     save_history(&mut editor, &history_name);

--- a/src/migrations/rebase.rs
+++ b/src/migrations/rebase.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use fs_err as fs;
 
 
-use anyhow::{Context as _};
+use anyhow::Context as _;
 use colorful::Colorful;
 use indexmap::IndexMap;
 use crate::connect::Connection;
@@ -185,9 +185,9 @@ pub async fn get_diverging_migrations(source: &mut Connection, target: &mut Conn
 }
 
 async fn rebase_migration_ids(context: &Context, rebase_migrations: &mut RebaseMigrations) -> anyhow::Result<()> {
-    fn update_id(old: &String, new: &String, col: &mut IndexMap<String, DBMigration>) {
+    fn update_id(old: &str, new: &str, col: &mut IndexMap<String, DBMigration>) {
         if let Some(value) = col.remove(old) {
-            col.insert(new.clone(), value);
+            col.insert(new.to_string(), value);
         }
     }
 

--- a/src/migrations/rebase.rs
+++ b/src/migrations/rebase.rs
@@ -50,7 +50,7 @@ impl MigrationToText for RebaseMigration<'_> {
         Ok(&self.migration.name)
     }
 
-    fn statements<'a>(&'a self) -> Self::StatementsIter<'a> {
+    fn statements(&self) -> Self::StatementsIter<'_> {
         std::iter::once(&self.migration.script)
     }
 }
@@ -99,7 +99,7 @@ impl RebaseMigrations {
             });
         }
 
-        if self.target_migrations.len() > 0 {
+        if !self.target_migrations.is_empty() {
             let (_, first_migration) = self.target_migrations.first().unwrap();
             let source_last = result.last();
 
@@ -120,7 +120,7 @@ impl RebaseMigrations {
             }
         }
 
-        if self.source_migrations.len() > 0 {
+        if !self.source_migrations.is_empty() {
             let (_, first_migration) = self.source_migrations.first().unwrap();
             let base_last = result.last();
 

--- a/src/migrations/source_map.rs
+++ b/src/migrations/source_map.rs
@@ -57,7 +57,7 @@ impl<N> SourceMap<N> {
                 return Ok((&slice.name, slice.byte_offset));
             }
         }
-        return Err(())
+        Err(())
     }
 }
 

--- a/src/migrations/status.rs
+++ b/src/migrations/status.rs
@@ -84,7 +84,7 @@ pub async fn migrations_applied(cli: &mut Connection, ctx: &Context,
     if db_migration.as_ref() != migrations.keys().last() {
         if !ctx.quiet {
             if let Some(db_migration) = &db_migration {
-                if let Some(_) = migrations.get(db_migration) {
+                if migrations.get(db_migration).is_some() {
                     let mut iter = migrations.keys()
                         .skip_while(|k| k != &db_migration);
                     iter.next(); // skip db_migration itself

--- a/src/migrations/upgrade_format.rs
+++ b/src/migrations/upgrade_format.rs
@@ -27,11 +27,11 @@ async fn _upgrade_format(context: &Context) -> anyhow::Result<()> {
     for name in names {
         let fname = name.file_stem().unwrap().to_str().unwrap();
 
-        if let Some(_) = old_filename.captures(fname) {
+        if old_filename.captures(fname).is_some() {
             // migrate to new filename
             eprintln!("Upgrading migration file layout for {}.edgeql...", fname);
             upgrade_format_of_file(&name, file_num(&name).unwrap()).await?;
-        } else if let Some(_) = new_filename.captures(fname) {
+        } else if new_filename.captures(fname).is_some() {
             println!("Migration {} OK", fname)
         } else {
             print::warn(format!("Unknown migration file naming schema: {fname}", ))

--- a/src/non_interactive.rs
+++ b/src/non_interactive.rs
@@ -63,7 +63,7 @@ pub async fn noninteractive_main(q: &Query, options: &Options)
                 anyhow::bail!("Analyze queries are not allowed. \
                                Use the dedicated `edgedb analyze` command.");
             }
-            run_query(&mut conn, query, &options, fmt).await?;
+            run_query(&mut conn, query, options, fmt).await?;
         }
     } else {
         print::error("either a --file option or \
@@ -101,7 +101,7 @@ async fn interpret_file<T>(file: &mut T, options: &Options, fmt: OutputFormat)
             anyhow::bail!("Analyze queries are not allowed. \
                            Use the dedicated `edgedb analyze` command.");
         }
-        run_query(&mut conn, &stmt, &options, fmt).await?;
+        run_query(&mut conn, stmt, options, fmt).await?;
     }
     Ok(())
 }
@@ -112,7 +112,7 @@ async fn run_query(conn: &mut Connection, stmt: &str, options: &Options,
 {
     _run_query(conn, stmt, options, fmt).await.map_err(|err| {
         if let Some(err) = err.downcast_ref::<edgedb_errors::Error>() {
-            match print_query_error(&err, stmt, false, "<query>") {
+            match print_query_error(err, stmt, false, "<query>") {
                 Ok(()) => ExitCode::new(1).into(),
                 Err(e) => e,
             }

--- a/src/non_interactive.rs
+++ b/src/non_interactive.rs
@@ -1,16 +1,16 @@
 use std::str;
 use std::io::{stdout, Write};
 
-use anyhow::{self, Context};
-use bytes::{BytesMut};
+use anyhow::Context;
+use bytes::BytesMut;
 use is_terminal::IsTerminal;
 use terminal_size::{Width, terminal_size};
-use tokio::fs::{File as AsyncFile};
+use tokio::fs::File as AsyncFile;
 use tokio::io::{AsyncRead, stdin};
 
-use edgedb_protocol::client_message::{CompilationOptions};
+use edgedb_protocol::client_message::CompilationOptions;
 use edgedb_protocol::client_message::{IoFormat, Cardinality};
-use edgedb_protocol::common::{Capabilities};
+use edgedb_protocol::common::Capabilities;
 use edgedb_protocol::value::Value;
 use edgeql_parser::preparser;
 use tokio_stream::StreamExt;

--- a/src/options.rs
+++ b/src/options.rs
@@ -362,7 +362,7 @@ pub enum Command {
     _GenCompletions(cli::install::GenCompletions),
     /// Self-installation commands
     #[command(name="cli")]
-    CliCommand(CliCommand),
+    Cli(CliCommand),
     /// Install EdgeDB
     #[command(name="_self_install")]
     #[command(hide=true)]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -68,11 +68,11 @@ pub fn tmp_file_name(path: &Path) -> OsString {
 }
 
 pub fn tmp_file_path(path: &Path) -> PathBuf {
-    path.parent().unwrap_or(&Path::new(".")).join(tmp_file_name(path))
+    path.parent().unwrap_or(Path::new(".")).join(tmp_file_name(path))
 }
 
 #[cfg(unix)]
-pub fn path_bytes<'x>(path: &'x Path) -> anyhow::Result<&'x [u8]> {
+pub fn path_bytes(path: &Path) -> anyhow::Result<&[u8]> {
     use std::os::unix::ffi::OsStrExt;
     return Ok(path.as_os_str().as_bytes())
 }
@@ -86,7 +86,7 @@ pub fn path_bytes<'x>(path: &'x Path) -> anyhow::Result<&'x [u8]> {
 }
 
 #[cfg(unix)]
-pub fn bytes_to_path<'x>(path: &'x [u8]) -> anyhow::Result<&'x Path> {
+pub fn bytes_to_path(path: &[u8]) -> anyhow::Result<&Path> {
     use std::os::unix::ffi::OsStrExt;
     use std::ffi::OsStr;
 
@@ -190,10 +190,10 @@ pub async fn spawn_editor(path: &Path) -> anyhow::Result<()> {
     let mut items = editor.split_whitespace();
     let mut cmd = tokio::process::Command::new(items.next().unwrap());
     cmd.args(items);
-    cmd.arg(&path);
+    cmd.arg(path);
     let res = cmd.status().await?;
     if res.success() {
-        return Ok(());
+        Ok(())
     } else {
         Err(anyhow::anyhow!("editor exited with: {}", res))
     }

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -62,18 +62,18 @@ pub fn warn_extra(extra: &BTreeMap<String, toml::Value>, prefix: &str) {
 }
 
 pub fn format_config(version: &Query) -> String {
-    return format!(
+    format!(
         "\
         [edgedb]\n\
         server-version = {:?}\n\
     ",
         version.as_config_value()
-    );
+    )
 }
 
 #[context("error reading project config `{}`", path.display())]
 pub fn read(path: &Path) -> anyhow::Result<Config> {
-    let text = fs::read_to_string(&path)?;
+    let text = fs::read_to_string(path)?;
     let mut toml = toml::de::Deserializer::new(&text);
     let val: SrcConfig = serde_path_to_error::deserialize(&mut toml)?;
     warn_extra(&val.extra, "");
@@ -93,10 +93,9 @@ pub fn read(path: &Path) -> anyhow::Result<Config> {
         project: Project {
             schema_dir: val
                 .project
-                .map(|p| p.schema_dir)
-                .flatten()
+                .and_then(|p| p.schema_dir)
                 .map(|s| s.into())
-                .unwrap_or_else(|| path.parent().unwrap_or(&Path::new("")).join("dbschema")),
+                .unwrap_or_else(|| path.parent().unwrap_or(Path::new("")).join("dbschema")),
         },
     });
 }
@@ -153,7 +152,7 @@ where
     Val: std::cmp::PartialEq,
     ToStr: FnOnce(&Val) -> String,
 {
-    let input = fs::read_to_string(&path)?;
+    let input = fs::read_to_string(path)?;
     let mut deserializer = toml::de::Deserializer::new(&input);
     let parsed: Cfg = serde_path_to_error::deserialize(&mut deserializer)?;
 
@@ -277,7 +276,7 @@ mod test {
     ";
 
     fn set_toml_version(data: &str, version: &super::Query) -> anyhow::Result<Option<String>> {
-        let mut toml = toml::de::Deserializer::new(&data);
+        let mut toml = toml::de::Deserializer::new(data);
         let parsed: super::SrcConfig = serde_path_to_error::deserialize(&mut toml)?;
 
         super::modify_config(

--- a/src/portable/control.rs
+++ b/src/portable/control.rs
@@ -39,7 +39,7 @@ fn daemon_start(instance: &str) -> anyhow::Result<()> {
             log::info!("Instance {:?} is already running", instance);
             return Ok(())
         }
-        process::Native::new("edgedb cli", "edgedb-cli", &current_exe()?)
+        process::Native::new("edgedb cli", "edgedb-cli", current_exe()?)
             .arg("instance")
             .arg("start")
             .arg("-I").arg(instance)
@@ -140,7 +140,7 @@ fn run_server_by_cli(meta: &InstanceInfo) -> anyhow::Result<()> {
     let pid_path = pid_file_path(&meta.name)?;
     let log_path = log_file(&meta.name)?;
     if let Some(dir) = log_path.parent() {
-        fs_err::create_dir_all(&dir)?;
+        fs_err::create_dir_all(dir)?;
     }
     let log_file = fs_err::OpenOptions::new()
         .create(true).write(true).append(true)
@@ -152,7 +152,7 @@ fn run_server_by_cli(meta: &InstanceInfo) -> anyhow::Result<()> {
     } if let Some(dir) = notify_socket.parent() {
         fs_err::create_dir_all(dir)?;
     }
-    get_server_cmd(&meta, false)?
+    get_server_cmd(meta, false)?
         .env("NOTIFY_SOCKET", &notify_socket)
         .pid_file(&pid_path)
         .log_file(&log_path)?
@@ -186,7 +186,8 @@ fn run_server_by_cli(meta: &InstanceInfo) -> anyhow::Result<()> {
                 }
                 drop(null);
 
-                Ok(pending::<()>().await)
+                pending::<()>().await;
+                Ok(())
             })
         })
 }
@@ -234,7 +235,7 @@ pub fn start(options: &Start) -> anyhow::Result<()> {
         let mut needs_restart = false;
         let try_write = lock.try_write();
         let lock = if let Ok(mut lock) = try_write {
-            write_lock_info(&lock_path, &mut *lock, &options.managed_by)?;
+            write_lock_info(&lock_path, &mut lock, &options.managed_by)?;
             lock
         } else {
             drop(try_write);
@@ -258,7 +259,7 @@ pub fn start(options: &Start) -> anyhow::Result<()> {
                     locked_by.escape_default());
             }
             let mut lock = lock.write()?;
-            write_lock_info(&lock_path, &mut *lock, &options.managed_by)?;
+            write_lock_info(&lock_path, &mut lock, &options.managed_by)?;
             lock
         };
         if matches!(options.managed_by.as_deref(), Some("edgedb-cli")) {
@@ -340,8 +341,8 @@ pub fn read_pid(instance: &str) -> anyhow::Result<Option<u32>> {
             Ok(None)
         }
         Err(e) => {
-            return Err(e)
-                .context(format!("cannot read pid file {:?}", pid_path))?;
+            Err(e)
+                .context(format!("cannot read pid file {:?}", pid_path))?
         }
     }
 }
@@ -365,17 +366,15 @@ pub fn do_stop(name: &str) -> anyhow::Result<()> {
     if lock.try_read().is_err() {  // properly running
         if supervisor && is_run_by_supervisor(lock) {
             supervisor_stop(name)
+        } else if let Some(pid) = read_pid(name)? {
+            log::info!("Stopping EdgeDB with pid {}", pid);
+            process::term(pid)?;
+            // wait for unlock
+            let _ = open_lock(name)?
+                .read().context("cannot acquire read lock")?;
+            Ok(())
         } else {
-            if let Some(pid) = read_pid(name)? {
-                log::info!("Stopping EdgeDB with pid {}", pid);
-                process::term(pid)?;
-                // wait for unlock
-                let _ = open_lock(name)?
-                    .read().context("cannot acquire read lock")?;
-                Ok(())
-            } else {
-                return Err(bug::error("cannot find pid"));
-            }
+            Err(bug::error("cannot find pid"))
         }
     } else {  // probably not running
         if supervisor {
@@ -412,11 +411,11 @@ pub fn stop(options: &Stop) -> anyhow::Result<()> {
 
 fn supervisor_stop_and_disable(instance: &str) -> anyhow::Result<bool> {
     if cfg!(target_os="macos") {
-        macos::stop_and_disable(&instance)
+        macos::stop_and_disable(instance)
     } else if cfg!(target_os="linux") {
-        linux::stop_and_disable(&instance)
+        linux::stop_and_disable(instance)
     } else if cfg!(windows) {
-        windows::stop_and_disable(&instance)
+        windows::stop_and_disable(instance)
     } else {
         anyhow::bail!("service is not supported on the platform");
     }

--- a/src/portable/control.rs
+++ b/src/portable/control.rs
@@ -108,7 +108,7 @@ fn write_lock_info(path: &Path, lock: &mut fs::File,
     use std::io::Write;
 
     lock.set_len(0)?;
-    lock.write(marker.as_ref().map(|x| &x[..]).unwrap_or("user").as_bytes())?;
+    lock.write_all(marker.as_ref().map(|x| &x[..]).unwrap_or("user").as_bytes())?;
     Ok(())
 }
 
@@ -149,7 +149,8 @@ fn run_server_by_cli(meta: &InstanceInfo) -> anyhow::Result<()> {
     let notify_socket = runstate_dir(&meta.name)?.join(".s.daemon");
     if notify_socket.exists() {
         fs_err::remove_file(&notify_socket)?;
-    } if let Some(dir) = notify_socket.parent() {
+    }
+    if let Some(dir) = notify_socket.parent() {
         fs_err::create_dir_all(dir)?;
     }
     get_server_cmd(meta, false)?

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -401,7 +401,7 @@ fn bootstrap_script(user: &str, password: &str) -> String {
 }
 
 #[context("cannot bootstrap EdgeDB instance")]
-pub fn bootstrap(paths: &Paths, info: &InstanceInfo, user: &str, database: &String)
+pub fn bootstrap(paths: &Paths, info: &InstanceInfo, user: &str, database: &str)
     -> anyhow::Result<()>
 {
     let server_path = info.server_path()?;

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -71,7 +71,7 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
         print::error(
             "`edgedb instance create` is not supported in Docker containers.",
         );
-        return Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
+        Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
     }
     if cmd.start_conf.is_some() {
         print::warn("The option `--start-conf` is deprecated. \
@@ -101,21 +101,21 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
     let cp = &cmd.cloud_params;
 
     if cp.region.is_some() {
-        return Err(opts.error(
+        Err(opts.error(
             clap::error::ErrorKind::ArgumentConflict,
             cformat!("The <bold>--region</bold> option is only applicable to cloud instances."),
         ))?;
     }
 
     if cp.billables.compute_size.is_some() {
-        return Err(opts.error(
+        Err(opts.error(
             clap::error::ErrorKind::ArgumentConflict,
             cformat!("The <bold>--compute-size</bold> option is only applicable to cloud instances."),
         ))?;
     }
 
     if cp.billables.storage_size.is_some() {
-        return Err(opts.error(
+        Err(opts.error(
             clap::error::ErrorKind::ArgumentConflict,
             cformat!("The <bold>--storage-size</bold> option is only applicable to cloud instances."),
         ))?;
@@ -210,7 +210,7 @@ fn create_cloud(
     let cp = &cmd.cloud_params;
 
     let region = match &cp.region {
-        None => cloud::ops::get_current_region(&client)?.name,
+        None => cloud::ops::get_current_region(client)?.name,
         Some(region) => region.to_string(),
     };
 
@@ -242,14 +242,14 @@ fn create_cloud(
 
     if tier == cloud::ops::CloudTier::Free {
         if compute_size.is_some() {
-            return Err(opts.error(
+            Err(opts.error(
                 clap::error::ErrorKind::ArgumentConflict,
                 cformat!("The <bold>--compute-size</bold> option can \
                 only be specified for Pro instances."),
             ))?;
         }
         if storage_size.is_some() {
-            return Err(opts.error(
+            Err(opts.error(
                 clap::error::ErrorKind::ArgumentConflict,
                 cformat!("The <bold>--storage-size</bold> option can \
                 only be specified for Pro instances."),
@@ -262,13 +262,13 @@ fn create_cloud(
         .context(format!("could not download pricing information for the {} tier", tier))?;
     let region_prices = tier_prices.get(&region)
         .context(format!("could not download pricing information for the {} region", region))?;
-    let default_compute = region_prices.into_iter()
+    let default_compute = region_prices.iter()
         .find(|&price| price.billable == "compute")
         .context("could not download pricing information for compute")?
         .units_default.clone()
         .context("could not find default value for compute")?;
 
-    let default_storage = region_prices.into_iter()
+    let default_storage = region_prices.iter()
         .find(|&price| price.billable == "storage")
         .context("could not download pricing information for storage")?
         .units_default.clone()
@@ -327,7 +327,7 @@ fn create_cloud(
 
     let source_instance_id = match &cmd.cloud_backup_source.from_instance {
         Some(InstanceName::Cloud{org_slug: org, name}) => {
-            match cloud::ops::find_cloud_instance_by_name(&name, &org, client) {
+            match cloud::ops::find_cloud_instance_by_name(name, org, client) {
                 Ok(Some(instance)) => {
                     Ok(Some(instance.id))
                 },
@@ -360,10 +360,10 @@ fn create_cloud(
         region: Some(region),
         requested_resources: Some(req_resources),
         tier: Some(tier),
-        source_instance_id: source_instance_id,
+        source_instance_id,
         source_backup_id: cmd.cloud_backup_source.from_backup_id.clone(),
     };
-    cloud::ops::create_cloud_instance(&client, &request)?;
+    cloud::ops::create_cloud_instance(client, &request)?;
     echo!(
         "EdgeDB Cloud instance",
         inst_name,
@@ -371,7 +371,7 @@ fn create_cloud(
     );
     echo!("To connect to the instance run:");
     echo!("  edgedb -I", inst_name);
-    return Ok(())
+    Ok(())
 }
 
 fn bootstrap_script(user: &str, password: &str) -> String {
@@ -385,7 +385,7 @@ fn bootstrap_script(user: &str, password: &str) -> String {
                 SET password_hash := {password_hash};
             }};
             "###,
-            name=quote_name(&user),
+            name=quote_name(user),
             password_hash=quote_string(&password_hash(password)),
         ).unwrap();
     } else {
@@ -393,11 +393,11 @@ fn bootstrap_script(user: &str, password: &str) -> String {
             CREATE SUPERUSER ROLE {name} {{
                 SET password_hash := {password_hash};
             }}"###,
-            name=quote_name(&user),
+            name=quote_name(user),
             password_hash=quote_string(&password_hash(password)),
         ).unwrap();
     }
-    return output;
+    output
 }
 
 #[context("cannot bootstrap EdgeDB instance")]
@@ -440,7 +440,7 @@ pub fn bootstrap(paths: &Paths, info: &InstanceInfo, user: &str, database: &Stri
     creds.port = info.port;
     creds.user = user.into();
     creds.database = Some(database.clone());
-    creds.password = Some(password.into());
+    creds.password = Some(password);
     creds.tls_ca = Some(cert);
     credentials::write(&paths.credentials, &creds)?;
 
@@ -450,7 +450,7 @@ pub fn bootstrap(paths: &Paths, info: &InstanceInfo, user: &str, database: &Stri
 pub fn create_service(meta: &InstanceInfo) -> anyhow::Result<()>
 {
     if cfg!(target_os="macos") {
-        macos::create_service(&meta)
+        macos::create_service(meta)
     } else if cfg!(target_os="linux") {
         if windows::is_wrapped() {
             // No service. Managed by windows.
@@ -460,10 +460,10 @@ pub fn create_service(meta: &InstanceInfo) -> anyhow::Result<()>
             // function is called.
             Ok(())
         } else {
-            linux::create_service(&meta)
+            linux::create_service(meta)
         }
     } else if cfg!(windows) {
-        windows::create_service(&meta)
+        windows::create_service(meta)
     } else {
         anyhow::bail!("creating a service is not supported on the platform");
     }

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -439,7 +439,7 @@ pub fn bootstrap(paths: &Paths, info: &InstanceInfo, user: &str, database: &str)
     let mut creds = Credentials::default();
     creds.port = info.port;
     creds.user = user.into();
-    creds.database = Some(database.clone());
+    creds.database = Some(database.to_string());
     creds.password = Some(password);
     creds.tls_ca = Some(cert);
     credentials::write(&paths.credentials, &creds)?;

--- a/src/portable/destroy.rs
+++ b/src/portable/destroy.rs
@@ -30,10 +30,10 @@ pub fn with_projects(name: &str, force: bool,
                      f: impl FnOnce() -> anyhow::Result<()>)
     -> anyhow::Result<()>
 {
-    let project_dirs = project::find_project_dirs_by_instance(&name)?;
+    let project_dirs = project::find_project_dirs_by_instance(name)?;
     if !force && !project_dirs.is_empty() {
-        warn(&name, &project_dirs);
-        return Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
+        warn(name, &project_dirs);
+        Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
     }
     f()?;
     for dir in project_dirs {
@@ -148,7 +148,7 @@ fn do_destroy(
         InstanceName::Cloud { org_slug, name: inst_name } => {
             log::info!("Removing cloud instance {}", name);
             if let Err(e) = crate::cloud::ops::destroy_cloud_instance(
-                &inst_name, &org_slug, &opts.cloud_options
+                inst_name, org_slug, &opts.cloud_options
             ) {
                 let msg = format!("Could not destroy EdgeDB Cloud instance: {:#}", e);
                 if options.force {

--- a/src/portable/info.rs
+++ b/src/portable/info.rs
@@ -34,7 +34,7 @@ pub fn info(options: &Info) -> anyhow::Result<()> {
         .context("cannot find installed packages maching your criteria")?;
 
     let item = options.get.as_deref()
-        .or(options.bin_path.then(|| "bin-path"));
+        .or(options.bin_path.then_some("bin-path"));
     if let Some(item) = item {
         match item {
             "bin-path" => {

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -6,9 +6,9 @@ use std::sync::{Mutex, Arc};
 
 use anyhow::Context;
 use colorful::Colorful;
-use pem;
+
 use ring::digest;
-use rustls;
+
 use rustls::client::WebPkiServerVerifier;
 use rustls::client::danger::{ServerCertVerifier, ServerCertVerified};
 use rustls::client::danger::HandshakeSignatureValid;
@@ -86,7 +86,7 @@ impl ServerCertVerifier for InteractiveCertVerifier {
                 // Acquire consensus to trust the root of presented_certs chain
                 let fingerprint = digest::digest(
                     &digest::SHA1_FOR_LEGACY_USE_ONLY,
-                    &end_entity,
+                    end_entity,
                 );
                 if self.trust_tls_cert {
                     if !self.quiet {
@@ -97,19 +97,17 @@ impl ServerCertVerifier for InteractiveCertVerifier {
                     }
                 } else if self.non_interactive {
                     return Err(e);
-                } else {
-                    if let Ok(answer) = question::Confirm::new(
-                        format!(
-                            "Unknown server certificate: {:?}. Trust?",
-                            fingerprint,
-                        )
-                    ).default(false).ask() {
-                        if !answer {
-                            return Err(e);
-                        }
-                    } else {
+                } else if let Ok(answer) = question::Confirm::new(
+                    format!(
+                        "Unknown server certificate: {:?}. Trust?",
+                        fingerprint,
+                    )
+                ).default(false).ask() {
+                    if !answer {
                         return Err(e);
                     }
+                } else {
+                    return Err(e);
                 }
 
                 // Export the cert in PEM format and return verification success
@@ -156,10 +154,10 @@ fn gen_default_instance_name(input: impl fmt::Display) -> String {
     if name.is_empty() {
         return "inst1".into();
     }
-    if matches!(name.chars().next().unwrap(), '0'..='9') {
+    if name.chars().next().unwrap().is_ascii_digit() {
         name.insert(0, '_');
     }
-    return name;
+    name
 }
 
 #[tokio::main]
@@ -169,7 +167,7 @@ async fn connect(cfg: &edgedb_tokio::Config) -> Result<Connection, Error> {
 
 #[tokio::main]
 async fn conn_params(cmd: &Link, opts: &Options) -> anyhow::Result<Config> {
-    let mut builder = options::prepare_conn_params(&opts)?;
+    let mut builder = options::prepare_conn_params(opts)?;
     prompt_conn_params(&opts.conn_options, &mut builder, cmd).await
 }
 
@@ -188,7 +186,7 @@ pub fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
     let inner = WebPkiServerVerifier::builder(Arc::new(root_cert_store)).build()?;
     let verifier = Arc::new(
         InteractiveCertVerifier {
-            inner: inner,
+            inner,
             cert_out: Mutex::new(None),
             tls_security: creds.tls_security,
             system_ca_only: creds.tls_ca.is_none(),
@@ -383,7 +381,7 @@ pub fn unlink(options: &Unlink) -> anyhow::Result<()> {
             "use `edgedb instance destroy -I {}` to remove the instance",
              name))?;
     }
-    with_projects(&name, options.force, print_warning, || {
+    with_projects(name, options.force, print_warning, || {
         fs::remove_file(credentials::path(name)?)
             .with_context(|| format!("cannot unlink {}", name))
     })?;

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -171,7 +171,7 @@ async fn connect(cfg: &edgedb_tokio::Config) -> Result<Client, Error> {
 
 #[tokio::main(flavor = "current_thread")]
 async fn conn_params(cmd: &Link, opts: &Options, has_branch: &mut bool) -> anyhow::Result<Config> {
-    let mut builder = options::prepare_conn_params(&opts)?;
+    let mut builder = options::prepare_conn_params(opts)?;
     prompt_conn_params(&opts.conn_options, &mut builder, cmd, has_branch).await
 }
 

--- a/src/portable/list_versions.rs
+++ b/src/portable/list_versions.rs
@@ -53,7 +53,7 @@ pub fn all_packages() -> Vec<PackageInfo> {
         Ok(nightly) => pkgs.extend(nightly),
         Err(e) => log::warn!("Unable to fetch nightly packages: {:#}", e),
     }
-    return pkgs;
+    pkgs
 }
 
 pub fn list_versions(options: &ListVersions) -> Result<(), anyhow::Error> {
@@ -111,8 +111,7 @@ pub fn list_versions(options: &ListVersions) -> Result<(), anyhow::Error> {
                     .collect::<Vec<_>>()
             )?);
         } else {
-            print_table(version_set.into_iter()
-                        .map(|(_, vp)| match vp.install {
+            print_table(version_set.into_values().map(|vp| match vp.install {
                             Some(v) => (v.version, true),
                             None => (vp.package.unwrap().version, false),
                         }));
@@ -132,7 +131,7 @@ fn print_table(items: impl Iterator<Item=(ver::Build, bool)>) {
     for (ver, installed) in items {
         let channel = Channel::from_version(&ver.specific());
         table.add_row(Row::new(vec![
-            Cell::new(&channel.as_ref().map_or("nightly", |x| x.as_str())),
+            Cell::new(channel.as_ref().map_or("nightly", |x| x.as_str())),
             Cell::new(&ver.to_string()),
             Cell::new(if installed { "✓" } else { "" }),
         ]));

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -91,7 +91,7 @@ pub fn read_ports() -> anyhow::Result<BTreeMap<String, u16>> {
 
 #[context("failed reading port mapping {}", path.display())]
 fn _read_ports(path: &Path) -> anyhow::Result<BTreeMap<String, u16>> {
-    let data = match fs::read_to_string(&path) {
+    let data = match fs::read_to_string(path) {
         Ok(data) if data.is_empty() => {
             return Ok(BTreeMap::new());
         }
@@ -187,13 +187,13 @@ pub fn write_json<T: serde::Serialize>(path: &Path, title: &str, data: &T)
     Ok(())
 }
 
-fn list_installed<'x>(dir: &'x Path)
+fn list_installed(dir: &Path)
     -> anyhow::Result<
-        impl Iterator<Item=anyhow::Result<(ver::Specific, PathBuf)>> + 'x
+        impl Iterator<Item=anyhow::Result<(ver::Specific, PathBuf)>> + '_
     >
 {
     let err_ctx = move || format!("error reading directory {:?}", dir);
-    let dir = fs::read_dir(&dir).with_context(err_ctx)?;
+    let dir = fs::read_dir(dir).with_context(err_ctx)?;
     Ok(dir.filter_map(move |result| {
         let entry = match result {
             Ok(entry) => entry,
@@ -202,10 +202,10 @@ fn list_installed<'x>(dir: &'x Path)
         let ver_opt = entry.file_name().to_str()
             .and_then(|x| x.parse().ok());
         if let Some(ver) = ver_opt {
-            return Some(Ok((ver, entry.path())))
+            Some(Ok((ver, entry.path())))
         } else {
             log::info!("Skipping directory {:?}", entry.path());
-            return None
+            None
         }
     }))
 }
@@ -368,7 +368,7 @@ fn installation_path(ver: &ver::Specific) -> anyhow::Result<PathBuf> {
 
 impl InstallInfo {
     pub fn base_path(&self) -> anyhow::Result<PathBuf> {
-        Ok(installation_path(&self.version.specific())?)
+        installation_path(&self.version.specific())
     }
     pub fn server_path(&self) -> anyhow::Result<PathBuf> {
         Ok(self.base_path()?.join("bin").join("edgedb-server"))
@@ -400,7 +400,7 @@ pub fn is_valid_local_instance_name(name: &str) -> bool {
             was_dash = false;
         }
     }
-    return !was_dash;
+    !was_dash
 }
 
 pub fn is_valid_cloud_name(name: &str) -> bool {
@@ -428,7 +428,7 @@ pub fn is_valid_cloud_name(name: &str) -> bool {
             was_dash = false;
         }
     }
-    return !was_dash;
+    !was_dash
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -69,7 +69,7 @@ pub fn open_lock(instance: &str) -> anyhow::Result<fd_lock::RwLock<fs::File>> {
         fs_err::create_dir_all(parent)?;
     }
     let lock_file = fs::OpenOptions::new()
-        .create(true).write(true).read(true)
+        .create(true).truncate(false).write(true).read(true)
         .open(&lock_path)
         .with_context(|| format!("cannot open lock file {:?}", lock_path))?;
     Ok(fd_lock::RwLock::new(lock_file))

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -192,10 +192,7 @@ fn bootout(name: &str) -> anyhow::Result<()> {
 }
 
 pub fn is_service_loaded(name: &str) -> bool {
-    match _service_status(name) {
-        Status::NotLoaded => false,
-        _ => true,
-    }
+    !matches!(_service_status(name), Status::NotLoaded)
 }
 
 pub fn service_status(name: &str) -> Service {
@@ -250,9 +247,10 @@ fn _service_status(name: &str) -> Status {
                 return Status::Ready;
             }
             Some(("last exit code", value)) => {
-                match value.parse() {
-                    Ok(value) => exit_code = Some(value),
-                    Err(_) => {}, // assuming "(never exited)"
+                if let Ok(value) = value.parse() {
+                    exit_code = Some(value)
+                } else {
+                    // assuming "(never exited)"
                 }
             }
             _ => {}

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -130,17 +130,17 @@ fn plist_data(name: &str, info: &InstanceInfo) -> anyhow::Result<String> {
 "###,
         instance_name=name,
         executable=current_exe()?.display(),
-        log_path=log_file(&name)?.display(),
+        log_path=log_file(name)?.display(),
     ))
 }
 
 fn _create_service(info: &InstanceInfo) -> anyhow::Result<()>
 {
     let name = &info.name;
-    let plist_dir_path;
-    plist_dir_path = plist_dir()?;
+    
+    let plist_dir_path = plist_dir()?;
     fs::create_dir_all(&plist_dir_path)?;
-    let plist_path = plist_dir_path.join(&plist_name(name));
+    let plist_path = plist_dir_path.join(plist_name(name));
     let unit_name = launchd_name(name);
     fs::write(&plist_path, plist_data(name, info)?)?;
     if let Some(dir) = runstate_dir(name)?.parent() {
@@ -215,7 +215,7 @@ fn _service_status(name: &str) -> Status {
 
     let list = process::Native::new("service info", "launchctl", "launchctl")
             .arg("print")
-            .arg(launchd_name(&name))
+            .arg(launchd_name(name))
             .get_output();
     let output = match list {
         Ok(output) => output,
@@ -228,7 +228,7 @@ fn _service_status(name: &str) -> Status {
     if !output.status.success() {
         log::debug!("`launchctl print {}` errored out with {:?}. \
                       Assuming service is not loaded.",
-                    launchd_name(&name), output.stderr);
+                    launchd_name(name), output.stderr);
         return NotLoaded;
     }
     let mut pid: Option<u32> = None;
@@ -261,23 +261,23 @@ fn _service_status(name: &str) -> Status {
     if let Some(pid) = pid {
         return Running { pid }
     }
-    if exit_code != None && exit_code != Some(0) {
+    if exit_code.is_some() && exit_code != Some(0) {
         return Failed { exit_code }
     }
     Inactive { error: "no pid found".into() }
 }
 
 pub fn stop_and_disable(name: &str) -> anyhow::Result<bool> {
-    if is_service_loaded(&name) {
+    if is_service_loaded(name) {
         // bootout will fail if the service is not loaded (e.g. manually-
         // starting services that never started after reboot), also it's
         // unnecessary to unload the service if it wasn't loaded.
         log::info!("Unloading service");
-        bootout(&name)?;
+        bootout(name)?;
     }
 
     let mut found = false;
-    let unit_path = plist_path(&name)?;
+    let unit_path = plist_path(name)?;
     if unit_path.exists() {
         found = true;
         log::info!("Removing unit file {}", unit_path.display());
@@ -315,20 +315,20 @@ pub fn detect_launchd() -> bool {
     } else {
         return false;
     };
-    let out = process::Native::new("detect launchd", "launchctl", &path)
+    let out = process::Native::new("detect launchd", "launchctl", path)
         .arg("print-disabled")  // Faster than bare print
         .arg(get_domain_target())
         .get_output();
     match out {
-        Ok(out) if out.status.success() => return true,
+        Ok(out) if out.status.success() => true,
         Ok(out) => {
             log::info!("detecting launchd session: {:?}",
                        String::from_utf8_lossy(&out.stderr));
-            return false;
+            false
         }
         Err(e) => {
             log::info!("detecting launchd session: {:#}", e);
-            return false;
+            false
         }
     }
 }

--- a/src/portable/main.rs
+++ b/src/portable/main.rs
@@ -44,7 +44,7 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options)
         Create(c) => create::create(c, options),
         Destroy(c) => destroy::destroy(c, options),
         ResetPassword(c) => reset_password::reset_password(c),
-        Link(c) => link::link(c, &options),
+        Link(c) => link::link(c, options),
         List(c) if cfg!(windows) => windows::list(c, options),
         List(c) => status::list(c, options),
         Resize(c) => resize::resize(c, options),
@@ -59,7 +59,7 @@ pub fn instance_main(cmd: &ServerInstanceCommand, options: &Options)
         Unlink(c) => link::unlink(c),
         Status(c) if cfg!(windows) => windows::status(c),
         Status(c) => status::status(c, options),
-        Credentials(c) => credentials::show_credentials(&options, &c),
+        Credentials(c) => credentials::show_credentials(options, c),
     }
 }
 

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -147,7 +147,7 @@ pub enum InstanceName {
 }
 
 fn billable_unit(s: &str) -> Result<String, String> {
-    let (numerator, denominator) = match s.split_once("/") {
+    let (numerator, denominator) = match s.split_once('/') {
         Some(v) => v,
         None => (s, "1"),
     };
@@ -784,5 +784,5 @@ pub fn instance_arg<'x>(positional: &'x Option<InstanceName>,
         return Ok(name);
     }
     echo!(err_marker(), "Instance name argument is required, use '-I name'");
-    return Err(ExitCode::new(2).into());
+    Err(ExitCode::new(2).into())
 }

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -160,7 +160,7 @@ fn billable_unit(s: &str) -> Result<String, String> {
         .parse()
         .map_err(|_| format!("`{s}` is not a positive number or valid fraction"))?;
 
-    if n <= 0 || d <= 0 {
+    if n == 0 || d == 0 {
         Err(String::from("`{s}` is not a positive number or valid fraction"))
     } else {
         Ok(s.to_string())

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use clap::{ValueHint};
+use clap::ValueHint;
 use serde::{Serialize, Deserialize};
 use edgedb_cli_derive::IntoArgs;
 

--- a/src/portable/platform.rs
+++ b/src/portable/platform.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 pub fn get_cli() -> anyhow::Result<&'static str> {
     if cfg!(target_arch="x86_64") {
         if cfg!(target_os="macos") {
-            return Ok("x86_64-apple-darwin");
+            Ok("x86_64-apple-darwin")
         } else if cfg!(target_os="linux") {
             return Ok("x86_64-unknown-linux-musl");
         } else if cfg!(windows) {
@@ -31,7 +31,7 @@ pub fn get_cli() -> anyhow::Result<&'static str> {
 pub fn get_server() -> anyhow::Result<&'static str> {
     if cfg!(target_arch="x86_64") {
         if cfg!(target_os="macos") {
-            return Ok("x86_64-apple-darwin");
+            Ok("x86_64-apple-darwin")
         } else if cfg!(target_os="linux") {
             return Ok("x86_64-unknown-linux-gnu");
         } else if cfg!(windows) {
@@ -63,7 +63,7 @@ fn docker_check() -> anyhow::Result<bool> {
             return Ok(true);
         }
     }
-    return Ok(false)
+    Ok(false)
 }
 
 pub fn optional_docker_check() -> anyhow::Result<bool> {

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use anyhow::Context;
-use clap::{ValueHint};
+use clap::ValueHint;
 use fn_error_context::context;
 use rand::{thread_rng, Rng};
 use sha1::Digest;
@@ -33,7 +33,7 @@ use crate::portable::exit_codes;
 use crate::portable::install;
 use crate::portable::local::{InstanceInfo, Paths, allocate_port};
 use crate::portable::options::{self, StartConf, Start, InstanceName};
-use crate::portable::platform::{optional_docker_check};
+use crate::portable::platform::optional_docker_check;
 use crate::portable::repository::{self, Channel, Query, PackageInfo};
 use crate::portable::upgrade;
 use crate::portable::ver;
@@ -747,7 +747,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
 }
 
 fn do_init(name: &str, pkg: &PackageInfo,
-           stash_dir: &Path, project_dir: &Path, schema_dir: &Path, database: &String, options: &Init)
+           stash_dir: &Path, project_dir: &Path, schema_dir: &Path, database: &str, options: &Init)
     -> anyhow::Result<ProjectInfo>
 {
     let port = allocate_port(name)?;
@@ -778,7 +778,7 @@ fn do_init(name: &str, pkg: &PackageInfo,
             default_user: "edgedb".into(),
             non_interactive: true,
             cloud_opts: options.cloud_opts.clone(),
-            default_branch: Some(database.clone())
+            default_branch: Some(database.to_string())
         }, name, port, &paths)?;
         create::create_service(&InstanceInfo {
             name: name.into(),

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -277,7 +277,7 @@ pub fn init(options: &Init, opts: &crate::options::Options) -> anyhow::Result<()
         print::error(
             "`edgedb project init` is not supported in Docker containers.",
         );
-        return Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
+        Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
     }
 
     if options.server_start_conf.is_some() {
@@ -288,7 +288,7 @@ pub fn init(options: &Init, opts: &crate::options::Options) -> anyhow::Result<()
 
     match &options.project_dir {
         Some(dir) => {
-            let dir = fs::canonicalize(&dir)?;
+            let dir = fs::canonicalize(dir)?;
             if dir.join("edgedb.toml").exists() {
                 if options.link {
                     link(options, &dir, &opts.cloud_options)?
@@ -310,7 +310,7 @@ pub fn init(options: &Init, opts: &crate::options::Options) -> anyhow::Result<()
             let base_dir = env::current_dir()
                 .context("failed to get current directory")?;
             if let Some(dir) = search_dir(&base_dir) {
-                let dir = fs::canonicalize(&dir)?;
+                let dir = fs::canonicalize(dir)?;
                 if options.link {
                     link(options, &dir, &opts.cloud_options)?
                 } else {
@@ -409,7 +409,7 @@ fn ask_database_or_branch(version: &Specific, project_dir: &Path, options: &Init
         return ask_branch();
     }
 
-    return ask_database(project_dir, options);
+    ask_database(project_dir, options)
 }
 
 pub fn get_default_branch_name(version: &Specific) -> String {
@@ -417,7 +417,7 @@ pub fn get_default_branch_name(version: &Specific) -> String {
         return String::from("main");
     }
 
-    return String::from("edgedb");
+    String::from("edgedb")
 }
 
 pub fn get_default_branch_or_database(version: &Specific, project_dir: &Path) -> String {
@@ -425,7 +425,7 @@ pub fn get_default_branch_or_database(version: &Specific, project_dir: &Path) ->
         return String::from("main");
     }
 
-    return directory_to_name(project_dir, "edgedb");
+    directory_to_name(project_dir, "edgedb")
 }
 
 fn link(
@@ -477,7 +477,7 @@ fn do_link(inst: &Handle, options: &Init, stash_dir: &Path)
         stash.cloud_profile = Some(profile);
     };
     stash.database = inst.database.as_deref();
-    stash.write(&stash_dir)?;
+    stash.write(stash_dir)?;
 
     if !options.no_migrations {
         migrate(inst, !options.non_interactive)?;
@@ -510,9 +510,9 @@ fn directory_to_name(path: &Path, default: &str) -> String {
         .replace(|c: char| !c.is_ascii_alphanumeric(), "_");
     let stem = stem.trim_matches('_');
     if stem.is_empty() {
-        return default.into();
+        default.into()
     } else {
-        return stem.into();
+        stem.into()
     }
 }
 
@@ -681,7 +681,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
                 name.to_owned(),
                 org_slug.to_owned(),
                 &stash_dir,
-                &project_dir,
+                project_dir,
                 &schema_dir,
                 &ver,
                 &database,
@@ -737,7 +737,7 @@ pub fn init_existing(options: &Init, project_dir: &Path, cloud_options: &crate::
                 name,
                 &pkg,
                 &stash_dir,
-                &project_dir,
+                project_dir,
                 &schema_dir,
                 &branch.unwrap_or(get_default_branch_name(specific_version)),
                 options
@@ -751,7 +751,7 @@ fn do_init(name: &str, pkg: &PackageInfo,
     -> anyhow::Result<ProjectInfo>
 {
     let port = allocate_port(name)?;
-    let paths = Paths::get(&name)?;
+    let paths = Paths::get(name)?;
     let inst_name = InstanceName::Local(name.to_owned());
 
     let instance = if cfg!(windows) {
@@ -787,7 +787,7 @@ fn do_init(name: &str, pkg: &PackageInfo,
         })?;
         InstanceKind::Wsl(WslInfo {})
     } else {
-        let inst = install::package(&pkg).context("error installing EdgeDB")?;
+        let inst = install::package(pkg).context("error installing EdgeDB")?;
         let info = InstanceInfo {
             name: name.into(),
             installation: Some(inst),
@@ -821,16 +821,16 @@ fn do_init(name: &str, pkg: &PackageInfo,
         database: options.database.clone(),
     };
 
-    let mut stash = StashDir::new(project_dir, &name);
+    let mut stash = StashDir::new(project_dir, name);
     stash.database = handle.database.as_deref();
-    stash.write(&stash_dir)?;
+    stash.write(stash_dir)?;
 
     if !options.no_migrations {
         migrate(&handle, false)?;
     } else {
         create_database(&handle)?;
     }
-    print_initialized(&name, &options.project_dir);
+    print_initialized(name, &options.project_dir);
     Ok(ProjectInfo {
         instance_name: name.into(),
         stash_dir: stash_dir.into(),
@@ -870,7 +870,7 @@ fn do_cloud_init(
     };
 
     let mut stash = StashDir::new(project_dir, &full_name);
-    stash.cloud_profile = client.profile.as_deref().or_else(|| Some("default"));
+    stash.cloud_profile = client.profile.as_deref().or(Some("default"));
     stash.database = handle.database.as_deref();
     stash.write(stash_dir)?;
 
@@ -915,14 +915,14 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
     let config_path = project_dir.join("edgedb.toml");
     let schema_dir = Path::new("dbschema");
     let schema_dir_path = project_dir.join(schema_dir);
-    let schema_files = find_schema_files(&schema_dir)?;
+    let schema_files = find_schema_files(schema_dir)?;
 
     let mut client = CloudClient::new(&opts.cloud_options)?;
     let (inst_name, exists) = ask_name(project_dir, options, &mut client)?;
 
     if exists {
         let mut inst;
-        inst = Handle::probe(&inst_name, project_dir, &schema_dir, &client)?;
+        inst = Handle::probe(&inst_name, project_dir, schema_dir, &client)?;
         let specific_version: &Specific = &inst.get_version()?.specific();
         let version_query = Query::from_version(specific_version)?;
         write_config(&config_path, &version_query)?;
@@ -968,8 +968,8 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
                 name.to_owned(),
                 org_slug.to_owned(),
                 &stash_dir,
-                &project_dir,
-                &schema_dir,
+                project_dir,
+                schema_dir,
                 &version,
                 &database,
                 options,
@@ -1019,11 +1019,11 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
             }
 
             do_init(
-                &name,
+                name,
                 &pkg,
                 &stash_dir,
-                &project_dir,
-                &schema_dir,
+                project_dir,
+                schema_dir,
                 &branch.unwrap_or(get_default_branch_name(specific_version)),
                 options
             )
@@ -1055,7 +1055,7 @@ fn stash_name(path: &Path) -> anyhow::Result<OsString> {
     let mut base = base.to_os_string();
     base.push("-");
     base.push(&hash);
-    return Ok(base);
+    Ok(base)
 }
 
 pub fn stash_base() -> anyhow::Result<PathBuf> {
@@ -1091,7 +1091,7 @@ fn run_and_migrate(info: &Handle) -> anyhow::Result<()> {
 fn start(handle: &Handle) -> anyhow::Result<()> {
     match &handle.instance {
         InstanceKind::Portable(inst) => {
-            control::do_start(&inst)?;
+            control::do_start(inst)?;
             Ok(())
         }
         InstanceKind::Wsl(_) => {
@@ -1240,15 +1240,15 @@ impl<'a> StashDir<'a> {
     }
     #[context("error writing project dir {:?}", dir)]
     fn write(&self, dir: &Path) -> anyhow::Result<()> {
-        let tmp = tmp_file_path(&dir);
+        let tmp = tmp_file_path(dir);
         fs::create_dir_all(&tmp)?;
-        fs::write(&tmp.join("project-path"), path_bytes(self.project_dir)?)?;
-        fs::write(&tmp.join("instance-name"), self.instance_name.as_bytes())?;
+        fs::write(tmp.join("project-path"), path_bytes(self.project_dir)?)?;
+        fs::write(tmp.join("instance-name"), self.instance_name.as_bytes())?;
         if let Some(profile) = self.cloud_profile {
-            fs::write(&tmp.join("cloud-profile"), profile.as_bytes())?;
+            fs::write(tmp.join("cloud-profile"), profile.as_bytes())?;
         }
         if let Some(database) = &self.database {
-            fs::write(&tmp.join("database"), database.as_bytes())?;
+            fs::write(tmp.join("database"), database.as_bytes())?;
         }
 
         let lnk = tmp.join("project-link");
@@ -1354,7 +1354,7 @@ impl Handle<'_> {
 
 #[context("cannot read schema directory `{}`", path.display())]
 fn find_schema_files(path: &Path) -> anyhow::Result<bool> {
-    let dir = match fs::read_dir(&path) {
+    let dir = match fs::read_dir(path) {
         Ok(dir) => dir,
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
             return Ok(false);
@@ -1386,8 +1386,8 @@ fn print_initialized(name: &str, dir_option: &Option<PathBuf>)
 
 #[context("cannot create default schema in `{}`", dir.display())]
 fn write_schema_default(dir: &Path, version: &Query) -> anyhow::Result<()> {
-    fs::create_dir_all(&dir)?;
-    fs::create_dir_all(&dir.join("migrations"))?;
+    fs::create_dir_all(dir)?;
+    fs::create_dir_all(dir.join("migrations"))?;
     let default = dir.join("default.esdl");
     let tmp = tmp_file_path(&default);
     fs::remove_file(&tmp).ok();
@@ -1479,7 +1479,7 @@ fn ask_local_version(options: &Init) -> anyhow::Result<(Query, PackageInfo)> {
                 }
             }
         } else {
-            match parse_ver_and_find(&value) {
+            match parse_ver_and_find(value) {
                 Ok(Some(pair)) => return Ok(pair),
                 Ok(None) => {
                     print::error("No matching packages found");
@@ -1553,7 +1553,7 @@ fn ask_cloud_version(options: &Init, client: &CloudClient) -> anyhow::Result<(Qu
                 }
             }
         } else {
-            match parse_ver_and_find_cloud(&value, client) {
+            match parse_ver_and_find_cloud(value, client) {
                 Ok(pair) => return Ok(pair),
                 Err(e) => {
                     print::error(e);
@@ -1572,7 +1572,7 @@ fn print_cloud_versions(title: &str, client: &CloudClient) -> anyhow::Result<()>
     println!("{}: {}{}",
         title,
         avail.iter()
-            .filter_map(|p| Query::from_version(&p).ok())
+            .filter_map(|p| Query::from_version(p).ok())
             .take(5)
             .map(|v| v.as_config_value())
             .collect::<Vec<_>>()
@@ -1585,7 +1585,7 @@ fn print_cloud_versions(title: &str, client: &CloudClient) -> anyhow::Result<()>
 fn search_for_unlink(base: &Path) -> anyhow::Result<PathBuf> {
     let mut path = base;
     while let Some(parent) = path.parent() {
-        let canon = fs::canonicalize(&path)
+        let canon = fs::canonicalize(path)
             .with_context(|| {
                 format!("failed to canonicalize dir {:?}", parent)
             })?;
@@ -1600,13 +1600,13 @@ fn search_for_unlink(base: &Path) -> anyhow::Result<PathBuf> {
 
 #[context("cannot read instance name of {:?}", stash_dir)]
 pub fn instance_name(stash_dir: &Path) -> anyhow::Result<InstanceName> {
-    let inst = fs::read_to_string(&stash_dir.join("instance-name"))?;
-    Ok(InstanceName::from_str(inst.trim())?)
+    let inst = fs::read_to_string(stash_dir.join("instance-name"))?;
+    InstanceName::from_str(inst.trim())
 }
 
 #[context("cannot read database name of {:?}", stash_dir)]
 fn database_name(stash_dir: &Path) -> anyhow::Result<Option<String>> {
-    let inst = match fs::read_to_string(&stash_dir.join("database")) {
+    let inst = match fs::read_to_string(stash_dir.join("database")) {
         Ok(text) => text,
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
             return Ok(None);
@@ -1618,7 +1618,7 @@ fn database_name(stash_dir: &Path) -> anyhow::Result<Option<String>> {
 
 pub fn unlink(options: &Unlink, opts: &crate::options::Options) -> anyhow::Result<()> {
     let stash_path = if let Some(dir) = &options.project_dir {
-        let canon = fs::canonicalize(&dir)
+        let canon = fs::canonicalize(dir)
             .with_context(|| format!("failed to canonicalize dir {:?}", dir))?;
         stash_path(&canon)?
     } else {
@@ -1646,13 +1646,13 @@ pub fn unlink(options: &Unlink, opts: &crate::options::Options) -> anyhow::Resul
                 project_dirs.iter().position(|d| d == &stash_path)
                     .map(|pos| project_dirs.remove(pos));
                 destroy::print_warning(&inst_name, &project_dirs);
-                return Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
+                Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
             }
             if options.destroy_server_instance {
                 destroy::force_by_name(&inst, opts)?;
             }
         } else {
-            match fs::read_to_string(&stash_path.join("instance-name")) {
+            match fs::read_to_string(stash_path.join("instance-name")) {
                 Ok(name) => {
                     echo!("Unlinking instance", name.emphasize());
                 }
@@ -1683,7 +1683,7 @@ pub fn project_dir_opt(cli_options: Option<&Path>)
     match cli_options {
         Some(dir) => {
             if dir.join("edgedb.toml").exists() {
-                let canon = fs::canonicalize(&dir)
+                let canon = fs::canonicalize(dir)
                     .with_context(|| {
                         format!("failed to canonicalize dir {:?}", dir)
                     })?;
@@ -1709,7 +1709,7 @@ pub fn project_dir_opt(cli_options: Option<&Path>)
 }
 
 pub fn info(options: &Info) -> anyhow::Result<()> {
-    let root = project_dir(options.project_dir.as_ref().map(|x| x.as_path()))?;
+    let root = project_dir(options.project_dir.as_deref())?;
     let stash_dir = stash_path(&root)?;
     if !stash_dir.exists() {
         echo!(print::err_marker(),
@@ -1725,7 +1725,7 @@ pub fn info(options: &Info) -> anyhow::Result<()> {
         .transpose()?;
 
     let item = options.get.as_deref()
-        .or(options.instance_name.then(|| "instance-name"));
+        .or(options.instance_name.then_some("instance-name"));
     if let Some(item) = item {
         match item {
             "instance-name" => {
@@ -1788,7 +1788,7 @@ pub fn find_project_stash_dirs(
         let sub_dir = entry.path();
         if sub_dir.file_name()
             .and_then(|f| f.to_str())
-            .map(|n| n.starts_with("."))
+            .map(|n| n.starts_with('.'))
             .unwrap_or(true)
         {
             // skip hidden files, most likely .DS_Store (see #689)
@@ -1831,7 +1831,7 @@ pub fn print_instance_in_use_warning(name: &str, project_dirs: &[PathBuf]) {
 
 #[context("cannot read {:?}", project_dir)]
 pub fn read_project_path(project_dir: &Path) -> anyhow::Result<PathBuf> {
-    let bytes = fs::read(&project_dir.join("project-path"))?;
+    let bytes = fs::read(project_dir.join("project-path"))?;
     Ok(bytes_to_path(&bytes)?.to_path_buf())
 }
 
@@ -1857,7 +1857,7 @@ pub fn upgrade(options: &Upgrade, opts: &crate::options::Options)
 pub fn update_toml(
     options: &Upgrade, opts: &crate::options::Options, query: Query,
 ) -> anyhow::Result<()> {
-    let root = project_dir(options.project_dir.as_ref().map(|x| x.as_path()))?;
+    let root = project_dir(options.project_dir.as_deref())?;
     let config_path = root.join("edgedb.toml");
     let config = config::read(&config_path)?;
     let schema_dir = &config.project.schema_dir;
@@ -1882,7 +1882,7 @@ pub fn update_toml(
         let name = instance_name(&stash_dir)?;
         let database = database_name(&stash_dir)?;
         let client = CloudClient::new(&opts.cloud_options)?;
-        let mut inst = Handle::probe(&name, &root, &schema_dir, &client)?;
+        let mut inst = Handle::probe(&name, &root, schema_dir, &client)?;
         inst.database = database;
 
         let result = match inst.instance {
@@ -1955,7 +1955,7 @@ fn print_other_project_warning(name: &str, project_path: &Path,
         }
         eprintln!("Run the following commands to update them:");
         for pd in &project_dirs {
-            upgrade::print_project_upgrade_command(&to_version, &None, pd);
+            upgrade::print_project_upgrade_command(to_version, &None, pd);
         }
     }
     Ok(())
@@ -1964,7 +1964,7 @@ fn print_other_project_warning(name: &str, project_path: &Path,
 pub fn upgrade_instance(
     options: &Upgrade, opts: &crate::options::Options
 ) -> anyhow::Result<()> {
-    let root = project_dir(options.project_dir.as_ref().map(|x| x.as_path()))?;
+    let root = project_dir(options.project_dir.as_deref())?;
     let config_path = root.join("edgedb.toml");
     let config = config::read(&config_path)?;
     let cfg_ver = &config.edgedb.server_version;
@@ -1978,7 +1978,7 @@ pub fn upgrade_instance(
     let instance_name = instance_name(&stash_dir)?;
     let database = database_name(&stash_dir)?;
     let client = CloudClient::new(&opts.cloud_options)?;
-    let mut inst = Handle::probe(&instance_name, &root, &schema_dir, &client)?;
+    let mut inst = Handle::probe(&instance_name, &root, schema_dir, &client)?;
     inst.database = database;
     let result = match inst.instance {
         InstanceKind::Remote
@@ -2036,7 +2036,7 @@ fn upgrade_local(
                 to_nightly: false,
                 to_testing: false,
                 name: None,
-                instance: Some(instance_name.into()),
+                instance: Some(instance_name),
                 verbose: false,
                 force: cmd.force,
                 force_dump_restore: cmd.force,
@@ -2044,7 +2044,7 @@ fn upgrade_local(
                 cloud_opts: opts.cloud_options.clone(),
             }, &inst.name)?;
         } else {
-            ver::print_version_hint(&pkg_ver, &to_version);
+            ver::print_version_hint(&pkg_ver, to_version);
             // When force is used we might upgrade to the same version, but
             // since some selector like `--to-latest` was specified we assume
             // user want to treat this upgrade as incompatible and do the
@@ -2052,7 +2052,7 @@ fn upgrade_local(
             if pkg_ver.is_compatible(&inst_ver) && !cmd.force {
                 upgrade::upgrade_compatible(inst, pkg)?;
             } else {
-                migrations::upgrade_check::to_version(&pkg, &config)?;
+                migrations::upgrade_check::to_version(&pkg, config)?;
                 upgrade::upgrade_incompatible(inst, pkg)?;
             }
         }

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -938,7 +938,7 @@ pub fn init_new(options: &Init, project_dir: &Path, opts: &crate::options::Optio
         } else {
             inst.database = options.database.clone();
         }
-        return do_link(&mut inst, options, &stash_dir);
+        return do_link(&inst, options, &stash_dir);
     };
 
     match &inst_name {

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -210,13 +210,12 @@ fn filter_package(pkg_root: &Url, pkg: &PackageData) -> Option<PackageInfo> {
 
 fn _filter_package(pkg_root: &Url, pkg: &PackageData) -> Option<PackageInfo> {
     let iref = pkg.installrefs.iter()
-        .filter(|r| (
+        .find(|r| (
                 r.kind == "application/x-tar" &&
                 r.encoding.as_ref().map(|x| &x[..]) == Some("zstd") &&
                 r.verification.blake2b.as_ref()
                     .map(valid_hash).unwrap_or(false)
-        ))
-        .next()?;
+        ))?;
     Some(PackageInfo {
         version: pkg.version.parse().ok()?,
         url: pkg_root.join(&iref.path).ok()?,
@@ -241,20 +240,18 @@ fn _filter_cli_package(pkg_root: &Url, pkg: &PackageData)
     -> Option<CliPackageInfo>
 {
     let iref = pkg.installrefs.iter()
-        .filter(|r| (
+        .find(|r| (
                 r.encoding.as_ref().map(|x| &x[..]) == Some("zstd") &&
                 r.verification.blake2b.as_ref()
                     .map(valid_hash).unwrap_or(false)
         ))
-        .next()
         .or_else(|| {
             pkg.installrefs.iter()
-            .filter(|r| (
-                    r.encoding.as_ref().map(|x| &x[..]) == Some("identity") &&
-                    r.verification.blake2b.as_ref()
-                        .map(valid_hash).unwrap_or(false)
-            ))
-            .next()
+                .find(|r| (
+                        r.encoding.as_ref().map(|x| &x[..]) == Some("identity") &&
+                        r.verification.blake2b.as_ref()
+                            .map(valid_hash).unwrap_or(false)
+                ))
         })?;
     let cmpr = if iref.encoding.as_ref().map(|x| &x[..]) == Some("zstd") {
         Some(Compression::Zstd)

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -205,7 +205,7 @@ fn filter_package(pkg_root: &Url, pkg: &PackageData) -> Option<PackageInfo> {
     if result.is_none() {
         log::info!("Skipping package {:?}", pkg);
     }
-    return result;
+    result
 }
 
 fn _filter_package(pkg_root: &Url, pkg: &PackageData) -> Option<PackageInfo> {
@@ -234,7 +234,7 @@ fn filter_cli_package(pkg_root: &Url, pkg: &PackageData)
     if result.is_none() {
         log::info!("Skipping package {:?}", pkg);
     }
-    return result;
+    result
 }
 
 fn _filter_cli_package(pkg_root: &Url, pkg: &PackageData)
@@ -287,15 +287,15 @@ pub fn get_platform_cli_packages(channel: Channel, platform: &str,
     -> anyhow::Result<Vec<CliPackageInfo>>
 {
     let pkg_root = pkg_root()?;
-    let data: RepositoryData;
-    data = match get_json(&json_url(platform, channel)?, timeo) {
+    
+    let data: RepositoryData = match get_json(&json_url(platform, channel)?, timeo) {
         Ok(data) => data,
         Err(e) if e.is::<NotFound>() => RepositoryData { packages: vec![] },
         Err(e) => return Err(e),
     };
     let packages = data.packages.iter()
         .filter(|pkg| pkg.basename == "edgedb-cli")
-        .filter_map(|p| filter_cli_package(&pkg_root, p))
+        .filter_map(|p| filter_cli_package(pkg_root, p))
         .collect();
     Ok(packages)
 }
@@ -311,15 +311,15 @@ fn get_platform_server_packages(channel: Channel, platform: &str)
     -> anyhow::Result<Vec<PackageInfo>>
 {
     let pkg_root = pkg_root()?;
-    let data: RepositoryData;
-    data = match get_json(&json_url(platform, channel)?, DEFAULT_TIMEOUT) {
+    
+    let data: RepositoryData = match get_json(&json_url(platform, channel)?, DEFAULT_TIMEOUT) {
         Ok(data) => data,
         Err(e) if e.is::<NotFound>() => RepositoryData { packages: vec![] },
         Err(e) => return Err(e),
     };
     let packages = data.packages.iter()
         .filter(|pkg| pkg.basename == "edgedb-server")
-        .filter_map(|p| filter_package(&pkg_root, p))
+        .filter_map(|p| filter_package(pkg_root, p))
         .collect();
     Ok(packages)
 }
@@ -359,9 +359,7 @@ pub fn get_specific_package(version: &ver::Specific)
     } else {
         get_server_packages(channel)?
     };
-    let pkg = all.into_iter()
-        .filter(|pkg| &pkg.version.specific() == version)
-        .next();
+    let pkg = all.into_iter().find(|pkg| &pkg.version.specific() == version);
     Ok(pkg)
 }
 
@@ -382,7 +380,7 @@ pub async fn download(dest: impl AsRef<Path>, url: &Url, quiet: bool)
     let bar = if quiet {
         ProgressBar::hidden()
     } else if let Some(len) = req.content_length() {
-        ProgressBar::new(len as u64)
+        ProgressBar::new(len)
     } else {
         ProgressBar::new_spinner()
     };
@@ -416,7 +414,7 @@ impl PackageHash {
         match self {
             PackageHash::Blake2b(val) => &val[..7],
             PackageHash::Unknown(val) => {
-                let start = val.find(":")
+                let start = val.find(':')
                     .unwrap_or(val.len().saturating_sub(7));
                 &val[start..min(7, val.len() - start)]
             }
@@ -625,7 +623,7 @@ impl<'de> Deserialize<'de> for PackageHash {
             }
             return Ok(PackageHash::Blake2b(hash.into()));
         }
-        return Ok(PackageHash::Unknown(s.into()));
+        Ok(PackageHash::Unknown(s.into()))
     }
 }
 
@@ -633,10 +631,10 @@ impl std::str::FromStr for Query {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> anyhow::Result<Query> {
         if s == "*" {
-            return Ok(Query {
+            Ok(Query {
                 channel: Channel::Stable,
                 version: None,
-            });
+            })
         } else if s == "nightly" {
             return Ok(Query {
                 channel: Channel::Nightly,

--- a/src/portable/reset_password.rs
+++ b/src/portable/reset_password.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use std::path::Path;
-use std::default::Default;
 use std::num::NonZeroU32;
 
 use base64::display::Base64Display;

--- a/src/portable/reset_password.rs
+++ b/src/portable/reset_password.rs
@@ -34,7 +34,7 @@ pub fn generate_password() -> String {
 
 #[context("error reading credentials at {}", path.display())]
 fn read_credentials(path: &Path) -> anyhow::Result<Credentials> {
-    let data = fs::read(&path)?;
+    let data = fs::read(path)?;
     Ok(serde_json::from_slice(&data)?)
 }
 
@@ -105,7 +105,7 @@ pub fn reset_password(options: &ResetPassword) -> anyhow::Result<()> {
 
     if save {
         let mut creds = creds.unwrap_or_else(Default::default);
-        creds.user = user.into();
+        creds.user = user;
         creds.password = Some(password);
         credentials::write(&credentials_file, &creds)?;
     }
@@ -130,7 +130,7 @@ pub fn password_hash(password: &str) -> String {
     use ring::rand::SecureRandom;
     let mut salt = [0u8; SALT_LENGTH];
     ring::rand::SystemRandom::new().fill(&mut salt).expect("random bytes");
-    return _build_verifier(password, &salt[..], HASH_ITERATIONS);
+    _build_verifier(password, &salt[..], HASH_ITERATIONS)
 }
 
 fn _build_verifier(password: &str, salt: &[u8], iterations: u32) -> String {
@@ -145,7 +145,7 @@ fn _build_verifier(password: &str, salt: &[u8], iterations: u32) -> String {
     let server_key = hmac::sign(&key, b"Server Key");
     let stored_key = Sha256::digest(client_key.as_ref());
 
-    return format!(
+    format!(
         "SCRAM-SHA-256${iterations}:{salt}${stored_key}:{server_key}",
         iterations=iterations,
         salt=_b64(salt),

--- a/src/portable/resize.rs
+++ b/src/portable/resize.rs
@@ -34,7 +34,7 @@ fn resize_cloud_cmd(
         && billables.compute_size.is_none()
         && billables.storage_size.is_none()
     {
-        return Err(opts.error(
+        Err(opts.error(
             clap::error::ErrorKind::MissingRequiredArgument,
             cformat!("Either <bold>--tier</bold>, <bold>--compute-size</bold>, \
             or <bold>--storage-size</bold> must be specified."),
@@ -58,7 +58,7 @@ fn resize_cloud_cmd(
 
     if let Some(tier) = billables.tier {
         if tier == inst.tier && compute_size.is_none() && storage_size.is_none() {
-            return Err(opts.error(
+            Err(opts.error(
                 clap::error::ErrorKind::InvalidValue,
                 cformat!("Instance \"{org_slug}/{name}\" is already a {tier:?} \
                 instance."),
@@ -67,14 +67,14 @@ fn resize_cloud_cmd(
 
         if tier == cloud::ops::CloudTier::Free {
             if compute_size.is_some() {
-                return Err(opts.error(
+                Err(opts.error(
                     clap::error::ErrorKind::ArgumentConflict,
                     cformat!("The <bold>--compute-size</bold> option can \
                     only be specified for Pro instances."),
                 ))?;
             }
             if storage_size.is_some() {
-                return Err(opts.error(
+                Err(opts.error(
                     clap::error::ErrorKind::ArgumentConflict,
                     cformat!("The <bold>--storage-size</bold> option can \
                     only be specified for Pro instances."),
@@ -94,14 +94,14 @@ fn resize_cloud_cmd(
                 let region_prices = tier_prices.get(&inst.region)
                     .context(format!("could not download pricing information for the {} region", inst.region))?;
                 if compute_size.is_none() {
-                    compute_size = Some(region_prices.into_iter()
+                    compute_size = Some(region_prices.iter()
                         .find(|&price| price.billable == "compute")
                         .context("could not download pricing information for compute")?
                         .units_default.clone()
                         .context("could not find default value for compute")?);
                 }
                 if storage_size.is_none() {
-                    storage_size = Some(region_prices.into_iter()
+                    storage_size = Some(region_prices.iter()
                         .find(|&price| price.billable == "storage")
                         .context("could not download pricing information for storage")?
                         .units_default.clone()
@@ -142,7 +142,7 @@ fn resize_cloud_cmd(
     }
 
     let mut resources_display = resources_display_vec.join("\n");
-    if resources_display != "" {
+    if !resources_display.is_empty() {
         resources_display = format!("\n{resources_display}");
     }
 
@@ -173,5 +173,5 @@ fn resize_cloud_cmd(
     );
     echo!("To connect to the instance run:");
     echo!("  edgedb -I", inst_name);
-    return Ok(())
+    Ok(())
 }

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -54,7 +54,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
                     with pid", up.pid.emphasize(),
                 );
                 echo!("Run with `--ignore-pid-check` to override");
-                return Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
+                Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
             }
             DataDirectory::Upgrading(_) => {
                 echo!("Note: backup appears to be from a broken upgrade");
@@ -70,17 +70,17 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
             "Do you really want to revert?");
         if !q.ask()? {
             print::error("Canceled.");
-            return Err(ExitCode::new(exit_codes::NOT_CONFIRMED))?;
+            Err(ExitCode::new(exit_codes::NOT_CONFIRMED))?;
         }
     }
 
-    if let Err(e) = control::do_stop(&name) {
+    if let Err(e) = control::do_stop(name) {
         print::error(format!("Error stopping service: {:#}", e));
         if !options.no_confirm {
             let q = question::Confirm::new("Do you want to proceed?");
             if !q.ask()? {
                 print::error("Canceled.");
-                return Err(ExitCode::new(exit_codes::NOT_CONFIRMED))?;
+                Err(ExitCode::new(exit_codes::NOT_CONFIRMED))?;
             }
         }
     }

--- a/src/portable/uninstall.rs
+++ b/src/portable/uninstall.rs
@@ -51,9 +51,9 @@ pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
                            cand.version, inst_name);
             }
             all = false;
-            return false;
+            false
         } else {
-            return true;
+            true
         }
     });
     let mut uninstalled = 0;
@@ -72,7 +72,7 @@ pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
     if !all && !options.unused {
         echo!("Uninstalled", uninstalled.emphasize(), "versions.");
         print::error("some instances are in use. See messages above.");
-        return Err(ExitCode::new(exit_codes::PARTIAL_SUCCESS))?;
+        Err(ExitCode::new(exit_codes::PARTIAL_SUCCESS))?;
     } else if uninstalled > 0 {
         echo!("Successfully uninstalled",
                uninstalled.emphasize(), "versions.");

--- a/src/portable/upgrade.rs
+++ b/src/portable/upgrade.rs
@@ -78,12 +78,12 @@ pub fn print_project_upgrade_command(version: &Query,
 fn check_project(name: &str, force: bool, ver_query: &Query)
     -> anyhow::Result<()>
 {
-    let project_dirs = project::find_project_dirs_by_instance(&name)?;
+    let project_dirs = project::find_project_dirs_by_instance(name)?;
     if project_dirs.is_empty() {
         return Ok(())
     }
 
-    project::print_instance_in_use_warning(&name, &project_dirs);
+    project::print_instance_in_use_warning(name, &project_dirs);
     let current_project = project::project_dir_opt(None)?;
 
     if force {
@@ -96,7 +96,7 @@ fn check_project(name: &str, force: bool, ver_query: &Query)
     }
     for pd in project_dirs {
         let pd = project::read_project_path(&pd)?;
-        print_project_upgrade_command(&ver_query, &current_project, &pd);
+        print_project_upgrade_command(ver_query, &current_project, &pd);
     }
     if !force {
         anyhow::bail!("Upgrade aborted.");
@@ -190,7 +190,7 @@ fn upgrade_cloud_cmd(
         cmd.force,
         |target_ver| {
             let target_ver_str = target_ver.to_string();
-            ver::print_version_hint(&target_ver, &query);
+            ver::print_version_hint(target_ver, &query);
             if !cmd.non_interactive {
                 question::Confirm::new(format!(
                     "This will upgrade {inst_name} to version {target_ver_str}.\
@@ -264,7 +264,7 @@ pub fn upgrade_cloud(
             force,
         };
 
-        cloud::ops::upgrade_cloud_instance(&client, &request)?;
+        cloud::ops::upgrade_cloud_instance(client, &request)?;
 
         Ok(UpgradeResult {
             action: UpgradeAction::Upgraded,
@@ -333,15 +333,15 @@ pub fn dump_and_stop(inst: &InstanceInfo, path: &Path) -> anyhow::Result<()> {
     // in case not started for now
     echo!("Dumping the database...");
     log::info!("Ensuring instance is started");
-    let res = control::do_start(&inst);
+    let res = control::do_start(inst);
     if let Err(err) = res {
         log::warn!("Error starting service: {:#}. Trying to start manually.",
             err);
         control::ensure_runstate_dir(&inst.name)?;
         let mut cmd = control::get_server_cmd(inst, false)?;
-        cmd.background_for(|| Ok(dump_instance(inst, &path)))?;
+        cmd.background_for(|| Ok(dump_instance(inst, path)))?;
     } else {
-        block_on_dump_instance(inst, &path)?;
+        block_on_dump_instance(inst, path)?;
         log::info!("Stopping instance before executable upgrade");
         control::do_stop(&inst.name)?;
     }
@@ -375,7 +375,7 @@ pub async fn dump_instance(inst: &InstanceInfo, destination: &Path)
         styler: None,
         conn_params: Connector::new(Ok(config)),
     };
-    commands::dump_all(&mut cli, &options, destination.as_ref(),
+    commands::dump_all(&mut cli, &options, destination,
                        true /*include_secrets*/).await?;
     Ok(())
 }

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -302,7 +302,7 @@ impl Eq for Build {}
 
 impl PartialOrd for Build {
     fn partial_cmp(&self, other: &Build) -> Option<Ordering> {
-        self.comparator().partial_cmp(&other.comparator())
+        Some(self.cmp(other))
     }
 }
 
@@ -337,9 +337,7 @@ impl Eq for Semver {}
 
 impl PartialOrd for Semver {
     fn partial_cmp(&self, other: &Semver) -> Option<Ordering> {
-        let a = (&self.0.major, &self.0.minor, &self.0.patch, &self.0.pre);
-        let b = (&other.0.major, &other.0.minor, &other.0.patch, &other.0.pre);
-        a.partial_cmp(&b)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -87,7 +87,7 @@ impl Wsl {
         }
         pro.arg("/usr/bin/edgedb");
         pro.no_proxy();
-        return pro
+        pro
     }
     #[cfg(windows)]
     fn copy_out(&self, src: impl AsRef<str>, destination: impl AsRef<Path>)
@@ -150,7 +150,7 @@ pub fn path_to_linux(path: &Path) -> anyhow::Result<String> {
     use std::path::Component::*;
     use std::path::Prefix::*;
     if !path.is_absolute() {
-        return Err(bug::error("path must be absolute"))?;
+        Err(bug::error("path must be absolute"))?;
     }
 
     let mut result = String::with_capacity(
@@ -216,9 +216,9 @@ pub fn create_instance(options: &options::Create, name: &str,
         .run()?;
 
     if let Some(dir) = paths.credentials.parent() {
-        fs_err::create_dir_all(&dir)?;
+        fs_err::create_dir_all(dir)?;
     }
-    wsl.copy_out(credentials_linux(&name), &paths.credentials)?;
+    wsl.copy_out(credentials_linux(name), &paths.credentials)?;
 
     Ok(())
 }
@@ -273,7 +273,7 @@ fn read_wsl(path: &Path) -> anyhow::Result<WslInfo> {
 #[context("cannot unpack debian distro from {:?}", zip_path)]
 fn unpack_appx(zip_path: &Path, dest: &Path) -> anyhow::Result<()> {
     let mut zip = zip::ZipArchive::new(
-        io::BufReader::new(fs::File::open(&zip_path)?))?;
+        io::BufReader::new(fs::File::open(zip_path)?))?;
     let name = zip.file_names()
         .find(|name| {
             let lower = name.to_lowercase();
@@ -292,7 +292,7 @@ fn unpack_appx(zip_path: &Path, dest: &Path) -> anyhow::Result<()> {
 #[context("cannot unpack root filesystem from {:?}", zip_path)]
 fn unpack_root(zip_path: &Path, dest: &Path) -> anyhow::Result<()> {
     let mut zip = zip::ZipArchive::new(
-        io::BufReader::new(fs::File::open(&zip_path)?))?;
+        io::BufReader::new(fs::File::open(zip_path)?))?;
     let name = zip.file_names()
         .find(|name| name.eq_ignore_ascii_case("install.tar.gz"))
         .ok_or_else(|| anyhow::anyhow!(
@@ -577,8 +577,8 @@ fn try_get_wsl() -> anyhow::Result<&'static Wsl> {
     match WSL.get_or_try_init(|| get_wsl_distro(false)) {
         Ok(v) => Ok(v),
         Err(e) if e.is::<NoDistribution>() => {
-            return Err(e).hint("WSL is initialized automatically on \
-              `edgedb project init` or `edgedb instance create`")?;
+            Err(e).hint("WSL is initialized automatically on \
+              `edgedb project init` or `edgedb instance create`")?
         }
         Err(e) => Err(e),
     }
@@ -607,8 +607,8 @@ pub fn create_service(info: &InstanceInfo) -> anyhow::Result<()> {
 }
 
 fn create_and_start(wsl: &Wsl, name: &str) -> anyhow::Result<()> {
-    wsl.edgedb().arg("instance").arg("start").arg("-I").arg(&name).run()?;
-    fs_err::write(service_file(&name)?, format!("wsl \
+    wsl.edgedb().arg("instance").arg("start").arg("-I").arg(name).run()?;
+    fs_err::write(service_file(name)?, format!("wsl \
         --distribution {} --user edgedb \
         /usr/bin/edgedb instance start -I {}",
         &wsl.distribution, &name))?;
@@ -642,7 +642,7 @@ pub fn server_cmd(instance: &str, _is_shutdown_supported: bool)
 pub fn daemon_start(instance: &str) -> anyhow::Result<()> {
     let wsl = try_get_wsl()?;
     wsl.edgedb()
-        .arg("instance").arg("start").arg("-I").arg(&instance)
+        .arg("instance").arg("start").arg("-I").arg(instance)
         .no_proxy().run()?;
     Ok(())
 }
@@ -945,7 +945,7 @@ pub fn revert(options: &options::Revert, name: &str) -> anyhow::Result<()> {
 fn get_instance_data_dir(name: &str, wsl: &Wsl) -> anyhow::Result<String> {
     let data_dir = if name == "_localdev" {
         match env::var("EDGEDB_SERVER_DEV_DIR") {
-            Ok(path) => if path.ends_with("/") {
+            Ok(path) => if path.ends_with('/') {
                 path
             } else {
                 path + "/"

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -35,11 +35,11 @@ use crate::print::{self, echo, Highlight};
 use crate::process;
 
 const CURRENT_DISTRO: &str = "EdgeDB.WSL.1";
-const DISTRO_URL: Lazy<Url> = Lazy::new(|| {
+static DISTRO_URL: Lazy<Url> = Lazy::new(|| {
     "https://aka.ms/wsl-debian-gnulinux".parse().expect("wsl url parsed")
 });
 const CERT_UPDATE_INTERVAL: Duration = Duration::from_secs(30*86400);
-const IS_IN_WSL: Lazy<bool> = Lazy::new(|| {
+static IS_IN_WSL: Lazy<bool> = Lazy::new(|| {
     if cfg!(target_os="linux") {
         fs::read_to_string("/proc/version")
             .map(|s| s.contains("Microsoft"))

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -150,7 +150,7 @@ pub fn path_to_linux(path: &Path) -> anyhow::Result<String> {
     use std::path::Component::*;
     use std::path::Prefix::*;
     if !path.is_absolute() {
-        Err(bug::error("path must be absolute"))?;
+        return Err(bug::error("path must be absolute"));
     }
 
     let mut result = String::with_capacity(

--- a/src/print/buffer.rs
+++ b/src/print/buffer.rs
@@ -131,7 +131,7 @@ impl<T: Output> Printer<T> {
     pub(in crate::print) fn write_indent(&mut self) -> Result<T::Error> {
         //debug_assert_eq!(self.column, 0);
         //debug_assert!(!self.flow);
-        const INDENT32: &'static str = "                                ";
+        const INDENT32: &str = "                                ";
         for _ in 0..(self.cur_indent / INDENT32.len()) {
             self.buffer.push_str(INDENT32);
         }

--- a/src/print/color.rs
+++ b/src/print/color.rs
@@ -104,7 +104,7 @@ pub trait Highlight: fmt::Display + Sized {
 }
 
 fn theme() -> &'static Theme {
-    &*THEME
+    &THEME
 }
 
 impl<T: fmt::Display> Highlight for &T {

--- a/src/print/color.rs
+++ b/src/print/color.rs
@@ -65,6 +65,7 @@ pub trait Highlight: fmt::Display + Sized {
             value: self,
         }
     }
+    #[allow(dead_code)]
     fn title(self) -> Colored<Self> {
         Colored {
             style: theme().title,

--- a/src/print/formatter.rs
+++ b/src/print/formatter.rs
@@ -28,6 +28,7 @@ pub trait Formatter {
     fn const_enum<T: ToString>(&mut self, s: T) -> Result<Self::Error>;
     fn nil(&mut self) -> Result<Self::Error>;
     fn typed<S: ToString>(&mut self, typ: &str, s: S) -> Result<Self::Error>;
+    #[allow(dead_code)]
     fn error<S: ToString>(&mut self, typ: &str, s: S) -> Result<Self::Error>;
     fn set<F>(&mut self, f: F) -> Result<Self::Error>
         where F: FnMut(&mut Self) -> Result<Self::Error>;

--- a/src/print/formatter.rs
+++ b/src/print/formatter.rs
@@ -227,7 +227,7 @@ impl<T: Output> Formatter for Printer<T>
             )?;
         } else {
             self.block(
-                self.styler.apply(Style::ArrayLiteral, &"["),
+                self.styler.apply(Style::ArrayLiteral, "["),
                 f,
                 self.styler.apply(Style::ArrayLiteral, "]"),
             )?;

--- a/src/print/formatter.rs
+++ b/src/print/formatter.rs
@@ -248,7 +248,7 @@ impl<T: Output> Formatter for Printer<T>
             let mut printed = 0;
             let mut savepoint = (self.buffer.len(), self.column);
             let mut first_try = || {
-                for item in iter.clone() {
+                for item in iter {
                     self.const_number(item)?;
                     self.comma()?;
                     let col_left = self.max_width.saturating_sub(self.column);

--- a/src/print/json.rs
+++ b/src/print/json.rs
@@ -24,19 +24,10 @@ impl FormatExt for Value {
             V::Object(dict) => {
                 prn.json_object(|prn| {
                     for (key, value) in dict {
-                        if key.starts_with('@') {
-                            prn.object_field(
-                                serde_json::to_string(key)
-                                .expect("cannot serialize string")
-                                .as_ref(),
-                            false)?;
-                        } else {
-                            prn.object_field(
-                                serde_json::to_string(key)
-                                .expect("cannot serialize string")
-                                .as_ref(),
-                                false)?;
-                        }
+                        let json_str = serde_json::to_string(key)
+                            .expect("cannot serialize string");
+                        prn.object_field(json_str.as_str(), false)?;
+
                         value.format(prn)?;
                         prn.comma()?;
                     }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -316,10 +316,10 @@ pub fn json_to_string<I: FormatExt>(items: &[I], config: &Config)
 
         styler: config.styler.clone(),
     };
-    match format_rows_str(&mut prn, &items, "[", "]", false) {
+    match format_rows_str(&mut prn, items, "[", "]", false) {
         Ok(()) => {},
         Err(Exception::DisableFlow) => {
-            format_rows_str(&mut prn, &items, "[", "]", true).unwrap_exc()?;
+            format_rows_str(&mut prn, items, "[", "]", true).unwrap_exc()?;
         }
         Err(Exception::Error(e)) => return Err(e),
     };

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -151,8 +151,9 @@ async fn format_rows_buf<S, I, E, O>(prn: &mut Printer<O>, rows: &mut S,
             if row_buf.len() > limit {
                 prn.ellipsis().wrap_err(PrintErr)?;
                 // consume extra items if any
-                while let Some(_) = rows.next().await
-                    .transpose().wrap_err(StreamErr)? {}
+                while rows.next().await
+                    .transpose().wrap_err(StreamErr)?
+                    .is_some() {}
                 break;
             }
         }
@@ -198,8 +199,9 @@ async fn format_rows<S, I, E, O>(prn: &mut Printer<O>,
             if counter > limit {
                 prn.ellipsis().wrap_err(PrintErr)?;
                 // consume extra items if any
-                while let Some(_) = rows.next().await
-                    .transpose().wrap_err(StreamErr)? {}
+                while rows.next().await
+                    .transpose().wrap_err(StreamErr)?
+                    .is_some() {}
                 break;
             }
         }

--- a/src/print/native.rs
+++ b/src/print/native.rs
@@ -32,7 +32,7 @@ fn format_string(s: &str, expanded: bool) -> String {
         }
     }
     buf.push('\'');
-    return buf;
+    buf
 }
 
 fn format_bytes(bytes: &[u8]) -> String {
@@ -55,7 +55,7 @@ fn format_bytes(bytes: &[u8]) -> String {
         }
     }
     buf.push('\'');
-    return buf;
+    buf
 }
 
 fn format_bigint(bint: BigInt) -> String {
@@ -63,9 +63,9 @@ fn format_bigint(bint: BigInt) -> String {
     let no_zeros = txt.trim_end_matches('0');
     let zeros = txt.len() - no_zeros.len();
     if zeros > 5 {
-        return format!("{}e{}n", no_zeros, zeros);
+        format!("{}e{}n", no_zeros, zeros)
     } else {
-        return format!("{}n", txt);
+        format!("{}n", txt)
     }
 }
 
@@ -75,17 +75,17 @@ fn format_decimal(value: BigDecimal) -> String {
         if txt.starts_with("0.00000") {
             let no_zeros = txt[2..].trim_start_matches('0');
             let zeros = txt.len()-2 - no_zeros.len();
-            return format!("0.{}e-{}", no_zeros, zeros);
+            format!("0.{}e-{}", no_zeros, zeros)
         } else {
-            return format!("{}n", txt);
+            format!("{}n", txt)
         }
     } else {
         let no_zeros = txt.trim_end_matches('0');
         let zeros = txt.len() - no_zeros.len();
         if zeros > 5 {
-            return format!("{}.0e{}n", no_zeros, zeros);
+            format!("{}.0e{}n", no_zeros, zeros)
         } else {
-            return format!("{}.0n", txt);
+            format!("{}.0n", txt)
         }
     }
 }

--- a/src/print/style.rs
+++ b/src/print/style.rs
@@ -31,9 +31,6 @@ pub enum Style {
 }
 
 #[derive(Debug)]
-pub struct Styled<T>(T, Style);
-
-#[derive(Debug)]
 pub struct Item(Option<Color>, Option<TermStyle>);
 
 #[derive(Debug)]

--- a/src/print/style.rs
+++ b/src/print/style.rs
@@ -7,6 +7,7 @@ use colorful::core::color_string::CString;
 
 
 #[derive(Hash, PartialEq, Eq, Debug, Clone, Copy)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum Style {
     Decorator,
     Comment,

--- a/src/print/style.rs
+++ b/src/print/style.rs
@@ -66,23 +66,23 @@ impl Styler {
         t.insert(Error,             Item(Some(Color::IndianRed1c), None));
         t.insert(BackslashCommand,  Item(Some(Color::MediumPurple2a), Some(Bold)));
 
-        return Styler(Arc::new(Theme {
+        Styler(Arc::new(Theme {
             items: t,
-        }));
+        }))
     }
     pub fn write(&self, style: Style, data: &str, buf: &mut String) {
         write!(buf, "{}", self.apply(style, data)).unwrap();
     }
     pub fn apply(&self, style: Style, data: &str) -> CString {
         if let Some(Item(col, style)) = self.0.items.get(&style) {
-            return match (col, style) {
+            match (col, style) {
                 (Some(c), Some(s)) => data.color(*c).style(*s),
                 (Some(c), None) => data.color(*c),
                 (None, Some(s)) => data.style(*s),
                 (None, None) => CString::new(data)
             }
         } else {
-            return CString::new(data);
+            CString::new(data)
         }
     }
 }

--- a/src/print/tests.rs
+++ b/src/print/tests.rs
@@ -30,13 +30,13 @@ impl<I: Clone> Stream for UnfusedStream<'_, I> {
         -> task::Poll<Option<Self::Item>>
     {
         let val = self.0.as_mut().expect("no poll after EOS");
-        if val.len() == 0 {
+        if val.is_empty() {
             self.0.take().unwrap();
             return task::Poll::Ready(None);
         }
         let item = val[0].clone();
         *val = &val[1..];
-        return task::Poll::Ready(Some(Ok(item)));
+        task::Poll::Ready(Some(Ok(item)))
     }
 }
 
@@ -81,7 +81,7 @@ fn json_fmt_width(w: usize, j: &str) -> String {
     print::json_to_string(
         serde_json::from_str::<serde_json::Value>(j).unwrap()
         .as_array().unwrap(),
-        &Config::new().max_width(w))
+        Config::new().max_width(w))
     .unwrap()
 }
 
@@ -204,30 +204,30 @@ fn set_ellipsis() {
 fn vector() {
     use crate::repl::VectorLimit::*;
     assert_eq!(test_format(&[
-        Value::Vector((0..10).into_iter().map(|v| v as _).collect()),
+        Value::Vector((0..10).map(|v| v as _).collect()),
     ]).unwrap(), "{<ext::pgvector::vector>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}");
     assert_eq!(
         test_format_cfg(&[
-            Value::Vector((0..10).into_iter().map(|v| v as _).collect()),
+            Value::Vector((0..10).map(|v| v as _).collect()),
         ], Config::new().max_vector_length(Fixed(2))).unwrap(),
         "{<ext::pgvector::vector>[0, 1, ...]}",
     );
     assert_eq!(
         test_format_cfg(&[
-            Value::Vector((0..10).into_iter().map(|v| v as _).collect()),
+            Value::Vector((0..10).map(|v| v as _).collect()),
         ], Config::new().max_vector_length(Unlimited)).unwrap(),
         "{<ext::pgvector::vector>[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}",
     );
     assert_eq!(
         test_format_cfg(&[
-            Value::Vector((0..10).into_iter().map(|v| v as _).collect()),
+            Value::Vector((0..10).map(|v| v as _).collect()),
         ], Config::new().max_width(20).max_vector_length(Auto)).unwrap(),
         "{\n  \
            <ext::pgvector::vector>[\n    0,\n    1,\n    2,\n    ...\n  ],\n}",
     );
     assert_eq!(
         test_format_cfg(&[
-            Value::Vector((0..10).into_iter().map(|v| v as _).collect()),
+            Value::Vector((0..10).map(|v| v as _).collect()),
         ], Config::new().max_width(50).max_vector_length(Auto)).unwrap(),
         "{\n  <ext::pgvector::vector>[0, 1, 2, 3, 4, 5, ...],\n}",
     );
@@ -404,7 +404,7 @@ fn all_widths_vec_obj() {
             test_format_cfg(&[
                 Value::Object { shape: shape.clone(), fields: vec![
                     Some(Value::Vector(
-                        (0..200).into_iter().map(|v| v as _).collect()
+                        (0..200).map(|v| v as _).collect()
                     )),
                 ]},
             ], Config::new().max_width(width).max_vector_length(mvec)).unwrap();
@@ -418,7 +418,7 @@ fn all_widths_vec() {
     for mvec in [Auto, Unlimited, Fixed(8), Fixed(35)] {
         for width in 0..100 {
             test_format_cfg(&[
-                Value::Vector((0..200).into_iter().map(|v| v as _).collect()),
+                Value::Vector((0..200).map(|v| v as _).collect()),
             ], Config::new().max_width(width).max_vector_length(mvec)).unwrap();
         }
     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -36,15 +36,15 @@ static HAS_UTF8_LOCALE: Lazy<bool> = Lazy::new(|| {
             if loc != null_mut() {
                 libc::freelocale(loc);
                 log::debug!("UTF-8 locale is enabled");
-                return true;
+                true
             } else {
                 log::debug!("Cannot load C.UTF-8");
-                return false;
+                false
             }
         }
     } else {
         log::debug!("UTF-8 not enabled (non-utf-8 locale)");
-        return false;
+        false
     }
 });
 
@@ -196,7 +196,7 @@ impl Native {
         if cfg!(target_os="macos") {
             me.env("LC_CTYPE", "UTF-8");
         }
-        return me;
+        me
     }
     pub fn no_proxy(&mut self) -> &mut Self {
         self.proxy = false;
@@ -212,11 +212,11 @@ impl Native {
     pub fn log_file(&mut self, path: &Path) -> anyhow::Result<&mut Self>
     {
         if let Some(dir) = path.parent() {
-            fs::create_dir_all(&dir)?;
+            fs::create_dir_all(dir)?;
         }
         let file = fs::OpenOptions::new()
-            .write(true).append(true).create(true)
-            .open(&path)
+            .append(true).create(true)
+            .open(path)
             .with_context(|| format!("cannot open log file {:?}", path))?;
         self.command.stdout(file.try_clone().context("cannot clone file")?);
         self.command.stderr(file);
@@ -365,8 +365,8 @@ impl Native {
             (child_result, _, _) = async {
                 tokio::join!(
                     child.wait(),
-                    stdout_loop(mark, out, capture_out.then(|| &mut stdout)),
-                    stdout_loop(mark, err, capture_err.then(|| &mut stderr)),
+                    stdout_loop(mark, out, capture_out.then_some(&mut stdout)),
+                    stdout_loop(mark, err, capture_err.then_some(&mut stderr)),
                 )
             } => child_result,
             _ = self.signal_loop(pid, &term) => unreachable!(),
@@ -490,7 +490,7 @@ impl Native {
         remove_pid_file(&self.pid_file);
         term.err_if_occurred()?;
 
-        return result;
+        result
     }
 
     async fn _feed(&mut self, data: &[u8]) -> anyhow::Result<()> {
@@ -697,7 +697,7 @@ impl Native {
             cstr.extend(key.as_bytes());
             cstr.push(b'=');
             cstr.extend(val.as_bytes());
-            return Ok(CString::new(cstr)?);
+            Ok(CString::new(cstr)?)
         }
 
         let mut env = Vec::new();
@@ -804,14 +804,14 @@ fn write_pid_file(path: &Option<PathBuf>, pid: u32) {
 
 fn remove_pid_file(path: &Option<PathBuf>) {
     if let Some(path) = path {
-        fs::remove_file(&path).map_err(|e| {
+        fs::remove_file(path).map_err(|e| {
             log::error!("Cannot remove pid file {:?}: {:#}", path, e);
         }).ok();
     }
 }
 
 fn _write_pid_file(path: &Path, pid: u32) -> anyhow::Result<()> {
-    let tmp_path = tmp_file_path(&path);
+    let tmp_path = tmp_file_path(path);
     fs::remove_file(&tmp_path).ok();
     fs::write(&tmp_path, pid.to_string().as_bytes())?;
     fs::rename(&tmp_path, path)?;

--- a/src/process.rs
+++ b/src/process.rs
@@ -33,7 +33,7 @@ static HAS_UTF8_LOCALE: Lazy<bool> = Lazy::new(|| {
             let c_utf8 = CString::new("C.UTF-8").unwrap();
             let loc = libc::newlocale(libc::LC_ALL,
                                       c_utf8.as_ptr(), null_mut());
-            if loc != null_mut() {
+            if !loc.is_null() {
                 libc::freelocale(loc);
                 log::debug!("UTF-8 locale is enabled");
                 true

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -72,7 +72,7 @@ impl Hinter for EdgeqlHelper {
     fn hint(&self, line: &str, pos: usize, _ctx: &Context)
         -> Option<Self::Hint>
     {
-        return completion::hint(line, pos);
+        completion::hint(line, pos)
     }
 }
 
@@ -82,7 +82,7 @@ impl Highlighter for EdgeqlHelper {
         -> Cow<'b, str>
     {
         if info.line_no() > 0 {
-            return format!("{0:.>1$}", " ", prompt.len()).into();
+            format!("{0:.>1$}", " ", prompt.len()).into()
         } else if prompt.ends_with("> ") {
             let content = &prompt[..prompt.len()-2];
             if content.ends_with(TX_MARKER) {
@@ -113,7 +113,7 @@ impl Highlighter for EdgeqlHelper {
                 highlight::backslash(&mut buf, &data[..bytes], &self.styler);
                 data = &data[bytes..];
             } else {
-                match full_statement(&data.as_bytes(), None) {
+                match full_statement(data.as_bytes(), None) {
                     Ok(bytes) => {
                         highlight::edgeql(&mut buf,
                             &data[..bytes], &self.styler);
@@ -121,19 +121,19 @@ impl Highlighter for EdgeqlHelper {
                     }
                     Err(_cont) => {
                         highlight::edgeql(&mut buf,
-                            &data, &self.styler);
-                        data = &"";
+                            data, &self.styler);
+                        data = "";
                     }
                 }
             }
         }
     }
-    fn highlight_char<'l>(&self, _line: &'l str, _pos: usize) -> bool {
+    fn highlight_char(&self, _line: &str, _pos: usize) -> bool {
         // TODO(tailhook) optimize: only need to return true on insert
         true
     }
     fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
-        return hint.rgb(0x56, 0x56, 0x56).to_string().into()
+        hint.rgb(0x56, 0x56, 0x56).to_string().into()
     }
     fn highlight_candidate<'h>(&self, item: &'h str, _typ: CompletionType)
         -> std::borrow::Cow<'h, str>
@@ -145,9 +145,9 @@ impl Highlighter for EdgeqlHelper {
             let (value, descr) = item.split_at(pos);
             buf.push_str(value);
             write!(buf, "{}", descr.light_gray()).unwrap();
-            return buf.into();
+            buf.into()
         } else {
-            return item.into();
+            item.into()
         }
     }
     fn has_continuation_prompt(&self) -> bool {
@@ -165,9 +165,9 @@ impl Validator for EdgeqlHelper {
             completion::Current::Backslash(_) => true,
         };
         if complete {
-            return Ok(ValidationResult::Valid(None));
+            Ok(ValidationResult::Valid(None))
         } else {
-            return Ok(ValidationResult::Incomplete);
+            Ok(ValidationResult::Incomplete)
         }
     }
 }
@@ -229,7 +229,7 @@ pub fn create_editor(config: &ConfigBuilder) -> Editor<EdgeqlHelper> {
     editor.set_helper(Some(EdgeqlHelper {
         styler: Styler::dark_256(),
     }));
-    return editor;
+    editor
 }
 
 pub fn var_editor(config: &ConfigBuilder, var_type: &Arc<dyn VariableInput>)
@@ -242,7 +242,7 @@ pub fn var_editor(config: &ConfigBuilder, var_type: &Arc<dyn VariableInput>)
     load_history(&mut editor, &history_name).map_err(|e| {
         log::warn!("Cannot load history: {:#}", e);
     }).ok();
-    return editor;
+    editor
 }
 
 pub fn edgeql_input(prompt: &str, editor: &mut Editor<EdgeqlHelper>,
@@ -250,7 +250,7 @@ pub fn edgeql_input(prompt: &str, editor: &mut Editor<EdgeqlHelper>,
     -> anyhow::Result<()>
 {
     let text = match
-        editor.readline_with_initial(&prompt, (&initial, ""))
+        editor.readline_with_initial(prompt, (initial, ""))
     {
         Ok(text) => text,
         Err(ReadlineError::Eof) => {
@@ -362,7 +362,7 @@ pub fn main(mut control: Receiver<Control>)
                         .saturating_sub(1)
                         .saturating_add(e)
                 } else {
-                    e as isize
+                    e
                 };
                 if normal < 0 {
                     eprintln!("No history entry {}", e);

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 
-use anyhow::{self, Context as _Context};
+use anyhow::Context as _Context;
 use dirs::data_local_dir;
 use rustyline::completion::Completer;
 use rustyline::config::{EditMode, CompletionType, Builder as ConfigBuilder};
@@ -14,7 +14,7 @@ use rustyline::hint::Hinter;
 use rustyline::history::History;
 use rustyline::validate::{Validator, ValidationResult, ValidationContext};
 use rustyline::{Editor, Config, Helper, Context};
-use rustyline::{self, error::ReadlineError, KeyEvent, Modifiers, Cmd};
+use rustyline::{error::ReadlineError, KeyEvent, Modifiers, Cmd};
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::oneshot::Sender;
 

--- a/src/prompt/variable.rs
+++ b/src/prompt/variable.rs
@@ -183,7 +183,7 @@ impl Hinter for VarHelper {
     fn hint(&self, line: &str, _pos: usize, _ctx: &Context)
         -> Option<Self::Hint>
     {
-        if line == "" {  // be friendly from the start
+        if line.is_empty() {  // be friendly from the start
             return None;
         }
         match self.var_type.parse(line) {
@@ -202,9 +202,9 @@ impl Highlighter for VarHelper {
         }
     }
     fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
-        return hint.rgb(0x56, 0x56, 0x56).to_string().into()
+        hint.rgb(0x56, 0x56, 0x56).to_string().into()
     }
-    fn highlight_char<'l>(&self, _line: &'l str, _pos: usize) -> bool {
+    fn highlight_char(&self, _line: &str, _pos: usize) -> bool {
         // needed to highlight hint
         true
     }

--- a/src/question.rs
+++ b/src/question.rs
@@ -38,11 +38,14 @@ pub struct Choice<'a, T: 'a> {
 }
 
 pub fn read_choice() -> anyhow::Result<std::string::String> {
-    for line in stdin().lock().lines() {
-        let line = line.context("reading user input")?;
-        return Ok(line.trim().to_lowercase())
-    }
-    anyhow::bail!("Unexpected end of input");
+    let mut lines = stdin().lock().lines();
+
+    let Some(line) = lines.next() else {
+        anyhow::bail!("Unexpected end of input");
+    };
+
+    let line = line.context("reading user input")?;
+    Ok(line.trim().to_lowercase())
 }
 
 impl<'a, T: Clone + 'a> Numeric<'a, T> {

--- a/src/question.rs
+++ b/src/question.rs
@@ -126,11 +126,11 @@ impl<'a> String<'a> {
             (initial, ""),
         )?;
         let mut val = val.trim();
-        if val == "" {
+        if val.is_empty() {
             val = self.default;
         }
         self.initial = Some(val.into());
-        return Ok(val.into());
+        Ok(val.into())
     }
 }
 
@@ -185,12 +185,12 @@ impl<'a> Confirm<'a> {
             let val = editor.readline_with_initial("> ", (&initial, ""))?;
             let val = val.trim();
             if self.is_dangerous {
-                match val.as_ref() {
+                match val {
                     "Yes" => return Ok(true),
                     _ => return Ok(false),
                 }
             } else {
-                match val.as_ref() {
+                match val {
                     "y" | "Y" | "yes" | "Yes" | "YES" => return Ok(true),
                     "n" | "N" | "no" | "No" | "NO" => return Ok(false),
                     "" if self.default.is_some() => {
@@ -243,7 +243,7 @@ impl<'a, T: Clone + 'a> Choice<'a, T> {
             let val = val.trim();
             if matches!(val, "?" | "h" | "help") {
                 const HELP: &str = "h or ?";
-                let pad = (&self.choices)
+                let pad = self.choices
                             .iter()
                             .map(|x| x.input.join(" or ").len())
                             .max()
@@ -257,7 +257,7 @@ impl<'a, T: Clone + 'a> Choice<'a, T> {
                         pad=pad
                     )
                 }
-                println!("{:pad$} - {}", HELP, "print help", pad=pad);
+                println!("{:pad$} - print help", HELP, pad=pad);
                 continue;
             }
             for choice in &self.choices {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -161,7 +161,7 @@ impl State {
     }
     fn print_banner(&self, version: &ver::Build) -> anyhow::Result<()> {
         echo!(
-            format!("{}\rEdgeDB", ansi_escapes::EraseLine.to_string()).light_gray(),
+            format!("{}\rEdgeDB", ansi_escapes::EraseLine).light_gray(),
             version.to_string().light_gray(),
             format_args!("(repl {})", env!("CARGO_PKG_VERSION")).fade(),
         );
@@ -172,8 +172,8 @@ impl State {
         params.branch(branch)?;
         let mut conn = params.connect_interactive().await?;
         let fetched_version = conn.get_version().await?;
-        if self.last_version.as_ref() != Some(&fetched_version) {
-            self.print_banner(&fetched_version)?;
+        if self.last_version.as_ref() != Some(fetched_version) {
+            self.print_banner(fetched_version)?;
             self.last_version = Some(fetched_version.to_owned());
         }
         self.conn_params = params;
@@ -251,7 +251,7 @@ impl State {
         };
 
         let current_database = match &self.current_branch {
-            Some(db) => &db,
+            Some(db) => db,
             None => &self.branch,
         };
 
@@ -336,7 +336,7 @@ impl State {
     }
     pub fn try_update_state(&mut self) -> anyhow::Result<bool> {
         if let Some(conn) = &mut self.connection {
-            if self.edgeql_state.data.len() > 0 {
+            if !self.edgeql_state.data.is_empty() {
                 let desc = self.edgeql_state_desc.decode()?;
                 let codec = desc.build_codec()?;
                 let value = codec.decode(&self.edgeql_state.data)?;
@@ -457,7 +457,7 @@ impl std::str::FromStr for VectorLimit {
             "unlimited" => Ok(VectorLimit::Unlimited),
             "auto" => Ok(VectorLimit::Auto),
             _ => s.parse().map(VectorLimit::Fixed)
-                .map_err(|_| "expected integer, `unlimited` or `auto`".into()),
+                .map_err(|_| "expected integer, `unlimited` or `auto`"),
         }
     }
 }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -33,7 +33,7 @@ pub async fn read_statement<T: AsyncRead>(buf: &mut BytesMut, stream: &mut T)
         }
     };
     let data = buf.split_to(statement_len).freeze();
-    return Ok(data);
+    Ok(data)
 }
 
 impl fmt::Display for EndOfFile {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -70,11 +70,8 @@ async fn input_item(name: &str, mut item: &Descriptor, all: &Typedesc,
     state: &mut repl::PromptRpc, optional: bool)
     -> Result<Option<Value>, anyhow::Error>
 {
-    match item {
-        Descriptor::Scalar(s) => {
-            item = all.get(s.base_type_pos)?;
-        }
-        _ => {},
+    if let Descriptor::Scalar(s) = item {
+        item = all.get(s.base_type_pos)?;
     }
     match item {
         Descriptor::BaseScalar(s) => {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -29,7 +29,7 @@ pub async fn input_variables(desc: &Typedesc, state: &mut repl::PromptRpc)
                     &format!("{}", idx), desc.get(*el)?, desc, state, false,
                 ).await?.expect("no optional"));
             }
-            return Ok(Value::Tuple(val));
+            Ok(Value::Tuple(val))
         }
         Some(Descriptor::NamedTuple(tuple)) if desc.proto().is_at_most(0, 11)
         => {
@@ -40,7 +40,7 @@ pub async fn input_variables(desc: &Typedesc, state: &mut repl::PromptRpc)
                     &el.name, desc.get(el.type_pos)?, desc, state, false
                 ).await?.expect("no optional"));
             }
-            return Ok(Value::NamedTuple { shape, fields });
+            Ok(Value::NamedTuple { shape, fields })
         }
         Some(Descriptor::ObjectShape(obj)) if desc.proto().is_at_least(0, 12)
         => {
@@ -53,15 +53,15 @@ pub async fn input_variables(desc: &Typedesc, state: &mut repl::PromptRpc)
                     &el.name, desc.get(el.type_pos)?, desc, state, optional,
                 ).await?);
             }
-            return Ok(Value::Object { shape, fields });
+            Ok(Value::Object { shape, fields })
         }
         Some(root) => {
-            return Err(anyhow::anyhow!(
-                "Unknown input type descriptor: {:?}", root));
+            Err(anyhow::anyhow!(
+                "Unknown input type descriptor: {:?}", root))
         }
         // Since protocol 0.12
         None => {
-            return Ok(Value::Nothing);
+            Ok(Value::Nothing)
         }
     }
 }

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -100,7 +100,7 @@ fn _check(cache_dir: &Path, strict: bool) -> anyhow::Result<()> {
         });
     if let Some(ver) = &pkg {
         if &self_version < ver {
-            newer_warning(&ver);
+            newer_warning(ver);
         }
     }
     log::debug!("Remote version {:?}", pkg);

--- a/src/watch/main.rs
+++ b/src/watch/main.rs
@@ -199,7 +199,7 @@ impl From<anyhow::Error> for ErrorJson {
             ErrorJson {
                 kind: "WatchError",
                 message: format!("error when trying to update the schema.\n  \
-                    Original error: {}", err.to_string()),
+                    Original error: {}", err),
                 hint: Some("see the window running \
                            `edgedb watch` for more info".into()),
                 details: None,

--- a/tests/certs.rs
+++ b/tests/certs.rs
@@ -66,7 +66,7 @@ fn mk_ca_cert() -> Result<(X509, PKey<Private>), ErrorStack> {
 /// Make a X509 request with the given private key
 fn mk_request(privkey: &PKey<Private>) -> Result<X509Req, ErrorStack> {
     let mut req_builder = X509ReqBuilder::new()?;
-    req_builder.set_pubkey(&privkey)?;
+    req_builder.set_pubkey(privkey)?;
 
     let mut x509_name = X509NameBuilder::new()?;
     x509_name.append_entry_by_text("C", "US")?;
@@ -76,7 +76,7 @@ fn mk_request(privkey: &PKey<Private>) -> Result<X509Req, ErrorStack> {
     let x509_name = x509_name.build();
     req_builder.set_subject_name(&x509_name)?;
 
-    req_builder.sign(&privkey, MessageDigest::sha256())?;
+    req_builder.sign(privkey, MessageDigest::sha256())?;
     let req = req_builder.build();
     Ok(req)
 }
@@ -134,7 +134,7 @@ fn mk_ca_signed_cert(
         .build(&cert_builder.x509v3_context(Some(ca_cert), None))?;
     cert_builder.append_extension(subject_alt_name)?;
 
-    cert_builder.sign(&ca_privkey, MessageDigest::sha256())?;
+    cert_builder.sign(ca_privkey, MessageDigest::sha256())?;
     let cert = cert_builder.build();
 
     Ok((cert, privkey))

--- a/tests/docker.rs
+++ b/tests/docker.rs
@@ -53,6 +53,12 @@ edgedb.connect(process.argv[2])
     "###
 }
 
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Context {
     pub fn new() -> Context {
         Context {
@@ -90,10 +96,9 @@ impl Context {
         self.add_file("sudoers", sudoers())
     }
     pub fn add_edbconnect(self) -> anyhow::Result<Self> {
-        Ok(self
+        self
             .add_file("edbconnect.py", edbconnect_py())?
-            .add_file("edbconnect.js", edbconnect_js())?
-        )
+            .add_file("edbconnect.js", edbconnect_js())
     }
     pub fn add_bin(self) -> anyhow::Result<Self> {
         self.add_file_mode("edgedb",
@@ -148,7 +153,7 @@ pub fn run(tagname: &str, script: &str) -> assert_cmd::assert::Assert {
         .arg("--mount=type=tmpfs,destination=/run/user/1000,tmpfs-mode=777")
         .arg("-u").arg("1000")
         .arg(tagname)
-        .args(&["sh", "-exc", &script])
+        .args(["sh", "-exc", &script])
         .assert()
 }
 
@@ -175,7 +180,7 @@ pub fn run_docker(tagname: &str, script: &str)
         .arg(format!("--volume={0}:{0}", path))
         .arg("--net=host")
         .arg(tagname)
-        .args(&["bash", "-exc", &script])
+        .args(["bash", "-exc", &script])
         .assert()
 }
 
@@ -203,7 +208,7 @@ pub fn run_systemd(tagname: &str, script: &str)
         .arg("--tmpfs=/run/systemd/system")
         .arg("--privileged")
         .arg(tagname)
-        .args(&["sh", "-exc", &script])
+        .args(["sh", "-exc", &script])
         .assert()
 }
 
@@ -216,7 +221,7 @@ pub fn run_with(tagname: &str, script: &str, link: &str)
         .arg("-u").arg("1000")
         .arg(format!("--link={0}:{0}", link))
         .arg(tagname)
-        .args(&["sh", "-exc", script])
+        .args(["sh", "-exc", script])
         .assert()
 }
 

--- a/tests/docker_portable_wrapper.rs
+++ b/tests/docker_portable_wrapper.rs
@@ -50,7 +50,7 @@ static TEST_EXECUTABLES: Lazy<HashMap<String, PathBuf>> = Lazy::new(|| {
         };
         executables.insert(art.target.name.clone(), art.executable.into());
     }
-    assert!(executables.len() > 0);
+    assert!(!executables.is_empty());
 
     let mut context = docker::Context::new();
     context = context.add_file("Dockerfile", dockerfile()).unwrap();
@@ -73,7 +73,7 @@ static TEST_EXECUTABLES: Lazy<HashMap<String, PathBuf>> = Lazy::new(|| {
     docker::build_image(context, "edgedb_test_portable").unwrap();
     shutdown_hooks::add_shutdown_hook(delete_docker_image);
 
-    return executables;
+    executables
 });
 
 extern fn delete_docker_image() {
@@ -142,7 +142,7 @@ fn run_test(name: &'static str) {
         .arg("--tmpfs=/run/systemd/system")
         .arg("--privileged")
         .arg("edgedb_test_portable")
-        .args(&["sh", "-exc", &script])
+        .args(["sh", "-exc", &script])
         .assert()
         .context(name, "running test in docker")
         .success();

--- a/tests/docker_portable_wrapper.rs
+++ b/tests/docker_portable_wrapper.rs
@@ -3,7 +3,7 @@
 //!
 //! Note: these tests likely won't run on non-Ubuntu OSs, since the test binaries
 //! might have dynamic library dependencies into the host system.
-#![cfg_attr(not(feature="test_docker_wrapper"), allow(dead_code, unused_imports))]
+#![cfg(feature="docker_test_wrapper")]
 
 use std::path::{Path, PathBuf};
 use std::collections::HashMap;
@@ -109,7 +109,6 @@ fn dockerfile() -> String {
     "###)
 }
 
-#[cfg(feature="docker_test_wrapper")]
 #[test_case("portable_smoke")]
 #[test_case("portable_project")]
 #[test_case("portable_project_dir")]

--- a/tests/func/configure.rs
+++ b/tests/func/configure.rs
@@ -109,8 +109,7 @@ fn configure_all_parameters() {
         .map(|line| line.split_whitespace().next().unwrap())
         .filter(|line| !line.is_empty() && line != &"help")
         .collect::<BTreeSet<_>>();
-    let db_reset_options = db_object_options.union(&db_simple_options)
-        .map(|x| *x).collect::<BTreeSet<_>>();
+    let db_reset_options = db_object_options.union(&db_simple_options).copied().collect::<BTreeSet<_>>();
     if !db_reset_options.is_subset(&cmd_reset_options) {
         assert_eq!(db_reset_options, cmd_reset_options); // nice diff
     }

--- a/tests/github-actions/main.rs
+++ b/tests/github-actions/main.rs
@@ -1,10 +1,10 @@
-#[cfg(all(feature="github_action_install"))]
+#[cfg(feature="github_action_install")]
 #[path="../docker.rs"]
 mod docker;
 
-#[cfg(all(feature="github_action_install"))]
+#[cfg(feature="github_action_install")]
 #[path="../certs.rs"]
 mod certs;
 
-#[cfg(all(feature="github_action_install"))]
+#[cfg(feature="github_action_install")]
 mod install;

--- a/tests/github-nightly/main.rs
+++ b/tests/github-nightly/main.rs
@@ -1,14 +1,14 @@
-#[cfg(all(feature="github_nightly"))]
+#[cfg(feature="github_nightly")]
 #[path="../docker.rs"]
 mod docker;
 
-#[cfg(all(feature="github_nightly"))]
+#[cfg(feature="github_nightly")]
 #[path="../measure.rs"]
 mod measure;
 
-#[cfg(all(feature="github_nightly"))] mod common;
+#[cfg(feature="github_nightly")] mod common;
 
-#[cfg(all(feature="github_nightly"))] mod compat;
-#[cfg(all(feature="github_nightly"))] mod install;
-#[cfg(all(feature="github_nightly"))] mod upgrade;
-#[cfg(all(feature="github_nightly"))] mod project;
+#[cfg(feature="github_nightly")] mod compat;
+#[cfg(feature="github_nightly")] mod install;
+#[cfg(feature="github_nightly")] mod upgrade;
+#[cfg(feature="github_nightly")] mod project;

--- a/tests/portable_project.rs
+++ b/tests/portable_project.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature="portable_tests"), allow(dead_code, unused_imports))]
+#![cfg(feature="portable_tests")]
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -6,8 +6,6 @@ use predicates::prelude::*;
 mod util;
 use util::*;
 
-
-#[cfg(feature="portable_tests")]
 #[test]
 fn project_link_and_init() {
     Command::new("edgedb")

--- a/tests/shared-client-tests/build.rs
+++ b/tests/shared-client-tests/build.rs
@@ -129,7 +129,7 @@ static MUTEX: Mutex<()> = Mutex::new(());
         let fs = case
             .get("fs")
             .and_then(|v| v.as_object())
-            .unwrap_or_else(|| &empty_map);
+            .unwrap_or(&empty_map);
         let platform = match case.get("platform").and_then(|p| p.as_str()) {
             Some("macos") => {
                 write!(testcase, "#[cfg(target_os=\"macos\")]");
@@ -170,7 +170,7 @@ static MUTEX: Mutex<()> = Mutex::new(());
             }
             if let Some(host) = opts.get("host") {
                 if let Some(host) = host.as_str() {
-                    if host.starts_with("/") {
+                    if host.starts_with('/') {
                         should_panic = true;
                     }
                 }

--- a/tests/shared-client-tests/build.rs
+++ b/tests/shared-client-tests/build.rs
@@ -159,11 +159,7 @@ static MUTEX: Mutex<()> = Mutex::new(());
             if let Some(dsn) = opts.get("dsn") {
                 if let Some(dsn) = dsn.as_str() {
                     // servo/rust-url#424
-                    if dsn.contains("%25eth0") {
-                        should_panic = true;
-                    } else if dsn.starts_with("edgedbadmin://") {
-                        should_panic = true;
-                    } else if dsn.contains("host=/") {
+                    if dsn.contains("%25eth0") || dsn.starts_with("edgedbadmin://") || dsn.contains("host=/") {
                         should_panic = true;
                     }
                 }

--- a/tests/shared-client-tests/tests/portable_shared.rs
+++ b/tests/shared-client-tests/tests/portable_shared.rs
@@ -79,17 +79,17 @@ impl Drop for MockFile {
             return;
         }
         if self.is_dir {
-            fs::remove_dir(&self.path).expect(&format!("rmdir {:?}", self.path));
+            fs::remove_dir(&self.path).unwrap_or_else(|_| panic!("rmdir {:?}", self.path));
         } else {
-            fs::remove_file(&self.path).expect(&format!("rm {:?}", self.path));
+            fs::remove_file(&self.path).unwrap_or_else(|_| panic!("rm {:?}", self.path));
         }
     }
 }
 
 fn mock_file(path: &str, content: &str) -> MockFile {
     let path = PathBuf::from(path);
-    ensure_dir(&path.parent().unwrap());
-    fs::write(&path, content).expect(&format!("write {path:?}"));
+    ensure_dir(path.parent().unwrap());
+    fs::write(&path, content).unwrap_or_else(|_| panic!("write {path:?}"));
     MockFile { path, is_dir: false }
 }
 
@@ -148,7 +148,7 @@ fn mock_project(
 
 fn ensure_dir(path: &Path) {
     if !path.exists() {
-        fs::create_dir_all(path).expect(&format!("mkdir -p {path:?}"));
+        fs::create_dir_all(path).unwrap_or_else(|_| panic!("mkdir -p {path:?}"));
     }
 }
 

--- a/tests/shared-client-tests/tests/portable_shared.rs
+++ b/tests/shared-client-tests/tests/portable_shared.rs
@@ -89,7 +89,7 @@ impl Drop for MockFile {
 fn mock_file(path: &str, content: &str) -> MockFile {
     let path = PathBuf::from(path);
     ensure_dir(path.parent().unwrap());
-    fs::write(&path, content).unwrap_or_else(|_| panic!("write {path:?}"));
+    fs::write(&path, content).unwrap_or_else(|_| panic!("{}", "write {path:?}"));
     MockFile { path, is_dir: false }
 }
 
@@ -148,7 +148,7 @@ fn mock_project(
 
 fn ensure_dir(path: &Path) {
     if !path.exists() {
-        fs::create_dir_all(path).unwrap_or_else(|_| panic!("mkdir -p {path:?}"));
+        fs::create_dir_all(path).unwrap_or_else(|_| panic!("{}", "mkdir -p {path:?}"));
     }
 }
 


### PR DESCRIPTION
Most of this PR are stylistic changes that move the codebase toward idiomatic Rust, but some of them are potential bug fixes:
- we used `write()` instead of `write_all()`, which might not write all of data if the buffer is too small,
- we used `const` for a few variables that should have been `static`, which *might* get them inlined, which is not what was intended.

Command used:
```
cargo clippy --all-features --workspace --all-targets -- \
-A clippy::collapsible_if \
-A clippy::derive_partial_eq_without_eq \
-A clippy::zero_ptr \
-A clippy::manual_strip \
-A clippy::new_ret_no_self \
-A clippy::type_complexity \
-A clippy::vec_init_then_push \
-A clippy::while_let_on_iterator \
-A clippy::useless_format \
-A clippy::too_many_arguments \
-A clippy::clone_on_copy
```
