### PR TITLE
Improve error message for `migration extract` and add tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,8 @@ fn main() {
                 let mut error_chain = err.chain();
                 if let Some(first) = error_chain.next() {
                     print::error(first);
+                } else {
+                    print::error(" <empty error message>");
                 }
                 for e in error_chain {
                     eprintln!("  Caused by: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,13 @@ fn main() {
             if let Some(e) = err.downcast_ref::<edgedb_errors::Error>() {
                 print::edgedb_error(e, false);
             } else {
-                print::error(err);
+                let mut error_chain = err.chain();
+                if let Some(first) = error_chain.next() {
+                    print::error(first);
+                }
+                for e in error_chain {
+                    eprintln!("  Caused by: {e}");
+                }
             }
             for item in err.chain() {
                 if let Some(e) = item.downcast_ref::<hint::HintedError>() {

--- a/tests/migrations/db1/extract01/default.esdl
+++ b/tests/migrations/db1/extract01/default.esdl
@@ -1,0 +1,5 @@
+module default {
+    type Type1 {
+        property field1 -> str;
+    };
+};


### PR DESCRIPTION
This PR:
- makes anyhow errors print into multiple lines, one "context" after another
  ```
  edgedb error: Cannot write dbschema/migrations/00001-m1ertew.edgeql
    Caused by: failed to copy file from /tmp/.tmpHqPxuN/migrations/00001-m1ertew.edgeql to /home/aljaz/EdgeDB/demo-5/dbschema/migrations/00001-m1ertew.edgeql
    Caused by: Permission denied (os error 13)
  ```

- improves `migration extract` to create `dbschema/migrations/` dir if it does not exist before writing,
  (this happens only if `dbschema/` dir already exists)

- improves the error message for writing files in `migration extract` from this:

    ```
    $ edgedb migration extract
    Writing: /home/aljaz/EdgeDB/demo-5/dbschema/migrations/00001-m1ertew.edgeql
    edgedb error: Cannot write dbschema/migrations/00001-m1ertew.edgeql: failed to copy file from /tmp/.tmps3flNq/migrations/00001-m1ertew.edgeql to /home/aljaz/EdgeDB/demo-5/dbschema/migrations/00001-m1ertew.edgeql: Permission denied (os error 13)
    ```
    ... to the error message above.
