### PR TITLE
Add quiet mode for native process

### DIFF
--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -126,6 +126,7 @@ fn spawn_and_check(info: &InstallInfo, ctx: Context, watch: bool) -> anyhow::Res
     let status_dir = tempfile::tempdir().context("tempdir failure")?;
     let mut cmd = process::Native::new("edgedb", "edgedb", server_path);
     cmd.env("NOTIFY_SOCKET", &status_dir.path().join("notify"));
+    cmd.quiet();
     cmd.arg("--temp-dir");
     cmd.arg("--auto-shutdown-after=0");
     cmd.arg("--default-auth-method=Trust");

--- a/src/process.rs
+++ b/src/process.rs
@@ -382,8 +382,8 @@ impl Native {
             (child_result, _, _) = async {
                 tokio::join!(
                     child.wait(),
-                    stdout_loop(mark, out, capture_out.then_some(&mut stdout), !self.quiet),
-                    stdout_loop(mark, err, capture_err.then_some(&mut stderr), !self.quiet),
+                    stdout_loop(mark, out, capture_out.then_some(&mut stdout), self.quiet),
+                    stdout_loop(mark, err, capture_err.then_some(&mut stderr), self.quiet),
                 )
             } => child_result,
             _ = self.signal_loop(pid, &term) => unreachable!(),
@@ -424,7 +424,7 @@ impl Native {
         let out = child.stdout.take();
         let mut res = tokio::select! {
             res = child.wait() => Err(res),
-            _ = stdout_loop(mark, out, Some(&mut stdout), !self.quiet) => Ok(()),
+            _ = stdout_loop(mark, out, Some(&mut stdout), self.quiet) => Ok(()),
             _ = self.signal_loop(pid, &term) => unreachable!(),
         };
 
@@ -524,8 +524,8 @@ impl Native {
             (result, _, _) = async {
                 tokio::join!(
                     self.run_and_kill(child, f),
-                    stdout_loop(&self.marker, out, None, !self.quiet),
-                    stdout_loop(&self.marker, err, None, !self.quiet),
+                    stdout_loop(&self.marker, out, None, self.quiet),
+                    stdout_loop(&self.marker, err, None, self.quiet),
                 )
             } => result,
             _ = self.signal_loop(pid, &term) => unreachable!(),
@@ -561,8 +561,8 @@ impl Native {
             (child_result, _, _) = async {
                 tokio::join!(
                     child.wait(),
-                    stdout_loop(&self.marker, out, None, !self.quiet),
-                    stdout_loop(&self.marker, err, None, !self.quiet),
+                    stdout_loop(&self.marker, out, None, self.quiet),
+                    stdout_loop(&self.marker, err, None, self.quiet),
                 )
             } => child_result,
             _ = feed_data(inp, data) => unreachable!(),
@@ -800,7 +800,7 @@ async fn stdout_loop(
     marker: &str,
     pipe: Option<impl AsyncRead + Unpin>,
     capture_buffer: Option<&mut Vec<u8>>,
-    print: bool,
+    quiet: bool,
 ) {
     match (pipe, capture_buffer) {
         (Some(mut pipe), Some(buffer)) => {
@@ -815,30 +815,20 @@ async fn stdout_loop(
             let buf = BufReader::new(pipe);
             let mut lines = buf.lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                if !print {
-                    continue;
-                }
-
-                if cfg!(windows) {
-                    io::stderr()
-                        .write_all(
-                            format!("[{}] {}\r\n", marker, line)
-                                .color(Color::Grey37)
-                                .to_string()
-                                .as_bytes(),
-                        )
-                        .await
-                        .ok();
+                let message = if cfg!(windows) {
+                    format!("[{}] {}\r\n", marker, line)
+                        .color(Color::Grey37)
+                        .to_string()
                 } else {
-                    io::stderr()
-                        .write_all(
-                            format!("[{}] {}\n", marker, line)
-                                .color(Color::Grey37)
-                                .to_string()
-                                .as_bytes(),
-                        )
-                        .await
-                        .ok();
+                    format!("[{}] {}\n", marker, line)
+                        .color(Color::Grey37)
+                        .to_string()
+                };
+
+                if quiet {
+                    log::debug!("{}", message);
+                } else {
+                    io::stderr().write_all(message.as_bytes()).await.ok();
                 }
             }
         }


### PR DESCRIPTION
### Summary
Sometimes, questionable/confusing output is displayed from sub-processes, ex in `edgedb project upgrade` on macos gives the following:
```
% edgedb project upgrade
Version 5.1+4ced01b is already downloaded
The schema is forward compatible. Ready for upgrade.
[edgedb] ---- Exception occurred: SIGTERM ----
[edgedb] 
[edgedb] 
[edgedb] ---- Traceback ----
[edgedb] 
[edgedb]     /Users/evan/Library/Application Support/edgedb/portable/5.1/lib/python3.12/site-packages/edb/common/signalctl.py, line 205, in wait_for
[edgedb] 2. asyncio.exceptions.CancelledError: 
[edgedb]         > return fut.result()
[edgedb]     /Users/evan/Library/Application Support/edgedb/portable/5.1/lib/python3.12/site-packages/edb/server/server.py, line 1705, in stop
[edgedb]         > await self._destroy_compiler_pool()
[edgedb]     /Users/evan/Library/Application Support/edgedb/portable/5.1/lib/python3.12/site-packages/edb/server/server.py, line 522, in _destroy_compiler_pool
[edgedb]         > await self._compiler_pool.stop()
[edgedb]     /Users/evan/Library/Application Support/edgedb/portable/5.1/lib/python3.12/site-packages/edb/server/compiler_pool/pool.py, line 768, in stop
[edgedb]         > await self._stop()
[edgedb]     /Users/evan/Library/Application Support/edgedb/portable/5.1/lib/python3.12/site-packages/edb/server/compiler_pool/pool.py, line 913, in _stop
[edgedb]         > await transport._wait()
[edgedb] 
[edgedb] asyncio.exceptions.CancelledError: 
... 
```
The `SIGTERM` error is handled internally but still displayed as output which can be confusing. This PR adds a `quiet` mode for sub-processes which redirects this output to debug logs.