### PR TITLE
Use command::Options in branching commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.5.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#cf5043a27c49a2baf98c99e76acdc3432b77d431"
+source = "git+https://github.com/edgedb/edgedb-rust/#783438e6322acc6a4960e61ad2f46b0c8c9517cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.4.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#cf5043a27c49a2baf98c99e76acdc3432b77d431"
+source = "git+https://github.com/edgedb/edgedb-rust/#783438e6322acc6a4960e61ad2f46b0c8c9517cd"
 dependencies = [
  "bytes",
 ]
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.6.0"
-source = "git+https://github.com/edgedb/edgedb-rust/#cf5043a27c49a2baf98c99e76acdc3432b77d431"
+source = "git+https://github.com/edgedb/edgedb-rust/#783438e6322acc6a4960e61ad2f46b0c8c9517cd"
 dependencies = [
  "bigdecimal",
  "bitflags 2.4.2",
@@ -1176,7 +1176,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.5.0"
-source = "git+https://github.com/edgedb/edgedb-rust/#cf5043a27c49a2baf98c99e76acdc3432b77d431"
+source = "git+https://github.com/edgedb/edgedb-rust/#783438e6322acc6a4960e61ad2f46b0c8c9517cd"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src/branch/connections.rs
+++ b/src/branch/connections.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use uuid::Uuid;
 use crate::connect::{Connection, Connector};
-use crate::options::Options;
+use crate::commands::Options;
 use crate::print;
 
 pub struct BranchConnection<'a> {
@@ -18,7 +18,7 @@ impl BranchConnection<'_> {
             let mut branch = get_connection_that_is_not(
                 &self.branch_name,
                 self.options,
-                &mut self.options.create_connector().await?.connect().await?
+                &mut self.options.conn_params.connect().await?
             ).await?;
 
             print::completion(branch.connection.execute(&format!("drop branch {} force", self.branch_name), &()).await?);
@@ -60,8 +60,10 @@ pub async fn get_connection_to_modify<'a>(branch: &String, options: &'a Options,
         Err(_) => {
             let temp_name = Uuid::new_v4().to_string();
             connection.execute(&format!("create empty branch {}", edgeql_parser::helpers::quote_name(&temp_name)), &()).await?;
+
+            let mut conn_params = options.conn_params.clone();
             Ok(BranchConnection {
-                connection: options.create_connector().await?.branch(&temp_name)?.connect().await?,
+                connection: conn_params.branch(&temp_name)?.connect().await?,
                 options,
                 branch_name: temp_name,
                 is_temp: true
@@ -78,8 +80,9 @@ pub async fn get_connection_that_is_not<'a>(target_branch: &String, options: &'a
 
     for branch in &branches {
         if branch != target_branch {
+            let mut connector = options.conn_params.clone();
             return Ok(BranchConnection {
-                connection: options.create_connector().await?.branch(branch)?.connect().await?,
+                connection: connector.branch(branch)?.connect().await?,
                 branch_name: branch.deref().to_string(),
                 is_temp: false,
                 options

--- a/src/branch/main.rs
+++ b/src/branch/main.rs
@@ -2,7 +2,7 @@ use crate::branch::context::Context;
 use crate::branch::option::{BranchCommand, Command};
 use crate::branch::{create, current, drop, list, merge, rebase, rename, switch, wipe};
 use crate::connect::{Connection, Connector};
-use crate::options::Options;
+use crate::commands::Options;
 
 use edgedb_tokio::get_project_dir;
 
@@ -10,7 +10,7 @@ use edgedb_tokio::get_project_dir;
 pub async fn branch_main(options: &Options, cmd: &BranchCommand) -> anyhow::Result<()> {
     let context = create_context().await?;
 
-    let mut connector: Connector = options.create_connector().await?;
+    let mut connector: Connector = options.conn_params.clone();
 
     // match commands that don't require a connection to run, then match the ones that do with a connection.
     match &cmd.subcommand {

--- a/src/branch/merge.rs
+++ b/src/branch/merge.rs
@@ -4,7 +4,7 @@ use crate::branch::option::{Merge};
 use crate::connect::Connection;
 use crate::migrations;
 use crate::migrations::merge::{apply_merge_migration_files, get_merge_migrations, write_merge_migrations};
-use crate::options::Options;
+use crate::commands::Options;
 
 pub async fn main(options: &Merge, context: &Context, source_connection: &mut Connection, cli_opts: &Options) -> anyhow::Result<()> {
     if context.project_config.is_none() {
@@ -18,8 +18,9 @@ pub async fn main(options: &Merge, context: &Context, source_connection: &mut Co
         anyhow::bail!("Cannot merge the current branch into its self");
     }
 
+    let mut connector = cli_opts.conn_params.clone();
     let mut target_connection = match connect_if_branch_exists(
-        cli_opts.create_connector().await?.branch(&options.target_branch)?
+        connector.branch(&options.target_branch)?
     ).await? {
         Some(connection) => connection,
         None => anyhow::bail!("The branch '{}' doesn't exist", options.target_branch)

--- a/src/branch/rebase.rs
+++ b/src/branch/rebase.rs
@@ -5,7 +5,7 @@ use crate::branch::context::Context;
 use crate::branch::option::Rebase;
 use crate::connect::Connection;
 use crate::migrations::rebase::{do_rebase, get_diverging_migrations, write_rebased_migration_files};
-use crate::options::Options;
+use crate::commands::Options;
 use crate::{migrations, print};
 use crate::branch::connections::get_connection_to_modify;
 
@@ -22,7 +22,8 @@ pub async fn main(options: &Rebase, context: &Context, source_connection: &mut C
 
     let temp_branch = clone_target_branch(&options.target_branch, source_connection).await?;
 
-    let mut temp_branch_connection = cli_opts.create_connector().await?.branch(&temp_branch)?.connect().await?;
+    let mut connector = cli_opts.conn_params.clone();
+    let mut temp_branch_connection = connector.branch(&temp_branch)?.connect().await?;
 
     match rebase(&temp_branch, source_connection, &mut temp_branch_connection, context, cli_opts, !options.no_apply).await {
         Err(e) => {

--- a/src/branch/rename.rs
+++ b/src/branch/rename.rs
@@ -1,7 +1,7 @@
 use crate::branch::connections::get_connection_to_modify;
 use crate::branch::context::Context;
 use crate::branch::option::Rename;
-use crate::options::Options;
+use crate::commands::Options;
 use crate::connect::Connection;
 use crate::print;
 

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -27,15 +27,7 @@ async fn common_cmd(_options: &Options, cmdopt: commands::Options, cmd: &Common)
 pub fn main(options: &Options) -> Result<(), anyhow::Error> {
     match options.subcommand.as_ref().expect("subcommand is present") {
         Command::Common(cmd) => {
-            let cmdopt = commands::Options {
-                command_line: true,
-                styler: if std::io::stdout().is_terminal() {
-                    Some(Styler::dark_256())
-                } else {
-                    None
-                },
-                conn_params: options.block_on_create_connector()?,
-            };
+            let cmdopt = init_command_opts(options)?;
             directory_check::check_and_warn();
             match cmd {
                 // Process commands that don't need connection first
@@ -96,7 +88,20 @@ pub fn main(options: &Options) -> Result<(), anyhow::Error> {
             watch::watch(options, c)
         },
         Command::Branch(c) => {
-            branch::branch_main(options, c)
+            let cmdopt = init_command_opts(options)?;
+            branch::branch_main(&cmdopt, c)
         }
     }
+}
+
+fn init_command_opts(options: &Options) -> Result<commands::Options, anyhow::Error> {
+    Ok(commands::Options {
+        command_line: true,
+        styler: if std::io::stdout().is_terminal() {
+            Some(Styler::dark_256())
+        } else {
+            None
+        },
+        conn_params: options.block_on_create_connector()?,
+    })
 }


### PR DESCRIPTION
A refactor that should not *really* matter, but it does decrease the "bug" surface of branching commands and unifies code with other commands.