### PR TITLE
Fix force_database_error and get_current_branch

### DIFF
--- a/src/analyze/tree.rs
+++ b/src/analyze/tree.rs
@@ -6,7 +6,6 @@ use crate::analyze::model::{ChildName, Cost, DebugNode, Shape};
 use crate::analyze::table;
 use crate::print::Highlight;
 
-struct Opt<'a, T>(&'a Option<T>);
 struct Border;
 
 #[derive(Debug, Clone)]
@@ -215,15 +214,6 @@ fn visit_debug_tree<'x>(
 
     for (child, ch) in marker.children(&node.plans) {
         visit_debug_tree(result, explain, child, ch);
-    }
-}
-
-impl<'a, T: fmt::Display> fmt::Display for Opt<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            None => write!(f, "∅"),
-            Some(v) => v.fmt(f),
-        }
     }
 }
 

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -92,10 +92,7 @@ impl Context {
 
         // if the connection branch is the default branch, query the database to see
         // what that default is
-        let branch: String = connection
-            .query_required_single("select sys::get_current_database()", &())
-            .await?;
-        Ok(branch)
+        Ok(connection.get_current_branch().await?.to_string())
     }
 
     pub fn can_update_current_branch(&self) -> bool {

--- a/src/portable/upgrade.rs
+++ b/src/portable/upgrade.rs
@@ -18,7 +18,6 @@ use crate::portable::options::{instance_arg, InstanceName, Upgrade};
 use crate::portable::project;
 use crate::portable::repository::{self, Channel, PackageInfo, Query, QueryOptions};
 use crate::portable::ver;
-use crate::portable::ver::Specific;
 use crate::portable::windows;
 use crate::print::{self, echo, Highlight};
 use crate::question;

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -179,9 +179,7 @@ impl State {
         }
         self.conn_params = params;
         self.branch = branch.into();
-        self.current_branch = conn
-            .query_required_single("select sys::get_current_database()", &())
-            .await?;
+        self.current_branch = Some(conn.get_current_branch().await?.to_string());
         self.connection = Some(conn);
         self.read_state();
         self.set_idle_transaction_timeout().await?;

--- a/tests/func/non_interactive.rs
+++ b/tests/func/non_interactive.rs
@@ -251,3 +251,31 @@ fn hash_password() {
         .success()
         .stdout(predicates::str::starts_with("SCRAM-SHA-256$"));
 }
+
+#[test]
+fn force_database_error() {
+    SERVER
+        .admin_cmd()
+        .arg("query")
+        .arg(
+            r#"configure current database
+                set force_database_error := 
+                  '{"type": "QueryError", "message": "ongoing maintenance"}';
+            "#,
+        )
+        .assert()
+        .context("set force_database_error", "should succeed")
+        .success();
+
+    SERVER
+        .admin_cmd()
+        .arg("query")
+        .arg(
+            r#"configure current database
+                reset force_database_error;
+            "#,
+        )
+        .assert()
+        .context("reset force_database_error", "should succeed")
+        .success();
+}


### PR DESCRIPTION
When opening REPL, we query `sys::get_current_database`.
If `force_database_error` is set, this query fail, preventing even
entering the REPL, which is bad for obvious reasons.

I've made sure to override `force_database_error` is these queries
and even made it so if we already have branch set in connection
options, we don't even make the query, but just use that query param
as the current branch.

Closes #1321
