### PR TITLE
Branches: add switch, list, and rename to repl & cmd results

### DIFF
--- a/src/branch/main.rs
+++ b/src/branch/main.rs
@@ -3,7 +3,7 @@ use crate::branch::context::Context;
 use crate::branch::option::{BranchCommand, Command};
 use crate::branch::{create, current, drop, list, merge, rebase, rename, switch, wipe};
 use crate::connect::{Connection, Connector};
-use crate::commands::Options;
+use crate::commands::{CommandResult, Options};
 
 use edgedb_tokio::get_project_dir;
 
@@ -11,40 +11,46 @@ use edgedb_tokio::get_project_dir;
 pub async fn branch_main(options: &Options, cmd: &BranchCommand) -> anyhow::Result<()> {
     let context = create_context().await?;
 
-    run_branch_command(&cmd.subcommand, options, &context, None).await
+    run_branch_command(&cmd.subcommand, options, &context, None).await?;
+
+    Ok(())
 }
 
-pub async fn run_branch_command(cmd: &Command, options: &Options, context: &Context, connection: Option<&mut Connection>) -> anyhow::Result<()> {
+pub async fn run_branch_command(cmd: &Command, options: &Options, context: &Context, connection: Option<&mut Connection>) -> anyhow::Result<Option<CommandResult>> {
     let mut connector: Connector = options.conn_params.clone();
 
     match &cmd {
-        Command::Switch(switch) => switch::main(switch, context, &mut connector).await,
+        Command::Switch(switch) => return switch::main(switch, context, &mut connector).await,
         Command::Wipe(wipe) => wipe::main(wipe, context, &mut connector).await,
         Command::Current(current) => current::main(current, context).await,
         command => {
             match connection {
-                Some(conn) => run_branch_command1(command, conn, context, options).await,
+                Some(conn) => return run_branch_command1(command, conn, context, options).await,
                 None => {
                     let mut conn = connector.connect().await?;
-                    run_branch_command1(command, &mut conn, context, options).await
+                    return run_branch_command1(command, &mut conn, context, options).await
                 }
             }
         }
-    }
+    }?;
+
+    Ok(None)
 }
 
-async fn run_branch_command1(command: &Command, connection: &mut Connection, context: &Context, options: &Options) -> anyhow::Result<()> {
+async fn run_branch_command1(command: &Command, connection: &mut Connection, context: &Context, options: &Options) -> anyhow::Result<Option<CommandResult>> {
     verify_server_can_use_branches(connection).await?;
 
     match command {
         Command::Create(create) => create::main(create, context, connection).await,
         Command::Drop(drop) => drop::main(drop, context, connection).await,
         Command::List(list) => list::main(list, context, connection).await,
-        Command::Rename(rename) => rename::main(rename, context, connection, options).await,
+        Command::Rename(rename) => return rename::main(rename, context, connection, options).await,
         Command::Rebase(rebase) => rebase::main(rebase, context, connection, options).await,
         Command::Merge(merge) => merge::main(merge, context, connection, options).await,
         unhandled => anyhow::bail!("unimplemented branch command '{:?}'", unhandled)
-    }
+    }?;
+
+    Ok(None)
 }
 
 pub async fn create_context() -> anyhow::Result<Context> {

--- a/src/branch/option.rs
+++ b/src/branch/option.rs
@@ -30,6 +30,9 @@ impl From<&BranchingCmd> for Command {
             BranchingCmd::Create(args) => Command::Create(args.clone()),
             BranchingCmd::Drop(args) => Command::Drop(args.clone()),
             BranchingCmd::Wipe(args) => Command::Wipe(args.clone()),
+            BranchingCmd::List(args) => Command::List(args.clone()),
+            BranchingCmd::Switch(args) => Command::Switch(args.clone()),
+            BranchingCmd::Rename(args) => Command::Rename(args.clone())
         }
     }
 }

--- a/src/branch/switch.rs
+++ b/src/branch/switch.rs
@@ -3,6 +3,7 @@ use crate::branch::context::Context;
 use crate::branch::create::create_branch;
 use crate::branch::main::verify_server_can_use_branches;
 use crate::branch::option::Switch;
+use crate::commands::CommandResult;
 use crate::connect::{Connector};
 
 
@@ -10,7 +11,7 @@ pub async fn main(
     options: &Switch,
     context: &Context,
     connector: &mut Connector,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Option<CommandResult>> {
     if context.branch.is_none() {
         anyhow::bail!("Cannot switch branches: No project found");
     }
@@ -58,5 +59,7 @@ pub async fn main(
 
     context.update_branch(&options.branch).await?;
 
-    Ok(())
+    Ok(Some(CommandResult {
+        new_branch: Some(options.branch.clone())
+    }))
 }

--- a/src/commands/branching.rs
+++ b/src/commands/branching.rs
@@ -1,10 +1,10 @@
-use crate::branch;
+use crate::{branch, print};
 use crate::commands::parser::BranchingCmd;
 use crate::connect::Connection;
-use crate::commands::Options;
+use crate::commands::{CommandResult, Options};
+use crate::repl::State;
 
-pub async fn main(connection: &mut Connection, cmd: &BranchingCmd, options: &Options) -> anyhow::Result<()> {
+pub async fn main(connection: &mut Connection, cmd: &BranchingCmd, options: &Options) -> anyhow::Result<Option<CommandResult>> {
     let context = branch::main::create_context().await?;
-    
     branch::main::run_branch_command(&cmd.into(), options, &context, Some(connection)).await
 }

--- a/src/commands/command_result.rs
+++ b/src/commands/command_result.rs
@@ -1,0 +1,3 @@
+pub struct CommandResult {
+    pub new_branch: Option<String>
+}

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -3,14 +3,14 @@ use edgedb_tokio::server_params::PostgresAddress;
 
 use crate::{analyze};
 use crate::commands::parser::{Common, DatabaseCmd, ListCmd, DescribeCmd};
-use crate::commands::{self, branching, Options};
+use crate::commands::{self, branching, CommandResult, Options};
 use crate::migrations::options::{MigrationCmd};
 use crate::migrations;
 use crate::print;
 
 
 pub async fn common(cli: &mut Connection, cmd: &Common, options: &Options)
-    -> Result<(), anyhow::Error>
+    -> Result<Option<CommandResult>, anyhow::Error>
 {
     use Common::*;
     match cmd {
@@ -96,7 +96,7 @@ pub async fn common(cli: &mut Connection, cmd: &Common, options: &Options)
             }
         },
         Branching(branching) => {
-            branching::main(cli, &branching.subcommand, options).await?
+            return branching::main(cli, &branching.subcommand, options).await
         }
         Migrate(params) => {
             migrations::migrate(cli, options, params).await?;
@@ -128,5 +128,5 @@ pub async fn common(cli: &mut Connection, cmd: &Common, options: &Options)
             }
         }
     }
-    Ok(())
+    Ok(None)
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub mod parser;
 mod ui;
 mod list_branches;
 mod branching;
+mod command_result;
 
 pub use self::configure::configure;
 pub use self::dump::{dump, dump_all};
@@ -46,3 +47,4 @@ pub use self::psql::psql;
 pub use self::exit::ExitCode;
 pub use self::info::info;
 pub use self::ui::show_ui;
+pub use self::command_result::CommandResult;

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -144,6 +144,12 @@ pub enum BranchingCmd {
     /// preserving the branch itself (its cfg::DatabaseConfig)
     /// and existing migration scripts
     Wipe(crate::branch::option::Wipe),
+    /// List all branches.
+    List(crate::branch::option::List),
+    /// Switches the current branch to a different one.
+    Switch(crate::branch::option::Switch),
+    /// Renames a branch.
+    Rename(crate::branch::option::Rename)
 }
 
 #[derive(clap::Args, Clone, Debug)]


### PR DESCRIPTION
## Summary
Adds the following to backslash commands:
- branch switch
- branch list
- branch rename

To achieve communication between these commands and the REPL environment, commands can now return a `CommandResult` which contains any information that might be important to the REPLs state; ex `new_branch` which can be provided by `switch` and `rename`.

This PR also adds the `/b` alias to branch commands.

We should also decide if we want `switch` in REPL, which modifies the project-specified branch