### PR TITLE
Bump version to 5.3.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,7 +1022,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "edgedb-cli"
-version = "5.2.0-dev"
+version = "5.3.0-dev"
 dependencies = [
  "ansi-escapes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [package]
 name = "edgedb-cli"
 license = "MIT/Apache-2.0"
-version = "5.2.0-dev"
+version = "5.3.0-dev"
 authors = ["EdgeDB Inc. <hello@edgedb.com>"]
 edition = "2018"
 


### PR DESCRIPTION
once [5.2.0](https://github.com/edgedb/edgedb-cli/actions/runs/9943698310) is out