### PR TITLE
Disable automatic query cache rebuild on local instances

### DIFF
--- a/src/portable/linux.rs
+++ b/src/portable/linux.rs
@@ -218,6 +218,10 @@ pub fn server_cmd(
     pro.env_default("EDGEDB_SERVER_LOG_LEVEL", "warn");
     pro.env_default("EDGEDB_SERVER_HTTP_ENDPOINT_SECURITY", "optional");
     pro.env_default("EDGEDB_SERVER_INSTANCE_NAME", &inst.name);
+    pro.env_default(
+        "EDGEDB_SERVER_CONFIG_cfg::auto_rebuild_query_cache",
+        "false",
+    );
     pro.arg("--data-dir").arg(data_dir);
     pro.arg("--runstate-dir").arg(runstate_dir(&inst.name)?);
     pro.arg("--port").arg(inst.port.to_string());

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -300,6 +300,10 @@ pub fn server_cmd(
     pro.env_default("EDGEDB_SERVER_LOG_LEVEL", "warn");
     pro.env_default("EDGEDB_SERVER_HTTP_ENDPOINT_SECURITY", "optional");
     pro.env_default("EDGEDB_SERVER_INSTANCE_NAME", &inst.name);
+    pro.env_default(
+        "EDGEDB_SERVER_CONFIG_cfg::auto_rebuild_query_cache",
+        "false",
+    );
     pro.arg("--data-dir").arg(data_dir);
     pro.arg("--runstate-dir").arg(runstate_dir);
     pro.arg("--port").arg(inst.port.to_string());


### PR DESCRIPTION
Automatic cache rebuild is mostly beneficial for production instances as
it minimizes the effects of schema changes on query latency.  In
development, on the other hand, the slow rebuild process might hinder
productivity, so disable it by default on instances started by the CLI.
