### PR TITLE
Use edgedb/test-utils for starting the server in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "append-only-vec"
@@ -529,6 +529,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +713,16 @@ name = "comma"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
+
+[[package]]
+name = "command-fds"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb11bd1378bf3731b182997b40cefe00aba6a6cc74042c8318c1b271d3badf7"
+dependencies = [
+ "nix 0.27.1",
+ "thiserror",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1101,6 +1117,7 @@ dependencies = [
  "termimad",
  "terminal_size 0.2.6",
  "test-case",
+ "test-utils",
  "textwrap",
  "thiserror",
  "tokio",
@@ -1819,7 +1836,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2225,6 +2242,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -3154,18 +3183,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3174,9 +3203,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "indexmap 2.2.3",
  "itoa",
@@ -3584,6 +3613,21 @@ dependencies = [
  "once_cell",
  "pem",
  "tempfile",
+]
+
+[[package]]
+name = "test-utils"
+version = "0.1.0"
+source = "git+https://github.com/edgedb/test-utils.git#bdfb2e4d35b413a65dc3c1c4122e7901f640f77c"
+dependencies = [
+ "anyhow",
+ "command-fds",
+ "fs_extra",
+ "nix 0.28.0",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "shutdown_hooks",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/test-utils.git#a224248c650ff435de55f91ba7b70369d88b775b"
+source = "git+https://github.com/edgedb/test-utils.git#fdb2b93975a92dd3569c9cc0c18e4b64e2a39a0f"
 dependencies = [
  "anyhow",
  "command-fds",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/test-utils.git#7d0185fdd65955cc042e6ed912a5083f5c107692"
+source = "git+https://github.com/edgedb/test-utils.git#a224248c650ff435de55f91ba7b70369d88b775b"
 dependencies = [
  "anyhow",
  "command-fds",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/test-utils.git#bdfb2e4d35b413a65dc3c1c4122e7901f640f77c"
+source = "git+https://github.com/edgedb/test-utils.git#7d0185fdd65955cc042e6ed912a5083f5c107692"
 dependencies = [
  "anyhow",
  "command-fds",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ tokio = {version="1.1.0", features=["rt-multi-thread"]}
 warp = {git="https://github.com/seanmonstar/warp.git", rev="7b07043cee0ca24e912155db4e8f6d9ab7c049ed", default-features=false, features=["tls"]}
 shared-client-tests = {path = "./tests/shared-client-tests"}
 fs_extra = "1.3.0"
+test-utils = {git="https://github.com/edgedb/test-utils.git"}
 
 [build-dependencies]
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ There are a few categories of tests in this repo:
   - invokes the cli binary,
   - run with: `cargo test --test=func`,
   - requires `edgedb-server` binary in PATH,
+  - will use [test-utils](https://github.com/edgedb/test-utils/) to start the server,
 
 - `tests/shared-client-tests/`
   - generates tests from [shared-client-testcases](https://github.com/edgedb/shared-client-testcases/),

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -38,7 +38,7 @@ use crate::portable::platform::optional_docker_check;
 use crate::portable::repository::{self, Channel, PackageInfo, Query};
 use crate::portable::upgrade;
 use crate::portable::ver;
-use crate::portable::ver::{Specific};
+use crate::portable::ver::Specific;
 use crate::portable::windows;
 use crate::print::{self, echo, Highlight};
 
@@ -756,7 +756,7 @@ pub fn init_existing(
             table::settings(rows.as_slice());
 
             if !schema_files {
-                write_schema_default(&schema_dir, &Query::from_version(&specific_version)?)?;
+                write_schema_default(&schema_dir, &Query::from_version(specific_version)?)?;
             }
 
             do_init(
@@ -1081,7 +1081,7 @@ pub fn init_new(
 
             write_config(&config_path, &ver_query)?;
             if !schema_files {
-                write_schema_default(&schema_dir_path, &Query::from_version(&specific_version)?)?;
+                write_schema_default(&schema_dir_path, &Query::from_version(specific_version)?)?;
             }
 
             do_init(

--- a/tests/func/dump_restore.rs
+++ b/tests/func/dump_restore.rs
@@ -1,3 +1,5 @@
+use test_utils::server::ServerInstance;
+
 use crate::{ServerGuard, SERVER};
 
 #[test]
@@ -92,7 +94,7 @@ fn dump_restore_all() {
         .success();
     println!("dumped");
 
-    let new_instance = ServerGuard::start();
+    let new_instance = ServerGuard(ServerInstance::start());
     println!("new instance started");
     new_instance
         .admin_cmd()
@@ -110,5 +112,6 @@ fn dump_restore_all() {
         .assert()
         .success()
         .stdout("\"world\"\n");
+    new_instance.0.stop();
     println!("query");
 }

--- a/tests/func/instance_link.rs
+++ b/tests/func/instance_link.rs
@@ -10,7 +10,7 @@ fn non_interactive_link() {
         .arg("instance")
         .arg("link")
         .arg("--port")
-        .arg(SERVER.port.to_string())
+        .arg(SERVER.0.info.port.to_string())
         .arg("--non-interactive")
         .arg("--trust-tls-cert")
         .arg("--overwrite")

--- a/tests/func/interactive.rs
+++ b/tests/func/interactive.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 #[test]
 fn simple_query() {
     let mut cmd = SERVER.admin_interactive();
-    let main = SERVER.default_branch;
+    let main = SERVER.default_branch();
 
     cmd.exp_string(&format!("{main}>")).unwrap();
     cmd.send_line("SELECT 'abc'++'def';\n").unwrap();
@@ -17,7 +17,7 @@ fn simple_query() {
 #[test]
 fn two_queries() {
     let mut cmd = SERVER.admin_interactive();
-    let main = SERVER.default_branch;
+    let main = SERVER.default_branch();
 
     cmd.exp_string(&format!("{main}>")).unwrap();
     cmd.send_line("SELECT 'AB'++'C'; SELECT 'XY'++'Z';\n")
@@ -29,7 +29,7 @@ fn two_queries() {
 #[test]
 fn test_switch_database() {
     let mut cmd = SERVER.admin_interactive();
-    let main = SERVER.default_branch;
+    let main = SERVER.default_branch();
 
     cmd.exp_string(&format!("{main}>")).unwrap();
     cmd.send_line("create database _test_switch_asdf;").unwrap();
@@ -43,7 +43,7 @@ fn test_switch_database() {
 #[test]
 fn create_report() {
     let mut cmd = SERVER.admin_interactive();
-    let main = SERVER.default_branch;
+    let main = SERVER.default_branch();
 
     cmd.exp_string(&format!("{main}>")).unwrap();
     cmd.send_line("CREATE TYPE default::Type1;\n").unwrap();
@@ -52,7 +52,7 @@ fn create_report() {
 
 #[test]
 fn configured_limit() -> Result<(), Box<dyn Error>> {
-    let main = SERVER.default_branch;
+    let main = SERVER.default_branch();
 
     let config = Config::new(
         r###"

--- a/tests/func/main.rs
+++ b/tests/func/main.rs
@@ -2,20 +2,15 @@
 #[macro_use]
 extern crate pretty_assertions;
 
-use std::convert::TryInto;
 use std::env;
 use std::fs;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process;
 use std::str::FromStr;
-use std::sync::mpsc::sync_channel;
-use std::sync::Mutex;
-use std::thread::{self, JoinHandle};
 
 use assert_cmd::Command;
 use once_cell::sync::Lazy;
-use serde_json::from_str;
+use test_utils::server::ServerInstance;
 
 // Can't run server on windows
 #[cfg(not(windows))]
@@ -38,31 +33,36 @@ mod help;
 #[path = "../common/util.rs"]
 mod util;
 
+struct ServerGuard(ServerInstance);
+
+static SERVER: Lazy<ServerGuard> = Lazy::new(start_server);
+
+fn start_server() -> ServerGuard {
+    shutdown_hooks::add_shutdown_hook(stop_server);
+
+    ServerGuard(ServerInstance::start())
+}
+
+extern "C" fn stop_server() {
+    SERVER.0.stop()
+}
+
 pub struct Config {
     dir: tempfile::TempDir,
 }
 
-#[cfg(not(windows))]
-fn term_process(proc: &mut process::Child) {
-    use nix::sys::signal::{self, Signal};
-    use nix::unistd::Pid;
-
-    if let Err(e) = signal::kill(Pid::from_raw(proc.id() as libc::pid_t), Signal::SIGTERM) {
-        eprintln!("could not send SIGTERM to edgedb-server: {:?}", e);
-    };
-}
-
-#[cfg(windows)]
-fn term_process(proc: &mut process::Child) {
-    // This is suboptimal -- ideally we need to close the process
-    // gracefully on Windows too.
-    if let Err(e) = proc.kill() {
-        eprintln!("could not kill edgedb-server: {:?}", e);
+impl Config {
+    pub fn new(data: &str) -> Config {
+        let tmp_dir = tempfile::tempdir().expect("tmpdir");
+        let dir = tmp_dir.path().join("edgedb");
+        fs::create_dir(&dir).expect("mkdir");
+        fs::write(dir.join("cli.toml"), data.as_bytes()).expect("config");
+        Config { dir: tmp_dir }
+    }
+    pub fn path(&self) -> &Path {
+        self.dir.path()
     }
 }
-
-pub static SHUTDOWN_INFO: Lazy<Mutex<Vec<ShutdownInfo>>> = Lazy::new(|| Mutex::new(Vec::new()));
-pub static SERVER: Lazy<ServerGuard> = Lazy::new(ServerGuard::start);
 
 #[cfg(not(windows))]
 #[test]
@@ -79,140 +79,21 @@ fn version() {
         .stdout(concat!("EdgeDB CLI ", env!("CARGO_PKG_VERSION"), "\n"));
 }
 
-pub struct ShutdownInfo {
-    process: process::Child,
-    thread: Option<JoinHandle<()>>,
-}
-
-pub struct ServerGuard {
-    pub port: u16,
-    runstate_dir: String,
-    tls_cert_file: String,
-    pub default_branch: &'static str,
-}
-
 impl ServerGuard {
-    fn start() -> ServerGuard {
-        use std::process::{Command, Stdio};
-
-        let bin_name = if let Ok(ver) = env::var("EDGEDB_MAJOR_VERSION") {
-            format!("edgedb-server-{}", ver)
+    pub fn default_branch(&self) -> &'static str {
+        if self.0.version_major >= 5 {
+            "main"
         } else {
-            "edgedb-server".to_string()
-        };
-
-        // TODO: execute this in parallel
-        let major_version = get_edgedb_server_version(&bin_name);
-
-        let mut cmd = Command::new(&bin_name);
-        cmd.env("EDGEDB_SERVER_INSECURE_DEV_MODE", "1"); // deprecated
-        cmd.env("EDGEDB_SERVER_SECURITY", "insecure_dev_mode");
-        cmd.arg("--temp-dir");
-        cmd.arg("--testmode");
-        cmd.arg("--echo-runtime-info");
-        cmd.arg("--port=auto");
-        cmd.arg("--generate-self-signed-cert");
-        #[cfg(unix)]
-        if unsafe { libc::geteuid() } == 0 {
-            use std::os::unix::process::CommandExt;
-            // This is moslty true in vagga containers, so run edgedb/postgres
-            // by any non-root user
-            cmd.uid(1);
+            "edgedb"
         }
-        cmd.stdout(Stdio::piped());
-
-        let mut process = cmd
-            .spawn()
-            .unwrap_or_else(|_| panic!("Can run {}", bin_name));
-        let server_stdout = process.stdout.take().expect("stdout is pipe");
-        let (tx, rx) = sync_channel(1);
-        let thread = thread::spawn(move || {
-            let buf = BufReader::new(server_stdout);
-            for line in buf.lines() {
-                match line {
-                    Ok(line) => {
-                        if line.starts_with("EDGEDB_SERVER_DATA:") {
-                            let data: serde_json::Value =
-                                from_str(&line["EDGEDB_SERVER_DATA:".len()..])
-                                    .expect("valid server data");
-                            println!("Server data {:?}", data);
-                            let port = data
-                                .get("port")
-                                .and_then(|x| x.as_u64())
-                                .and_then(|x| x.try_into().ok())
-                                .expect("valid server data");
-                            let runstate_dir = data
-                                .get("runstate_dir")
-                                .and_then(|x| x.as_str())
-                                .map(|x| x.to_owned())
-                                .expect("valid server data");
-                            let tls_cert_file = data
-                                .get("tls_cert_file")
-                                .and_then(|x| x.as_str())
-                                .map(|x| x.to_owned())
-                                .expect("valid server data");
-                            tx.send((port, runstate_dir, tls_cert_file))
-                                .expect("valid channel");
-                            break;
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("Error reading from server: {}", e);
-                        break;
-                    }
-                }
-            }
-        });
-        let (port, runstate_dir, tls_cert_file) = rx.recv().expect("valid port received");
-
-        let mut sinfo = SHUTDOWN_INFO.lock().expect("shutdown mutex works");
-        if sinfo.is_empty() {
-            shutdown_hooks::add_shutdown_hook(stop_processes);
-        }
-        sinfo.push(ShutdownInfo {
-            process,
-            thread: Some(thread),
-        });
-
-        ServerGuard {
-            port,
-            runstate_dir,
-            tls_cert_file,
-            default_branch: if major_version < 5 { "edgedb" } else { "main" },
-        }
-    }
-
-    pub fn version(&self) -> semver::Version {
-        let output = SERVER
-            .admin_cmd()
-            .arg("query")
-            .arg("--output-format=tab-separated")
-            .arg(
-                "
-            WITH v := sys::get_version()
-            SELECT
-                <str>v.major ++ '.' ++ <str>v.minor ++ '.0'
-                ++ (('-' ++ <str>v.stage ++ '.' ++ <str>v.stage_no)
-                    IF v.stage != <sys::VersionStage>'final' ELSE '')
-                ++ (('+' ++ std::array_join(v.local, '.')) IF len(v.local) > 0
-                    ELSE '')
-            ",
-            )
-            .unwrap();
-        std::str::from_utf8(&output.stdout)
-            .unwrap()
-            .strip_suffix('\n')
-            .unwrap()
-            .parse()
-            .unwrap()
     }
 
     pub fn admin_cmd(&self) -> Command {
         let mut cmd = Command::cargo_bin("edgedb").expect("binary found");
         cmd.arg("--no-cli-update-check");
         cmd.arg("--admin");
-        cmd.arg("--unix-path").arg(&self.runstate_dir);
-        cmd.arg("--port").arg(self.port.to_string());
+        cmd.arg("--unix-path").arg(&self.0.info.socket_dir);
+        cmd.arg("--port").arg(self.0.info.port.to_string());
         cmd.env("CLICOLOR", "0");
         cmd
     }
@@ -222,15 +103,8 @@ impl ServerGuard {
         cmd.arg("--no-cli-update-check");
         cmd.arg("--admin");
         // test deprecated --host /unix/path
-        cmd.arg("--host").arg(&self.runstate_dir);
-        cmd.arg("--port").arg(self.port.to_string());
-        cmd.env("CLICOLOR", "0");
-        cmd
-    }
-
-    pub fn raw_cmd(&self) -> Command {
-        let mut cmd = Command::cargo_bin("edgedb").expect("binary found");
-        cmd.arg("--no-cli-update-check");
+        cmd.arg("--host").arg(&self.0.info.socket_dir);
+        cmd.arg("--port").arg(self.0.info.port.to_string());
         cmd.env("CLICOLOR", "0");
         cmd
     }
@@ -243,8 +117,8 @@ impl ServerGuard {
         let mut cmd = process::Command::cargo_bin("edgedb").expect("binary found");
         cmd.arg("--no-cli-update-check");
         cmd.arg("--admin");
-        cmd.arg("--unix-path").arg(&self.runstate_dir);
-        cmd.arg("--port").arg(self.port.to_string());
+        cmd.arg("--unix-path").arg(&self.0.info.socket_dir);
+        cmd.arg("--port").arg(self.0.info.port.to_string());
         spawn_command(cmd, Some(10000)).expect("start interactive")
     }
     #[cfg(not(windows))]
@@ -258,79 +132,19 @@ impl ServerGuard {
         let mut cmd = process::Command::cargo_bin("edgedb").expect("binary found");
         cmd.arg("--no-cli-update-check");
         cmd.arg("--admin");
-        cmd.arg("--unix-path").arg(&self.runstate_dir);
-        cmd.arg("--port").arg(self.port.to_string());
-        cmd.arg("--tls-ca-file").arg(&self.tls_cert_file);
+        cmd.arg("--unix-path").arg(&self.0.info.socket_dir);
+        cmd.arg("--port").arg(self.0.info.port.to_string());
+        cmd.arg("--tls-ca-file").arg(&self.0.info.tls_cert_file);
         cmd.env("CLICOLOR", "0");
         f(&mut cmd);
         spawn_command(cmd, Some(10000)).expect("start interactive")
     }
 
     pub fn database_cmd(&self, database_name: &str) -> Command {
-        let mut cmd = Command::cargo_bin("edgedb").expect("binary found");
-        cmd.arg("--no-cli-update-check");
-        cmd.arg("--admin");
-        cmd.arg("--unix-path").arg(&self.runstate_dir);
-        cmd.arg("--port").arg(self.port.to_string());
+        let mut cmd = self.admin_cmd();
+        cmd.arg("--tls-ca-file").arg(&self.0.info.tls_cert_file);
         cmd.arg("--database").arg(database_name);
-        cmd.arg("--tls-ca-file").arg(&self.tls_cert_file);
         cmd
-    }
-}
-
-fn get_edgedb_server_version(bin_name: &str) -> u8 {
-    use std::process::{Command, Stdio};
-
-    let mut cmd = Command::new(bin_name);
-    cmd.arg("--version");
-    cmd.stdout(Stdio::piped());
-
-    let mut process = cmd.spawn().unwrap();
-    let server_stdout = process.stdout.take().expect("stdout is pipe");
-    let buf = BufReader::new(server_stdout);
-
-    let mut version_str = None;
-    for line in buf.lines() {
-        match line {
-            Ok(line) => {
-                if let Some(line) = line.strip_prefix("edgedb-server, version ") {
-                    version_str = Some(line.split('+').next().unwrap().to_string());
-                    break;
-                }
-            }
-            Err(e) => {
-                eprintln!("Error reading from server: {}", e);
-                break;
-            }
-        }
-    }
-
-    let version_str = version_str.unwrap();
-    let major = version_str.split('.').next().unwrap();
-    major.parse::<u8>().unwrap()
-}
-
-extern "C" fn stop_processes() {
-    let mut items = SHUTDOWN_INFO.lock().expect("shutdown mutex works");
-    for item in items.iter_mut() {
-        term_process(&mut item.process);
-    }
-    for item in items.iter_mut() {
-        item.process.wait().ok();
-        item.thread.take().expect("not yet joined").join().ok();
-    }
-}
-
-impl Config {
-    pub fn new(data: &str) -> Config {
-        let tmp_dir = tempfile::tempdir().expect("tmpdir");
-        let dir = tmp_dir.path().join("edgedb");
-        fs::create_dir(&dir).expect("mkdir");
-        fs::write(dir.join("cli.toml"), data.as_bytes()).expect("config");
-        Config { dir: tmp_dir }
-    }
-    pub fn path(&self) -> &Path {
-        self.dir.path()
     }
 }
 

--- a/tests/func/migrations.rs
+++ b/tests/func/migrations.rs
@@ -720,7 +720,7 @@ fn error() {
         .arg("empty_err")
         .assert()
         .success();
-    let err = if SERVER.version().major >= 4 {
+    let err = if SERVER.0.version_major >= 4 {
         r###"error: Unexpected keyword 'CREATE'
   ┌─ tests/migrations/db1/error/bad.esdl:3:9
   │


### PR DESCRIPTION
edgedb-rust and edgedb-cli both have machinery for running edgedb-server, which is non-trivial amount of code.

I recently changed edgedb-rust to not print edgedb-server output into the console but instead create a log file and write into it instead.

This PR is exporting all that machinery into https://github.com/edgedb/test-utils repo and using that.

In the future, we might want to improve test-utils to allow:
- tests running concurrently, from multiple processes, using [cargo-nextest](https://nexte.st),
- keep the database running between test runs and just wiping it before a new test run, to improve testing times.

The amount of tests of cli and bindings is waaay too low so this step will be even more useful in the future.