### PR TITLE
Fix: Set branch when updating credentials

### DIFF
--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -65,6 +65,7 @@ impl Context {
         let mut credentials = credentials::read(&path).await?;
 
         credentials.database = Some(branch.to_string());
+        credentials.branch = Some(branch.to_string());
 
         credentials::write_async(&path, &credentials).await
     }


### PR DESCRIPTION
Seems like I forgot to update the switch code when we added `branch` to edgedb-rust