### PR TITLE
Fix for initial installation when the CLI does the arch switch on macOS

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -195,8 +195,14 @@ fn _main(options: &CliUpgrade, path: PathBuf) -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let down_dir = path
+        .parent()
+        .context("download path missing directory component")?;
+    fs::create_dir_all(down_dir).with_context(|| format!("failed to create {:?}", down_dir))?;
+
     let down_path = path.with_extension("download");
     let tmp_path = tmp_file_path(&path);
+
     download(&down_path, &pkg.url, options.quiet)?;
     unpack_file(&down_path, &tmp_path, pkg.compression)?;
 


### PR DESCRIPTION
When the CLI installs itself on macOS it checks if the correct binary
architecture was downloaded (i.e. aarch64 for Apple Silicon), and if the
binary is x86, it calls the `upgrade` path instead to download the
correct binary.  Unfortunately, the `upgrade` path assumes the
installation directory already exists, and it doesn't on the initial
install, so the whole thing fails with "No such file or directory".

Fix this by making the directories on upgrade too.
