### PR TITLE
Branch context without instance

### DIFF
--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -46,7 +46,7 @@ impl Context {
 
         // try to read current branch from instance credentials
         let current_branch = if let Some(instance_name) = &instance_name {
-            let credentials_path = credentials::path(&instance_name)?;
+            let credentials_path = credentials::path(instance_name)?;
             let credentials = credentials::read(&credentials_path).await?;
 
             credentials.branch.or(credentials.database)
@@ -90,7 +90,7 @@ impl Context {
             return Ok(());
         };
 
-        let path = credentials::path(&instance_name)?;
+        let path = credentials::path(instance_name)?;
         let mut credentials = credentials::read(&path).await?;
         credentials.database = Some(branch.to_string());
         credentials.branch = Some(branch.to_string());

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -1,78 +1,116 @@
+use edgedb_tokio::get_project_dir;
+
+use crate::commands::Options;
 use crate::connect::Connection;
 use crate::credentials;
 use crate::portable::config::Config;
 use crate::portable::options::InstanceName;
-use crate::portable::project::{instance_name, stash_path};
+use crate::portable::project;
 use std::fs;
-use std::path::{Path, PathBuf};
 
 pub struct Context {
-    pub project_config: Option<Config>,
-    pub branch: Option<String>,
+    /// Instance name provided either with --instance or inferred from the project.
+    instance_name: Option<String>,
 
-    project_dir: Option<PathBuf>,
+    /// None means that the current branch is unknown because:
+    /// - the instance uses the default branch (and we cannot know what
+    ///   that is without making a query), or
+    /// - we don't know which instance we are connecting to. This might be because:
+    ///   - there was neither a project or the --instance option,
+    ///   - the project has no linked instance.
+    current_branch: Option<String>,
 }
 
 impl Context {
-    pub async fn new(project_dir: Option<&PathBuf>) -> anyhow::Result<Context> {
-        let project_config = match project_dir {
-            Some(path) => Some(crate::portable::config::read(&path.join("edgedb.toml"))?),
-            None => None,
-        };
+    pub async fn new(options: &Options) -> anyhow::Result<Context> {
+        // use instance name provided with --instance
+        let instance_name = options.conn_params.get()?.instance_name();
+        let instance_name = instance_name.map(|n| n.clone().into());
+        let mut instance_name = instance_name.map(assume_local_instance).transpose()?;
 
-        let credentials = match project_dir {
-            Some(path) => {
-                Some(credentials::read(&credentials::path(&get_instance_name(path)?)?).await?)
+        // fallback to instance name of the associated project
+        if instance_name.is_none() {
+            let project_dir = get_project_dir(None, true).await?;
+
+            let name = if let Some(project_dir) = project_dir {
+                let stash_dir = project::stash_path(&fs::canonicalize(project_dir)?)?;
+                project::instance_name(&stash_dir).ok()
+            } else {
+                None
+            };
+
+            if let Some(name) = name {
+                instance_name = Some(assume_local_instance(name)?);
             }
-            None => None,
+        }
+
+        // try to read current branch from instance credentials
+        let current_branch = if let Some(instance_name) = &instance_name {
+            let credentials_path = credentials::path(&instance_name)?;
+            let credentials = credentials::read(&credentials_path).await?;
+
+            credentials.branch.or(credentials.database)
+        } else {
+            None
         };
 
         Ok(Context {
-            project_config,
-            branch: credentials.and_then(|v| v.database),
-            project_dir: project_dir.map(PathBuf::from),
+            instance_name,
+            current_branch,
         })
     }
 
-    pub async fn get_default_branch_name(
-        &self,
-        connection: &mut Connection,
-    ) -> anyhow::Result<&str> {
-        let version = connection.get_version().await?.specific();
-
-        if version.major >= 5 {
-            return Ok("main");
+    /// Returns the "current" branch. Connection must not have its branch param modified.
+    pub async fn get_current_branch(&self, connection: &mut Connection) -> anyhow::Result<String> {
+        if let Some(b) = &self.current_branch {
+            return Ok(b.clone());
         }
 
-        Ok("edgedb")
+        // if the instance is unknown, current branch is just "the branch of the connection"
+        // so we can pull it out here (if it is not the default branch)
+        if connection.branch() != "__default__" {
+            return Ok(connection.branch().to_string());
+        }
+
+        // if the connection branch is the default branch, query the database to see
+        // what that default is
+        let branch: String = connection
+            .query_required_single("select sys::get_current_database()", &())
+            .await?;
+        Ok(branch)
     }
 
-    pub fn get_instance_name(&self) -> anyhow::Result<Option<String>> {
-        Ok(match &self.project_dir {
-            Some(dir) => Some(get_instance_name(dir)?),
-            None => None,
-        })
+    pub fn can_update_current_branch(&self) -> bool {
+        // we can update the current branch only if we know the instance, so we can write the credentials
+        self.instance_name.is_some()
     }
 
-    pub async fn update_branch(&self, branch: &str) -> anyhow::Result<()> {
-        let instance_name = match self.get_instance_name()? {
-            Some(i) => i,
-            None => return Ok(()),
+    pub async fn update_current_branch(&self, branch: &str) -> anyhow::Result<()> {
+        let Some(instance_name) = &self.instance_name else {
+            return Ok(());
         };
 
         let path = credentials::path(&instance_name)?;
-
         let mut credentials = credentials::read(&path).await?;
-
         credentials.database = Some(branch.to_string());
         credentials.branch = Some(branch.to_string());
 
         credentials::write_async(&path, &credentials).await
     }
+
+    pub async fn get_project_config(&self) -> anyhow::Result<Option<Config>> {
+        let project_dir = get_project_dir(None, true).await?;
+        let Some(path) = &project_dir else {
+            return Ok(None);
+        };
+        Ok(Some(crate::portable::config::read(
+            &path.join("edgedb.toml"),
+        )?))
+    }
 }
 
-fn get_instance_name(project_dir: &Path) -> anyhow::Result<String> {
-    match instance_name(&stash_path(&fs::canonicalize(project_dir)?)?)? {
+fn assume_local_instance(instance_name: InstanceName) -> anyhow::Result<String> {
+    match instance_name {
         InstanceName::Local(local) => Ok(local),
         InstanceName::Cloud {
             name: _,

--- a/src/branch/current.rs
+++ b/src/branch/current.rs
@@ -1,20 +1,20 @@
-use crate::branch::context::Context;
-use crate::branch::option::Current;
 use crossterm::style::Stylize;
 
-pub async fn main(options: &Current, context: &Context) -> anyhow::Result<()> {
+use crate::branch::context::Context;
+use crate::branch::option::Current;
+use crate::connect::Connection;
+
+pub async fn main(
+    options: &Current,
+    context: &Context,
+    connection: &mut Connection,
+) -> anyhow::Result<()> {
+    let current_branch = context.get_current_branch(connection).await?;
+
     if options.plain {
-        if let Some(branch) = &context.branch {
-            println!("{}", branch);
-        }
-
-        return Ok(());
+        println!("{}", current_branch);
+    } else {
+        eprintln!("The current branch is '{}'", current_branch.green());
     }
-
-    match &context.branch {
-        Some(branch) => eprintln!("The current branch is '{}'", branch.clone().green()),
-        None => anyhow::bail!("No project found"),
-    }
-
     Ok(())
 }

--- a/src/branch/drop.rs
+++ b/src/branch/drop.rs
@@ -10,13 +10,13 @@ pub async fn main(
     context: &Context,
     connection: &mut Connection,
 ) -> anyhow::Result<()> {
-    if let Some(current_branch) = &context.branch {
-        if current_branch == &options.target_branch {
-            anyhow::bail!(
-                "Dropping the currently active branch is not supported, please switch to a \
-                different branch to drop this one with `edgedb branch switch <branch>`"
-            );
-        }
+    let current_branch = context.get_current_branch(connection).await?;
+
+    if current_branch == options.target_branch {
+        anyhow::bail!(
+            "Dropping the currently active branch is not supported, please switch to a \
+            different branch to drop this one with `edgedb branch switch <branch>`"
+        );
     }
 
     if !options.non_interactive {

--- a/src/branch/list.rs
+++ b/src/branch/list.rs
@@ -8,6 +8,8 @@ pub async fn main(
     context: &Context,
     connection: &mut Connection,
 ) -> anyhow::Result<()> {
+    let current_branch = context.get_current_branch(connection).await?;
+
     let branches: Vec<String> = connection
         .query(
             "SELECT (SELECT sys::Database FILTER NOT .builtin).name",
@@ -16,7 +18,7 @@ pub async fn main(
         .await?;
 
     for branch in branches {
-        if context.branch.as_ref() == Some(&branch) {
+        if current_branch == branch {
             println!("{} - Current", branch.green());
         } else {
             println!("{}", branch);

--- a/src/branch/merge.rs
+++ b/src/branch/merge.rs
@@ -16,7 +16,8 @@ pub async fn main(
 ) -> anyhow::Result<()> {
     let current_branch = context.get_current_branch(source_connection).await?;
     let project_config = context
-        .get_project_config().await?
+        .get_project_config()
+        .await?
         .ok_or_else(|| anyhow::anyhow!("Merge must be used within a project"))?;
 
     if options.target_branch == current_branch {

--- a/src/branch/rebase.rs
+++ b/src/branch/rebase.rs
@@ -79,7 +79,7 @@ async fn rebase(
 
     migrations.print_status();
 
-    let migration_context = migrations::Context::for_project(&project_config)?;
+    let migration_context = migrations::Context::for_project(project_config)?;
     do_rebase(&mut migrations, &migration_context).await?;
 
     if apply_migrations {

--- a/src/branch/rename.rs
+++ b/src/branch/rename.rs
@@ -11,14 +11,14 @@ pub async fn main(
     connection: &mut Connection,
     cli_opts: &Options,
 ) -> anyhow::Result<Option<CommandResult>> {
-    if Some(&options.old_name) == context.branch.as_ref()
-        || connection.database() == options.old_name
-    {
+    let current_branch = context.get_current_branch(connection).await?;
+
+    if options.old_name == current_branch || connection.database() == options.old_name {
         let mut modify_connection =
             get_connection_to_modify(&options.old_name, cli_opts, connection).await?;
         rename(&mut modify_connection.connection, options).await?;
         modify_connection.clean().await?;
-        context.update_branch(&options.new_name).await?;
+        context.update_current_branch(&options.new_name).await?;
     } else {
         rename(connection, options).await?;
     }

--- a/src/commands/branching.rs
+++ b/src/commands/branching.rs
@@ -8,6 +8,6 @@ pub async fn main(
     cmd: &BranchingCmd,
     options: &Options,
 ) -> anyhow::Result<Option<CommandResult>> {
-    let context = branch::main::create_context().await?;
+    let context = branch::context::Context::new(options).await?;
     branch::main::run_branch_command(&cmd.into(), options, &context, Some(connection)).await
 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -210,6 +210,9 @@ impl Connection {
     pub fn database(&self) -> &str {
         self.config.database()
     }
+    pub fn branch(&self) -> &str {
+        self.config.branch()
+    }
     pub fn set_ignore_error_state(&mut self) -> State {
         let new_state = make_ignore_error_state(self.inner.state_descriptor());
         mem::replace(&mut self.state, new_state)

--- a/src/portable/control.rs
+++ b/src/portable/control.rs
@@ -85,22 +85,21 @@ pub fn get_server_cmd(
 pub fn ensure_runstate_dir(name: &str) -> anyhow::Result<PathBuf> {
     let runstate_dir = runstate_dir(name)?;
     match fs::create_dir_all(&runstate_dir) {
-        Ok(()) => {}
+        Ok(()) => Ok(runstate_dir),
         Err(e) if e.kind() == io::ErrorKind::PermissionDenied && cfg!(unix) => {
-            return Err(e)
+            Err(anyhow::Error::new(e)
                 .context(format!("failed to create runstate dir {:?}", runstate_dir))
                 .hint(
                     "This may mean that `XDG_RUNTIME_DIR` \
-                    is inherited from another user's environment. \
-                    Run `unset XDG_RUNTIME_DIR` or use a better login-as-user \
-                    tool (use `sudo` instead of `su`).",
-                )?;
+                            is inherited from another user's environment. \
+                            Run `unset XDG_RUNTIME_DIR` or use a better login-as-user \
+                            tool (use `sudo` instead of `su`).",
+                )
+                .into())
         }
-        Err(e) => {
-            return Err(e).context(format!("failed to create runstate dir {:?}", runstate_dir));
-        }
+        Err(e) => Err(anyhow::Error::new(e)
+            .context(format!("failed to create runstate dir {:?}", runstate_dir))),
     }
-    Ok(runstate_dir)
 }
 
 #[context("cannot write lock metadata at {:?}", path)]
@@ -176,7 +175,8 @@ fn run_server_by_cli(meta: &InstanceInfo) -> anyhow::Result<()> {
                 // So that all early errors are visible, but all later ones
                 // (i.e. a message on term) do not clobber user's terminal.
                 if unsafe { libc::dup2(log_file.as_raw_fd(), 2) } < 0 {
-                    return Err(io::Error::last_os_error()).context("cannot close stdout")?;
+                    return Err(anyhow::Error::new(io::Error::last_os_error())
+                        .context("cannot close stdout"));
                 }
                 drop(log_file);
 
@@ -186,7 +186,8 @@ fn run_server_by_cli(meta: &InstanceInfo) -> anyhow::Result<()> {
                 // descriptor creation. So we replace it with `/dev/null` (the
                 // writing end of the original pipe is closed at this point).
                 if unsafe { libc::dup2(null.as_raw_fd(), 1) } < 0 {
-                    return Err(io::Error::last_os_error()).context("cannot close stdout")?;
+                    return Err(anyhow::Error::new(io::Error::last_os_error())
+                        .context("cannot close stdout"));
                 }
                 drop(null);
 

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -450,8 +450,7 @@ pub fn unlink(options: &Unlink) -> anyhow::Result<()> {
                     name
                 )
             })
-            .into()
-        );
+            .into());
     }
     with_projects(name, options.force, print_warning, || {
         fs::remove_file(credentials::path(name)?).with_context(|| format!("cannot unlink {}", name))

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -443,14 +443,15 @@ pub fn unlink(options: &Unlink) -> anyhow::Result<()> {
     };
     let inst = InstanceInfo::try_read(name)?;
     if inst.is_some() {
-        return Err(anyhow::anyhow!("cannot unlink local instance {:?}.", name)).with_hint(
-            || {
+        return Err(anyhow::anyhow!("cannot unlink local instance {:?}.", name)
+            .with_hint(|| {
                 format!(
                     "use `edgedb instance destroy -I {}` to remove the instance",
                     name
                 )
-            },
-        )?;
+            })
+            .into()
+        );
     }
     with_projects(name, options.force, print_warning, || {
         fs::remove_file(credentials::path(name)?).with_context(|| format!("cannot unlink {}", name))

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -141,6 +141,17 @@ pub enum InstanceName {
     Cloud { org_slug: String, name: String },
 }
 
+impl From<edgedb_tokio::InstanceName> for InstanceName {
+    fn from(x: edgedb_tokio::InstanceName) -> Self {
+        match x {
+            edgedb_tokio::InstanceName::Local(s) => InstanceName::Local(s),
+            edgedb_tokio::InstanceName::Cloud { org_slug, name } => {
+                InstanceName::Cloud { org_slug, name }
+            }
+        }
+    }
+}
+
 fn billable_unit(s: &str) -> Result<String, String> {
     let (numerator, denominator) = match s.split_once('/') {
         Some(v) => v,

--- a/src/process.rs
+++ b/src/process.rs
@@ -66,7 +66,9 @@ pub fn term(pid: u32) -> anyhow::Result<()> {
     use signal_hook::consts::signal::SIGTERM;
 
     if unsafe { libc::kill(pid as i32, SIGTERM) } != 0 {
-        return Err(anyhow::Error::new(io::Error::last_os_error()).context(format!("cannot stop {pid}")));
+        return Err(
+            anyhow::Error::new(io::Error::last_os_error()).context(format!("cannot stop {pid}"))
+        );
     }
     Ok(())
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -66,7 +66,7 @@ pub fn term(pid: u32) -> anyhow::Result<()> {
     use signal_hook::consts::signal::SIGTERM;
 
     if unsafe { libc::kill(pid as i32, SIGTERM) } != 0 {
-        return Err(io::Error::last_os_error()).with_context(|| format!("cannot stop {pid}"))?;
+        return Err(anyhow::Error::new(io::Error::last_os_error()).context(format!("cannot stop {pid}")));
     }
     Ok(())
 }

--- a/tests/func/help.rs
+++ b/tests/func/help.rs
@@ -12,10 +12,7 @@ fn help_connect() {
 
 #[test]
 fn help_no_extended_connect_help() {
-    let cmd = crate::edgedb_cli_cmd()
-        .arg("--help")
-        .assert()
-        .success();
+    let cmd = crate::edgedb_cli_cmd().arg("--help").assert().success();
 
     let out = String::from_utf8(cmd.get_output().stdout.clone()).unwrap();
 

--- a/tests/func/help.rs
+++ b/tests/func/help.rs
@@ -1,9 +1,6 @@
-use assert_cmd::Command;
-
 #[test]
 fn help_connect() {
-    let cmd = Command::cargo_bin("edgedb")
-        .expect("binary found")
+    let cmd = crate::edgedb_cli_cmd()
         .arg("--help-connect")
         .assert()
         .success();
@@ -15,8 +12,7 @@ fn help_connect() {
 
 #[test]
 fn help_no_extended_connect_help() {
-    let cmd = Command::cargo_bin("edgedb")
-        .expect("binary found")
+    let cmd = crate::edgedb_cli_cmd()
         .arg("--help")
         .assert()
         .success();

--- a/tests/func/instance_link.rs
+++ b/tests/func/instance_link.rs
@@ -1,29 +1,11 @@
 use crate::SERVER;
-use assert_cmd::Command;
 
 #[test]
 fn non_interactive_link() {
-    Command::cargo_bin("edgedb")
-        .expect("binary found")
-        .env("CLICOLOR", "0")
-        .arg("--no-cli-update-check")
-        .arg("instance")
-        .arg("link")
-        .arg("--port")
-        .arg(SERVER.0.info.port.to_string())
-        .arg("--non-interactive")
-        .arg("--trust-tls-cert")
-        .arg("--overwrite")
-        .arg("--quiet")
-        .arg("_test_inst")
-        .assert()
-        .success();
-    Command::cargo_bin("edgedb")
-        .expect("binary found")
-        .env("CLICOLOR", "0")
-        .env("RUST_LOG", "debug")
-        .arg("--no-cli-update-check")
-        .arg("-I_test_inst")
+    let instance_name = SERVER.ensure_instance_linked();
+
+    crate::edgedb_cli_cmd()
+        .arg(format!("-I{instance_name}"))
         .arg("query")
         .arg("SELECT 7*8")
         .assert()
@@ -33,10 +15,7 @@ fn non_interactive_link() {
 
 #[test]
 fn link_requires_conn() {
-    Command::cargo_bin("edgedb")
-        .expect("binary found")
-        .env("CLICOLOR", "0")
-        .arg("--no-cli-update-check")
+    crate::edgedb_cli_cmd()
         .arg("instance")
         .arg("link")
         .arg("--non-interactive")

--- a/tests/func/main.rs
+++ b/tests/func/main.rs
@@ -36,9 +36,7 @@ mod util;
 fn edgedb_cli_cmd() -> assert_cmd::Command {
     let mut cmd = Command::cargo_bin("edgedb").expect("binary found");
 
-    cmd.env("CLICOLOR", "0")
-        .env("RUST_LOG", "debug")
-        .arg("--no-cli-update-check");
+    cmd.env("CLICOLOR", "0").arg("--no-cli-update-check");
     cmd
 }
 

--- a/tests/func/main.rs
+++ b/tests/func/main.rs
@@ -33,6 +33,15 @@ mod help;
 #[path = "../common/util.rs"]
 mod util;
 
+fn edgedb_cli_cmd() -> assert_cmd::Command {
+    let mut cmd = Command::cargo_bin("edgedb").expect("binary found");
+
+    cmd.env("CLICOLOR", "0")
+        .env("RUST_LOG", "debug")
+        .arg("--no-cli-update-check");
+    cmd
+}
+
 struct ServerGuard(ServerInstance);
 
 static SERVER: Lazy<ServerGuard> = Lazy::new(start_server);
@@ -89,8 +98,7 @@ impl ServerGuard {
     }
 
     pub fn admin_cmd(&self) -> Command {
-        let mut cmd = Command::cargo_bin("edgedb").expect("binary found");
-        cmd.arg("--no-cli-update-check");
+        let mut cmd = edgedb_cli_cmd();
         cmd.arg("--admin");
         cmd.arg("--unix-path").arg(&self.0.info.socket_dir);
         cmd.arg("--port").arg(self.0.info.port.to_string());
@@ -99,8 +107,7 @@ impl ServerGuard {
     }
 
     pub fn admin_cmd_deprecated(&self) -> Command {
-        let mut cmd = Command::cargo_bin("edgedb").expect("binary found");
-        cmd.arg("--no-cli-update-check");
+        let mut cmd = edgedb_cli_cmd();
         cmd.arg("--admin");
         // test deprecated --host /unix/path
         cmd.arg("--host").arg(&self.0.info.socket_dir);
@@ -145,6 +152,25 @@ impl ServerGuard {
         cmd.arg("--tls-ca-file").arg(&self.0.info.tls_cert_file);
         cmd.arg("--database").arg(database_name);
         cmd
+    }
+
+    pub fn ensure_instance_linked(&self) -> &'static str {
+        const INSTANCE_NAME: &str = "_test_inst";
+
+        edgedb_cli_cmd()
+            .arg("instance")
+            .arg("link")
+            .arg("--port")
+            .arg(self.0.info.port.to_string())
+            .arg("--non-interactive")
+            .arg("--trust-tls-cert")
+            .arg("--overwrite")
+            .arg("--quiet")
+            .arg(INSTANCE_NAME)
+            .assert()
+            .success();
+
+        INSTANCE_NAME
     }
 }
 

--- a/tests/func/non_interactive.rs
+++ b/tests/func/non_interactive.rs
@@ -131,3 +131,38 @@ fn database_create_wipe_drop() {
         .context("select-again", "make sure that database is not there")
         .failure();
 }
+
+#[test]
+fn branch_create() {
+    let default_branch = SERVER.default_branch();
+
+    SERVER
+        .admin_cmd()
+        .arg("branch")
+        .arg("create")
+        .arg("--empty")
+        .arg("test_branch_1")
+        .assert()
+        .context("create", "create new empty branch")
+        .success();
+
+    SERVER
+        .admin_cmd()
+        .arg("branch")
+        .arg("create")
+        .arg("test_branch_2")
+        .arg(format!("--from {default_branch}"))
+        .assert()
+        .context("create", "create new empty branch")
+        .success();
+
+    // not specifying either should use the current database
+    SERVER
+        .admin_cmd()
+        .arg("branch")
+        .arg("create")
+        .arg("test_branch_3")
+        .assert()
+        .success();
+}
+

--- a/tests/func/non_interactive.rs
+++ b/tests/func/non_interactive.rs
@@ -199,7 +199,9 @@ fn branch_commands() {
         .assert()
         .context("switch", "without specifying an instance")
         .failure()
-        .stderr(predicates::str::contains("Cannot switch branches without specifying the instance"));
+        .stderr(predicates::str::contains(
+            "Cannot switch branches without specifying the instance",
+        ));
 
     // switch requires instance name, so let's link the test instance
     let instance_name = SERVER.ensure_instance_linked();
@@ -238,4 +240,3 @@ fn branch_commands() {
 
     // TODO: test how this works in projects
 }
-


### PR DESCRIPTION
Branch commands depended on project to determine instance which instance is the "current branch" associated with.

This means that it was not possible to do this:
```
edgedb --dns=edgedb://localhost:5656 branch create x
```
... because it would fail complaining about "no project".

Now, instance is first pulled from `--instance` argument, falls back to instance of current project and then is allowed to be missing.

If it is missing, current branch is the specified `--branch`:
```
edgedb --dns=edgedb://localhost:5656 --branch=x branch current --plain
x
```

---

This PR also removes hardcoded default branch name `main` for 5.x+ databases and instead queries the server to get the branch.