### PR TITLE
Revert dump overwrite default to true

### DIFF
--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -411,8 +411,8 @@ pub struct Dump {
     pub format: Option<DumpFormat>,
 
     /// Used to automatically overwrite existing files of the same name. Defaults
-    /// to `true` when `--all` is used, otherwise `false`.
-    #[arg(long)]
+    /// to `true`.
+    #[arg(long, default_value = "true")]
     pub overwrite_existing: bool,
 }
 


### PR DESCRIPTION
A proper fix would be to treat `/dev/` differently than the current branch of disabling overwriting, but let's allow overwriting for all first.