### PR TITLE
Fix: Change 'branch' to 'target_branch' in branch command options

### DIFF
--- a/src/branch/drop.rs
+++ b/src/branch/drop.rs
@@ -11,7 +11,7 @@ pub async fn main(
     connection: &mut Connection,
 ) -> anyhow::Result<()> {
     if let Some(current_branch) = &context.branch {
-        if current_branch == &options.branch {
+        if current_branch == &options.target_branch {
             anyhow::bail!(
                 "Dropping the currently active branch is not supported, please switch to a \
                 different branch to drop this one with `edgedb branch switch <branch>`"
@@ -22,7 +22,7 @@ pub async fn main(
     if !options.non_interactive {
         let q = question::Confirm::new_dangerous(format!(
             "Do you really want to drop the branch {:?}?",
-            options.branch
+            options.target_branch
         ));
         if !connection.ping_while(q.async_ask()).await? {
             print::error("Canceled by user.");
@@ -32,7 +32,7 @@ pub async fn main(
 
     let mut statement = format!(
         "drop branch {}",
-        edgeql_parser::helpers::quote_name(&options.branch)
+        edgeql_parser::helpers::quote_name(&options.target_branch)
     );
 
     if options.force {

--- a/src/branch/option.rs
+++ b/src/branch/option.rs
@@ -59,7 +59,7 @@ pub struct Create {
 #[derive(clap::Args, Debug, Clone)]
 pub struct Drop {
     /// The branch to drop.
-    pub branch: String,
+    pub target_branch: String,
 
     /// Drop the branch without asking for confirmation.
     #[arg(long)]
@@ -74,7 +74,7 @@ pub struct Drop {
 #[derive(clap::Args, Debug, Clone)]
 pub struct Wipe {
     /// The branch to wipe.
-    pub branch: String,
+    pub target_branch: String,
 
     /// Wipe without asking for confirmation.
     #[arg(long)]
@@ -85,7 +85,7 @@ pub struct Wipe {
 #[derive(clap::Args, Debug, Clone)]
 pub struct Switch {
     /// The branch to switch to.
-    pub branch: String,
+    pub target_branch: String,
 
     /// Create the branch if it doesn't exist.
     #[arg(short = 'c', long)]

--- a/src/branch/switch.rs
+++ b/src/branch/switch.rs
@@ -17,8 +17,8 @@ pub async fn main(
 
     let current_branch = context.branch.as_ref().unwrap();
 
-    if current_branch == &options.branch {
-        anyhow::bail!("Already on '{}'", options.branch);
+    if current_branch == &options.target_branch {
+        anyhow::bail!("Already on '{}'", options.target_branch);
     }
 
     if let Some(mut connection) = connect_if_branch_exists(connector).await? {
@@ -32,24 +32,24 @@ pub async fn main(
             )
             .await?;
 
-        if !branches.contains(&options.branch) {
+        if !branches.contains(&options.target_branch) {
             if options.create {
-                eprintln!("Creating '{}'...", &options.branch);
+                eprintln!("Creating '{}'...", &options.target_branch);
                 create_branch(
                     &mut connection,
-                    &options.branch,
+                    &options.target_branch,
                     options.from.as_ref().unwrap_or(current_branch),
                     options.empty,
                     options.copy_data,
                 )
                 .await?;
             } else {
-                anyhow::bail!("Branch '{}' doesn't exists", options.branch)
+                anyhow::bail!("Branch '{}' doesn't exists", options.target_branch)
             }
         }
     } else {
         // try to connect to the target branch
-        let target_branch_connector = connector.branch(&options.branch)?;
+        let target_branch_connector = connector.branch(&options.target_branch)?;
         match connect_if_branch_exists(target_branch_connector).await? {
             Some(mut connection) => {
                 verify_server_can_use_branches(&mut connection).await?;
@@ -60,12 +60,12 @@ pub async fn main(
 
     eprintln!(
         "Switching from '{}' to '{}'",
-        current_branch, options.branch
+        current_branch, options.target_branch
     );
 
-    context.update_branch(&options.branch).await?;
+    context.update_branch(&options.target_branch).await?;
 
     Ok(Some(CommandResult {
-        new_branch: Some(options.branch.clone()),
+        new_branch: Some(options.target_branch.clone()),
     }))
 }

--- a/src/branch/wipe.rs
+++ b/src/branch/wipe.rs
@@ -11,10 +11,10 @@ pub async fn main(
     _context: &Context,
     connector: &mut Connector,
 ) -> anyhow::Result<()> {
-    let connection = connect_if_branch_exists(connector.branch(&options.branch)?).await?;
+    let connection = connect_if_branch_exists(connector.branch(&options.target_branch)?).await?;
 
     if connection.is_none() {
-        anyhow::bail!("Branch '{}' doesn't exist", &options.branch)
+        anyhow::bail!("Branch '{}' doesn't exist", &options.target_branch)
     }
 
     let mut connection = connection.unwrap();
@@ -23,7 +23,7 @@ pub async fn main(
         let q = question::Confirm::new_dangerous(format!(
             "Do you really want to wipe \
                     the contents of the branch {:?}?",
-            options.branch
+            options.target_branch
         ));
         if !connection.ping_while(q.async_ask()).await? {
             print::error("Canceled by user.");


### PR DESCRIPTION
### Summary
Having `branch` in branch command options causes conflicts with `branch` in connection options resulting in unintended behavior in wipe, switch, and drop. This PR renames `branch` to `target_branch` to fix the conflicts