### PR TITLE
Branches: remove switch comment on create options

### DIFF
--- a/src/branch/option.rs
+++ b/src/branch/option.rs
@@ -17,7 +17,7 @@ pub enum Command {
     Current(Current)
 }
 
-/// Creates a new branch and switches to it.
+/// Creates a new branch.
 #[derive(clap::Args, Debug, Clone)]
 pub struct Create {
     /// The name of the branch to create.


### PR DESCRIPTION
We've removed the functionality of `edgedb branch create` automatically switching to the created branch, so the description of `create` is invalid.