### PR TITLE
Update outdated dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex 0.7.2",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size 0.3.0",
 ]
 
@@ -1048,7 +1048,7 @@ dependencies = [
  "base32",
  "base64 0.22.1",
  "bigdecimal",
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "bitvec",
  "blake2b_simd",
  "blake3",
@@ -1100,7 +1100,7 @@ dependencies = [
  "openssl",
  "os-release",
  "pem",
- "predicates 2.1.5",
+ "predicates 3.1.2",
  "pretty_assertions",
  "prettytable-rs",
  "rand",
@@ -1126,8 +1126,8 @@ dependencies = [
  "shell-escape",
  "shutdown_hooks",
  "signal-hook",
- "snafu 0.7.5",
- "strsim 0.10.0",
+ "snafu",
+ "strsim",
  "tar",
  "tempfile",
  "term 1.0.0",
@@ -1205,7 +1205,7 @@ dependencies = [
  "edgedb-errors",
  "num-bigint",
  "num-traits",
- "snafu 0.8.4",
+ "snafu",
  "uuid",
 ]
 
@@ -1261,7 +1261,7 @@ dependencies = [
  "phf",
  "serde_json",
  "sha2",
- "snafu 0.8.4",
+ "snafu",
  "thiserror",
  "unicode-width",
 ]
@@ -2010,13 +2010,11 @@ dependencies = [
 
 [[package]]
 name = "immutable-chunkmap"
-version = "1.0.5"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7617eb072b88069788fa9d5cadae34faebca64e5325ec5deaa2b4c96510f9e8c"
+checksum = "4419f022e55cc63d5bbd6b44b71e1d226b9c9480a47824c706e9d54e5c40c5eb"
 dependencies = [
  "arrayvec",
- "packed_struct",
- "packed_struct_codegen",
 ]
 
 [[package]]
@@ -2237,7 +2235,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2667,27 +2665,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
-name = "packed_struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
-dependencies = [
- "bitvec",
- "packed_struct_codegen",
-]
-
-[[package]]
-name = "packed_struct_codegen"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,7 +2928,10 @@ checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -3278,14 +3258,23 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rpassword"
-version = "6.0.1"
+version = "7.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf099a1888612545b683d2661a1940089f6c2e5a8e38979b2159da876bfd956"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
 dependencies = [
  "libc",
- "serde",
- "serde_json",
- "winapi",
+ "rtoolbox",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3700,34 +3689,11 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "snafu"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
-dependencies = [
- "backtrace",
- "doc-comment",
- "snafu-derive 0.7.5",
-]
-
-[[package]]
-name = "snafu"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b835cb902660db3415a672d862905e791e54d306c6e8189168c7f3d9ae1c79d"
 dependencies = [
- "snafu-derive 0.8.4",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "snafu-derive",
 ]
 
 [[package]]
@@ -3773,12 +3739,6 @@ name = "strict"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -3948,24 +3908,35 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-case"
-version = "2.2.2"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d6cf5a7dffb3f9dceec8e6b8ca528d9bd71d36c9f074defb548ce161f598c0"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
 dependencies = [
  "test-case-macros",
 ]
 
 [[package]]
-name = "test-case-macros"
-version = "2.2.2"
+name = "test-case-core"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45b7bf6e19353ddd832745c8fcf77a17a93171df7151187f26623f2b75b5b26"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
  "cfg-if",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "test-case-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
  "bstr",
  "doc-comment",
  "libc",
- "predicates 3.1.2",
+ "predicates",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -642,7 +642,7 @@ version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -1011,7 +1011,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1087,7 +1087,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1156,7 +1156,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "immutable-chunkmap",
- "indexmap 2.0.0-pre",
+ "indexmap 2.5.0",
  "indicatif",
  "is-terminal",
  "libc",
@@ -1173,7 +1173,7 @@ dependencies = [
  "openssl",
  "os-release",
  "pem",
- "predicates 3.1.2",
+ "predicates",
  "pretty_assertions",
  "prettytable-rs",
  "rand",
@@ -1237,8 +1237,8 @@ version = "0.4.0"
 dependencies = [
  "clap 4.5.17",
  "clap_generate",
- "heck 0.4.1",
- "indexmap 2.0.0-pre",
+ "heck",
+ "indexmap 2.5.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1796,12 +1796,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1833,12 +1827,6 @@ checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http 0.2.12",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2106,21 +2094,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0-pre"
-source = "git+https://github.com/bluss/indexmap?rev=11ac52c#11ac52c3c828a42d69c5fb3248198511836bfd2f"
-dependencies = [
- "hashbrown 0.13.2",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -2229,15 +2209,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -2992,20 +2963,6 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
@@ -3689,8 +3646,8 @@ dependencies = [
  "assert_cmd",
  "edgedb-protocol",
  "hex",
- "indexmap 2.0.0-pre",
- "predicates 2.1.5",
+ "indexmap 2.5.0",
+ "predicates",
  "serde_json",
  "sha1",
  "tempfile",
@@ -3792,7 +3749,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -5028,7 +4985,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5047,7 +5004,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "hmac",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +60,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "ansi-escapes"
@@ -115,6 +133,15 @@ name = "append-only-vec"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d9f7083455f1a474276ccd32374958d2cb591024aac45101c7623b10271347"
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -375,12 +402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
 name = "bigdecimal"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,7 +447,7 @@ checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -439,7 +460,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -757,12 +778,6 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
@@ -793,6 +808,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +824,21 @@ checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc16"
@@ -944,12 +983,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
+
+[[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1015,6 +1077,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1155,7 +1228,7 @@ dependencies = [
  "winreg",
  "wslapi",
  "zip",
- "zstd 0.12.4",
+ "zstd",
 ]
 
 [[package]]
@@ -1732,6 +1805,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "headers"
@@ -2252,21 +2329,25 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libflate"
-version = "1.4.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff4ae71b685bbad2f2f391fe74f6b7659a34871c08b210fdc039e43bee07d18"
+checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
 dependencies = [
  "adler32",
+ "core2",
  "crc32fast",
+ "dary_heap",
  "libflate_lz77",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "1.2.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
+checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
 dependencies = [
+ "core2",
+ "hashbrown 0.14.5",
  "rle-decode-fast",
 ]
 
@@ -2310,12 +2391,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
 ]
 
 [[package]]
@@ -2719,17 +2816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,14 +2823,12 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]
@@ -3659,6 +3743,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "siphasher"
@@ -4935,62 +5025,79 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
+]
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494"
 dependencies = [
  "aes",
- "byteorder",
+ "arbitrary",
  "bzip2",
- "constant_time_eq 0.1.5",
+ "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
  "flate2",
  "hmac",
+ "indexmap 2.4.0",
+ "lzma-rs",
+ "memchr",
  "pbkdf2",
+ "rand",
  "sha1",
+ "thiserror",
  "time",
- "zstd 0.11.2+zstd.1.5.2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe 6.0.6",
+ "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
-dependencies = [
- "libc",
  "zstd-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,18 +585,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "bitflags 1.3.2",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
@@ -613,18 +601,9 @@ checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.2",
+ "clap_lex",
  "strsim",
- "terminal_size 0.3.0",
-]
-
-[[package]]
-name = "clap_complete"
-version = "3.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
-dependencies = [
- "clap 3.2.25",
+ "terminal_size",
 ]
 
 [[package]]
@@ -633,7 +612,7 @@ version = "4.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d7f143a7e709cbe6c34853dcd3bb1370c7e1bb4d9e7310ca8cb40b490ae035"
 dependencies = [
- "clap 4.5.17",
+ "clap",
 ]
 
 [[package]]
@@ -646,25 +625,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
-]
-
-[[package]]
-name = "clap_generate"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1b28c4a802ac3628604fd267cac62aaea74dc61af3410db6b1c44c03b42599"
-dependencies = [
- "clap 3.2.25",
- "clap_complete 3.2.5",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -1127,8 +1087,8 @@ dependencies = [
  "blake3",
  "bytes",
  "chrono",
- "clap 4.5.17",
- "clap_complete 4.5.25",
+ "clap",
+ "clap_complete",
  "clicolors-control",
  "codespan-reporting",
  "color-print",
@@ -1156,7 +1116,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "immutable-chunkmap",
- "indexmap 2.5.0",
+ "indexmap",
  "indicatif",
  "is-terminal",
  "libc",
@@ -1206,7 +1166,7 @@ dependencies = [
  "term 1.0.0",
  "termcolor",
  "termimad",
- "terminal_size 0.3.0",
+ "terminal_size",
  "test-case",
  "test-utils",
  "textwrap",
@@ -1235,14 +1195,13 @@ dependencies = [
 name = "edgedb-cli-derive"
 version = "0.4.0"
 dependencies = [
- "clap 4.5.17",
- "clap_generate",
+ "clap",
  "heck",
- "indexmap 2.5.0",
+ "indexmap",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
  "termimad",
  "trybuild",
 ]
@@ -1328,7 +1287,7 @@ dependencies = [
  "base32",
  "bigdecimal",
  "bumpalo",
- "indexmap 2.5.0",
+ "indexmap",
  "memchr",
  "num-bigint",
  "phf",
@@ -1762,7 +1721,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1781,18 +1740,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2084,22 +2037,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
  "serde",
 ]
 
@@ -2318,7 +2261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
 dependencies = [
  "core2",
- "hashbrown 0.14.5",
+ "hashbrown",
  "rle-decode-fast",
 ]
 
@@ -2727,12 +2670,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,7 +2960,6 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
  "version_check",
 ]
 
@@ -3562,7 +3498,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -3646,7 +3582,7 @@ dependencies = [
  "assert_cmd",
  "edgedb-protocol",
  "hex",
- "indexmap 2.5.0",
+ "indexmap",
  "predicates",
  "serde_json",
  "sha1",
@@ -3929,16 +3865,6 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
-dependencies = [
- "rustix 0.37.27",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "terminal_size"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
@@ -4019,7 +3945,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
  "smawk",
- "terminal_size 0.2.6",
  "unicode-linebreak",
  "unicode-width",
 ]
@@ -4247,7 +4172,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5004,7 +4929,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "hmac",
- "indexmap 2.5.0",
+ "indexmap",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,20 +977,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1001,17 +992,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1083,7 +1063,7 @@ dependencies = [
  "combine",
  "crossbeam-utils",
  "ctrlc",
- "dirs 4.0.0",
+ "dirs",
  "dissimilar",
  "downcast-rs",
  "edgedb-cli-derive",
@@ -1093,7 +1073,7 @@ dependencies = [
  "edgedb-tokio",
  "edgeql-parser",
  "env_logger",
- "fd-lock 3.0.13",
+ "fd-lock 4.0.2",
  "fn-error-context",
  "fs-err",
  "fs_extra",
@@ -1111,7 +1091,7 @@ dependencies = [
  "log",
  "minimad",
  "native-tls",
- "nix 0.26.4",
+ "nix 0.29.0",
  "nom",
  "notify",
  "num-bigint",
@@ -1241,7 +1221,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "crc16",
- "dirs 5.0.1",
+ "dirs",
  "edgedb-derive",
  "edgedb-errors",
  "edgedb-protocol",
@@ -1412,13 +1392,13 @@ dependencies = [
 
 [[package]]
 name = "fd-lock"
-version = "3.0.13"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
  "rustix 0.38.35",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1652,12 +1632,12 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+checksum = "dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30"
 dependencies = [
- "libc",
- "windows-targets 0.48.5",
+ "rustix 0.38.35",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2140,6 +2120,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2137,16 @@ dependencies = [
  "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2508,20 +2507,21 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
-version = "5.2.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
+ "log",
  "mio 0.8.11",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2582,12 +2582,13 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "open"
-version = "3.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
+checksum = "61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3"
 dependencies = [
+ "is-wsl",
+ "libc",
  "pathdiff",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4645,14 +4646,14 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
- "once_cell",
  "rustix 0.38.35",
+ "winsafe",
 ]
 
 [[package]]
@@ -4729,30 +4730,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -4776,21 +4753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4826,12 +4788,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -4844,12 +4800,6 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -4859,12 +4809,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4886,12 +4830,6 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -4901,12 +4839,6 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4922,12 +4854,6 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -4937,12 +4863,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4967,12 +4887,19 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wslapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,7 +1213,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "toml 0.5.11",
+ "toml",
  "tracing",
  "unicode-segmentation",
  "unicode-width",
@@ -4265,15 +4265,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
@@ -4382,7 +4373,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "termcolor",
- "toml 0.8.19",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "ansi-escapes"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3c0daaaae24df5995734b689627f8fa02101bc5bbc768be3055b66a010d7af"
+checksum = "10b98e9c74265950a28ae39c02e290858714c23071ab4f71c61d2908e2edfe44"
 
 [[package]]
 name = "anstream"
@@ -703,9 +703,9 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colorful"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97af0562545a7d7f3d9222fcf909963bec36dcb502afaacab98c6ffac8da47ce"
+checksum = "ffb474a9c3219a8254ead020421ecf1b90427f29b55f6aae9a2471fa62c126ef"
 
 [[package]]
 name = "combine"
@@ -769,9 +769,9 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "coolor"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4d7a805ca0d92f8c61a31c809d4323fdaa939b0b440e544d21db7797c5aaad"
+checksum = "691defa50318376447a73ced869862baecfab35f6aabaa91a4cd726b315bfe1a"
 dependencies = [
  "crossterm",
 ]
@@ -814,6 +814,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crokey"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520e83558f4c008ac06fa6a86e5c1d4357be6f994cce7434463ebcdaadf47bb1"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370956e708a1ce65fe4ac5bb7185791e0ece7485087f17736d54a23a0895049f"
+dependencies = [
+ "crossterm",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -874,15 +900,15 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
-version = "0.23.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "crossterm_winapi",
- "libc",
- "mio 0.8.11",
+ "mio 1.0.2",
  "parking_lot 0.12.3",
+ "rustix 0.38.35",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1056,7 +1082,6 @@ dependencies = [
  "colorful",
  "combine",
  "crossbeam-utils",
- "crossterm",
  "ctrlc",
  "dirs 4.0.0",
  "dissimilar",
@@ -1125,10 +1150,10 @@ dependencies = [
  "strsim 0.10.0",
  "tar",
  "tempfile",
- "term",
+ "term 1.0.0",
  "termcolor",
  "termimad",
- "terminal_size 0.2.6",
+ "terminal_size 0.3.0",
  "test-case",
  "test-utils",
  "textwrap",
@@ -2194,6 +2219,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8e41c97e6bc7ecb552016274b99fbb5d035e8de288c582d9b933af6677bfda"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e1d8b05d672c53cb9c7b920bbba8783845ae4f0b076e02a3db1d02c81b4163"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.76",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,9 +2360,9 @@ checksum = "fc0a023a2715164b8a15b7f91a4baa3decc92158a539b96bf0bdb61f18c69366"
 
 [[package]]
 name = "minimad"
-version = "0.9.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277639f0198568f70f8fe4ab88a52a67c96bca12f27ba5c17a76acdcb8b45834"
+checksum = "a9c5d708226d186590a7b6d4a9780e2bdda5f689e0d58cd17012a298efd745d2"
 dependencies = [
  "once_cell",
 ]
@@ -2363,6 +2411,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -2939,7 +2988,7 @@ dependencies = [
  "encode_unicode 1.0.0",
  "is-terminal",
  "lazy_static",
- "term",
+ "term 0.7.0",
  "unicode-width",
 ]
 
@@ -3608,7 +3657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio 0.8.11",
+ "mio 1.0.2",
  "signal-hook",
 ]
 
@@ -3717,6 +3766,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
 
 [[package]]
 name = "strsim"
@@ -3830,6 +3885,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df4175de05129f31b80458c6df371a15e7fc3fd367272e6bf938e5c351c7ea0"
+dependencies = [
+ "home",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,14 +3905,16 @@ dependencies = [
 
 [[package]]
 name = "termimad"
-version = "0.20.6"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfab44b4bc17601cf226cce31c87462a4a5bd5d325948c8ebbc9e715660a1287"
+checksum = "920e7c4671e79f3d9df269da9c8edf0dbc580044fd727d3594f7bfba5eb6107a"
 dependencies = [
  "coolor",
+ "crokey",
  "crossbeam",
- "crossterm",
+ "lazy-regex",
  "minimad",
+ "serde",
  "thiserror",
  "unicode-width",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,7 +1115,7 @@ dependencies = [
  "edgedb-tokio",
  "edgeql-parser",
  "env_logger",
- "fd-lock 4.0.2",
+ "fd-lock",
  "fn-error-context",
  "fs-err",
  "fs_extra",
@@ -1371,6 +1380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,16 +1426,6 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
-
-[[package]]
-name = "fd-lock"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0010f02effd88c702318c5dde0463206be67495d0b4d906ba7c0a8f166cc7f06"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "fd-lock"
@@ -3363,24 +3368,24 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rustyline"
-version = "8.0.0"
-source = "git+https://github.com/tailhook/rustyline?branch=edgedb_20210403#8c0afd236b4869f9fbf41a6a322149feacbe49bd"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "cfg-if",
- "dirs-next",
- "fd-lock 2.0.0",
+ "clipboard-win",
+ "fd-lock",
+ "home",
  "libc",
  "log",
  "memchr",
- "nix 0.26.4",
+ "nix 0.28.0",
  "radix_trie",
- "scopeguard",
- "smallvec",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,13 +303,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -355,12 +355,6 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base32"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
 name = "base32"
@@ -522,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
 dependencies = [
  "jobserver",
  "libc",
@@ -582,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -592,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -614,11 +608,11 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.24"
+version = "4.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7db6eca8c205649e8d3ccd05aa5042b1800a784e56bc7c43524fde8abbfa9b"
+checksum = "18d7f143a7e709cbe6c34853dcd3bb1370c7e1bb4d9e7310ca8cb40b490ae035"
 dependencies = [
- "clap 4.5.16",
+ "clap 4.5.17",
 ]
 
 [[package]]
@@ -630,7 +624,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -698,7 +692,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1045,8 +1039,8 @@ dependencies = [
  "assert_cmd",
  "async-listen",
  "backtrace",
- "base32 0.4.0",
- "base64 0.21.7",
+ "base32",
+ "base64 0.22.1",
  "bigdecimal",
  "bitflags 1.3.2",
  "bitvec",
@@ -1054,8 +1048,8 @@ dependencies = [
  "blake3",
  "bytes",
  "chrono",
- "clap 4.5.16",
- "clap_complete 4.5.24",
+ "clap 4.5.17",
+ "clap_complete 4.5.25",
  "clicolors-control",
  "codespan-reporting",
  "color-print",
@@ -1073,7 +1067,7 @@ dependencies = [
  "edgedb-protocol",
  "edgedb-tokio",
  "edgeql-parser",
- "env_logger 0.10.2",
+ "env_logger",
  "fd-lock 3.0.13",
  "fn-error-context",
  "fs-err",
@@ -1163,7 +1157,7 @@ dependencies = [
 name = "edgedb-cli-derive"
 version = "0.4.0"
 dependencies = [
- "clap 4.5.16",
+ "clap 4.5.17",
  "clap_generate",
  "heck 0.4.1",
  "indexmap 2.0.0-pre",
@@ -1182,7 +1176,7 @@ source = "git+https://github.com/edgedb/edgedb-rust/#9025de8e629584d91aa91135ab7
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
  "trybuild",
 ]
 
@@ -1250,10 +1244,10 @@ dependencies = [
 [[package]]
 name = "edgeql-parser"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb#9d6f484ea8a14a7d1f10c7a334c765fa34924337"
+source = "git+https://github.com/edgedb/edgedb#9def2e608ef1f5ad2c3874d2b468cdf5f93adaa6"
 dependencies = [
  "append-only-vec",
- "base32 0.5.1",
+ "base32",
  "bigdecimal",
  "bumpalo",
  "indexmap 2.5.0",
@@ -1308,19 +1302,6 @@ checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
  "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1454,7 +1435,7 @@ checksum = "2cd66269887534af4b0c3e3337404591daa8dc8b9b2b3db71f9523beb4bafb41"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1601,7 +1582,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1961,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
@@ -2583,7 +2564,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2594,9 +2575,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.1+3.3.1"
+version = "300.3.2+3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
 dependencies = [
  "cc",
 ]
@@ -2785,7 +2766,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2814,7 +2795,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3061,15 +3042,6 @@ name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -3501,14 +3473,14 @@ checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "indexmap 2.5.0",
  "itoa",
@@ -3717,7 +3689,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3777,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3983,7 +3955,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4069,7 +4041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58d491693b54014df34a52e25519be0f38cd97fe9fc8f2a6c541becab45f808b"
 dependencies = [
  "anyhow",
- "env_logger 0.11.5",
+ "env_logger",
  "log",
  "pem",
  "test-cert-gen-2",
@@ -4103,7 +4075,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4140,9 +4112,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4151,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4252,7 +4224,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4493,7 +4465,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -4527,7 +4499,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4597,9 +4569,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.3"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4618,11 +4590,11 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.3",
  "wasite",
  "web-sys",
 ]
@@ -4990,7 +4962,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ indicatif = "0.17.0"
 url = { version = "2.1.1", features=["serde"] }
 immutable-chunkmap = "2.0.5"
 regex = "1.4.5"
-toml = "0.5.8"
+toml = "0.8.19"
 termimad = {workspace=true}
 minimad = "0.13.1"
 edgedb-cli-derive = { path="edgedb-cli-derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ anyhow = "1.0.23"
 bytes = "1.5.0"
 blake2b_simd = "1.0.0"
 blake3 = "1.1.0"
-rustyline = { git="https://github.com/tailhook/rustyline", branch="edgedb_20210403"}
+rustyline = { version = "14.0.0" }
 clap = {workspace = true, features=["derive", "cargo", "deprecated", "wrap_help"]}
 clap_complete = "4.4.3"
 color-print = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ docker_test_wrapper = []
 
 [workspace.dependencies]
 clap = "4.4.6"
-clap_generate = "3.0.3"
 termimad = "0.30.0"
 trybuild = "1.0.19"
 indexmap = {version = "2.4", features=["serde"]}
@@ -76,7 +75,7 @@ termcolor = "1.1.0"
 async-listen = "0.2.0"
 sha1 = "0.10.1"
 hex = {version="0.4.3", features=["serde"]}
-textwrap = {version="0.16.0", features=["terminal_size"]}
+textwrap = "0.16.0"
 log = "0.4.8"
 env_logger = "0.11.0"
 os-release = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,11 +121,11 @@ arc-swap = "1.4.0"
 ctrlc = "3.2.0"
 crossbeam-utils = "0.8.5"
 tar = "0.4.37"
-zstd = "0.12"
+zstd = "0.13"
 semver = {version="1.0.4", features=["serde"]}
 fd-lock = "4.0.2"
-zip = "0.6.2"
-libflate = "1.1.1"
+zip = "2.2.0"
+libflate = "2.1.0"
 open = "5.3.0"
 tokio = {version="1.23.0",features=[
     "macros", "rt", "rt-multi-thread", "fs", "process", "io-std", "net",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,8 @@ clap = "4.4.6"
 clap_generate = "3.0.3"
 termimad = "0.30.0"
 trybuild = "1.0.19"
-# we need slicing of indexmap, so need version 2.0
-indexmap = {git="https://github.com/bluss/indexmap", rev="11ac52c", features=["serde"]}
-heck = "0.4.0"
+indexmap = {version = "2.4", features=["serde"]}
+heck = "0.5.0"
 
 [dependencies]
 edgeql-parser = {git = "https://github.com/edgedb/edgedb"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ docker_test_wrapper = []
 [workspace.dependencies]
 clap = "4.4.6"
 clap_generate = "3.0.3"
-termimad = "0.20.1"
+termimad = "0.30.0"
 trybuild = "1.0.19"
 # we need slicing of indexmap, so need version 2.0
 indexmap = {git="https://github.com/bluss/indexmap", rev="11ac52c", features=["serde"]}
@@ -39,7 +39,7 @@ edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust/"}
 edgedb-errors = {git = "https://github.com/edgedb/edgedb-rust/"}
 edgedb-tokio = {git = "https://github.com/edgedb/edgedb-rust/", features=["admin_socket", "unstable"]}
 snafu = {version="0.7.0", features=["backtraces"]}
-ansi-escapes = "0.1"
+ansi-escapes = "0.2"
 anyhow = "1.0.23"
 bytes = "1.5.0"
 blake2b_simd = "1.0.0"
@@ -53,8 +53,8 @@ whoami = "1.1"
 is-terminal = "0.4.4"
 scram = { git="https://github.com/elprans/scram" }
 rpassword = "6.0.1"
-colorful = "0.2.1"
-terminal_size = "0.2.5"
+colorful = "0.3.2"
+terminal_size = "0.3"
 bigdecimal = "0.4"
 num-bigint = "0.4.3"
 humantime = "2.0.0"
@@ -74,7 +74,6 @@ prettytable-rs = {version="0.10.0", default-features=false}
 tempfile = "3.1.0"
 codespan-reporting = "0.11"
 termcolor = "1.1.0"
-crossterm = "0.23.1"
 async-listen = "0.2.0"
 sha1 = "0.10.1"
 hex = {version="0.4.3", features=["serde"]}
@@ -90,7 +89,7 @@ native-tls = {version="0.2.4"}
 thiserror = "1.0.16"
 which = {version="4", default-features=false}
 indexmap = {workspace=true}
-term = "0.7"
+term = "1.0"
 libc = "0.2.68"
 urlencoding = "2.1.0"
 fn-error-context = "0.2"
@@ -109,7 +108,7 @@ immutable-chunkmap = "1.0.1"
 regex = "1.4.5"
 toml = "0.5.8"
 termimad = {workspace=true}
-minimad = "0.9.0"
+minimad = "0.13.1"
 edgedb-cli-derive = { path="edgedb-cli-derive" }
 fs-err = "2.6.0"
 pem = "3.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ edgedb-protocol = {git = "https://github.com/edgedb/edgedb-rust/", features=["al
 edgedb-derive = {git = "https://github.com/edgedb/edgedb-rust/"}
 edgedb-errors = {git = "https://github.com/edgedb/edgedb-rust/"}
 edgedb-tokio = {git = "https://github.com/edgedb/edgedb-rust/", features=["admin_socket", "unstable"]}
-snafu = {version="0.7.0", features=["backtraces"]}
+snafu = "0.8.4"
 ansi-escapes = "0.2"
 anyhow = "1.0.23"
 bytes = "1.5.0"
@@ -48,11 +48,11 @@ rustyline = { git="https://github.com/tailhook/rustyline", branch="edgedb_202104
 clap = {workspace = true, features=["derive", "cargo", "deprecated", "wrap_help"]}
 clap_complete = "4.4.3"
 color-print = "0.3.5"
-strsim = "0.10.0"
+strsim = "0.11.0"
 whoami = "1.1"
 is-terminal = "0.4.4"
 scram = { git="https://github.com/elprans/scram" }
-rpassword = "6.0.1"
+rpassword = "7.3.1"
 colorful = "0.3.2"
 terminal_size = "0.3"
 bigdecimal = "0.4"
@@ -104,7 +104,7 @@ shell-escape = "0.1.5"
 wait-timeout = "0.2.0"
 indicatif = "0.17.0"
 url = { version = "2.1.1", features=["serde"] }
-immutable-chunkmap = "1.0.1"
+immutable-chunkmap = "2.0.5"
 regex = "1.4.5"
 toml = "0.5.8"
 termimad = {workspace=true}
@@ -135,15 +135,15 @@ notify = "6.1"
 gethostname = "0.5.0"
 bitvec = "1.0.1"
 nom = "7.1.3"
-bitflags = "1.3.2"
+bitflags = "2.6"
 renamore = "0.3.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"
-predicates = "2.1.1"
+predicates = "3.1.2"
 pretty_assertions = "1.2.0"
 shutdown_hooks = "0.1.0"
-test-case = "2.0.0"
+test-case = "3.3.0"
 openssl = "0.10.30"
 tokio = {version="1.1.0", features=["rt-multi-thread"]}
 warp = {git="https://github.com/seanmonstar/warp.git", rev="7b07043cee0ca24e912155db4e8f6d9ab7c049ed", default-features=false, features=["tls"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ sha1 = "0.10.1"
 hex = {version="0.4.3", features=["serde"]}
 textwrap = {version="0.16.0", features=["terminal_size"]}
 log = "0.4.8"
-env_logger = "0.10.0"
+env_logger = "0.11.0"
 os-release = "0.1.0"
 reqwest = {version="0.12.5", features=["json", "native-tls"]}
 reqwest-middleware = {version = "0.3.0", features=["json"]}
@@ -96,10 +96,10 @@ urlencoding = "2.1.0"
 fn-error-context = "0.2"
 combine = "4.2.1"
 sha2 = "0.10.2"
-base32 = "0.4.0"
+base32 = "0.5.1"
 rand = "0.8.2"
 downcast-rs = "1.2.0"
-base64 = "0.21.7"
+base64 = "0.22.1"
 ring = {version="0.17.7", features=["std"]}
 shell-escape = "0.1.5"
 wait-timeout = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = {version="1.0", features=["preserve_order"]}
 serde_path_to_error = "0.1.3"
 serde_str = {git="https://github.com/tailhook/serde-str"}
 serde_millis = "0.1.1"
-dirs = "4"
+dirs = "5.0"
 uuid = {version="1.1.2", features=["serde", "v4", "fast-rng"]}
 prettytable-rs = {version="0.10.0", default-features=false}
 tempfile = "3.1.0"
@@ -87,7 +87,7 @@ reqwest-retry = "0.6.0"
 tracing = "0.1.26"
 native-tls = {version="0.2.4"}
 thiserror = "1.0.16"
-which = {version="4", default-features=false}
+which = {version="6", default-features=false}
 indexmap = {workspace=true}
 term = "1.0"
 libc = "0.2.68"
@@ -123,16 +123,16 @@ crossbeam-utils = "0.8.5"
 tar = "0.4.37"
 zstd = "0.12"
 semver = {version="1.0.4", features=["serde"]}
-fd-lock = "3.0.2"
+fd-lock = "4.0.2"
 zip = "0.6.2"
 libflate = "1.1.1"
-open = "3.0.2"
+open = "5.3.0"
 tokio = {version="1.23.0",features=[
     "macros", "rt", "rt-multi-thread", "fs", "process", "io-std", "net",
 ]}
 dissimilar = "1.0.6"
-notify = "5.0.0"
-gethostname = "0.4.1"
+notify = "6.1"
+gethostname = "0.5.0"
 bitvec = "1.0.1"
 nom = "7.1.3"
 bitflags = "1.3.2"
@@ -155,11 +155,11 @@ serde_json = "1.0"
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = {version="0.3.10", features=["iterator"]}
-nix = "0.26.2"
+nix = "0.29"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.8"
-winreg = "0.10.1"
+winreg = "0.52.0"
 wslapi = "0.1.3"
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/edgedb-cli-derive/Cargo.toml
+++ b/edgedb-cli-derive/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["EdgeDB Inc. <hello@edgedb.com>"]
 edition = "2018"
 
 [dependencies]
-syn = {version="1.0.72", features=["extra-traits"]}
+syn = {version="1.0.72", features=["extra-traits", "full"]}
 quote = "1.0.9"
 proc-macro2 = "1.0.78"
 proc-macro-error = "1.0.4"

--- a/edgedb-cli-derive/Cargo.toml
+++ b/edgedb-cli-derive/Cargo.toml
@@ -6,10 +6,10 @@ authors = ["EdgeDB Inc. <hello@edgedb.com>"]
 edition = "2018"
 
 [dependencies]
-syn = {version="1.0.72", features=["extra-traits", "full"]}
+syn = {version="2.0.76", features=["extra-traits", "full"]}
 quote = "1.0.9"
 proc-macro2 = "1.0.78"
-proc-macro-error = "1.0.4"
+proc-macro-error = {version = "1.0.4", default-features = false}
 clap = {workspace = true}
 clap_generate = {workspace = true}
 termimad = {workspace = true}

--- a/edgedb-cli-derive/Cargo.toml
+++ b/edgedb-cli-derive/Cargo.toml
@@ -11,7 +11,6 @@ quote = "1.0.9"
 proc-macro2 = "1.0.78"
 proc-macro-error = {version = "1.0.4", default-features = false}
 clap = {workspace = true}
-clap_generate = {workspace = true}
 termimad = {workspace = true}
 trybuild = {workspace = true}
 indexmap = {workspace = true}

--- a/src/branch/current.rs
+++ b/src/branch/current.rs
@@ -1,4 +1,4 @@
-use crossterm::style::Stylize;
+use termimad::crossterm::style::Stylize;
 
 use crate::branch::context::Context;
 use crate::branch::option::Current;

--- a/src/branch/list.rs
+++ b/src/branch/list.rs
@@ -1,7 +1,7 @@
 use crate::branch::context::Context;
 use crate::branch::option::List;
 use crate::connect::Connection;
-use crossterm::style::Stylize;
+use termimad::crossterm::style::Stylize;
 
 pub async fn main(
     _options: &List,

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,8 +53,8 @@ pub fn get_config() -> anyhow::Result<Config> {
 #[context("reading file {:?}", path.as_ref())]
 fn read_config(path: impl AsRef<Path>) -> anyhow::Result<Config> {
     let text = fs::read_to_string(&path)?;
-    let mut toml = toml::de::Deserializer::new(&text);
-    let mut val: Config = serde_path_to_error::deserialize(&mut toml)?;
+    let toml = toml::de::Deserializer::new(&text);
+    let mut val: Config = serde_path_to_error::deserialize(toml)?;
     val.file_name = Some(path.as_ref().to_path_buf());
     Ok(val)
 }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -28,7 +28,7 @@ fn prepare_markdown(text: &str) -> String {
 }
 
 static MADSKIN: Lazy<termimad::MadSkin> = Lazy::new(|| {
-    use crossterm::style::{Attribute, Color};
+    use termimad::crossterm::style::{Attribute, Color};
 
     if !print::use_color() {
         return termimad::MadSkin::no_style();
@@ -46,7 +46,7 @@ static MADSKIN: Lazy<termimad::MadSkin> = Lazy::new(|| {
 });
 
 fn parse_markdown(text: &str) -> minimad::Text {
-    use minimad::CompositeStyle::*;
+    use minimad::CompositeStyle::{self, *};
     use minimad::Line::*;
     use minimad::{Composite, Text};
 
@@ -84,7 +84,7 @@ fn parse_markdown(text: &str) -> minimad::Text {
                 | (
                     Paragraph,
                     Some(&mut Normal(Composite {
-                        style: ListItem,
+                        style: CompositeStyle::ListItem(_),
                         ref mut compounds,
                     })),
                 )

--- a/src/migrations/prompt.rs
+++ b/src/migrations/prompt.rs
@@ -5,8 +5,9 @@ use colorful::Colorful;
 use edgeql_parser::expr;
 use rustyline::completion::Completer;
 use rustyline::config::EditMode;
-use rustyline::highlight::{Highlighter, PromptInfo};
+use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
+use rustyline::history::FileHistory;
 use rustyline::validate::{ValidationContext, ValidationResult, Validator};
 use rustyline::{error::ReadlineError, Cmd, KeyEvent, Modifiers};
 use rustyline::{Config, Editor, Helper};
@@ -26,28 +27,21 @@ impl Highlighter for ExpressionHelper {
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
         &'s self,
         prompt: &'p str,
-        info: PromptInfo<'_>,
+        _default: bool,
     ) -> Cow<'b, str> {
-        if info.line_no() > 0 {
-            format!("{0:.>1$}", " ", prompt.len()).into()
-        } else {
-            prompt.into()
-        }
+        prompt.into()
     }
     fn highlight<'l>(&self, line: &'l str, _pos: usize) -> Cow<'l, str> {
         let mut buf = String::with_capacity(line.len() + 8);
         highlight::edgeql(&mut buf, line, &self.styler);
         buf.into()
     }
-    fn highlight_char(&self, _line: &str, _pos: usize) -> bool {
+    fn highlight_char(&self, _line: &str, _pos: usize, _forced: bool) -> bool {
         // TODO(tailhook) optimize: only need to return true on insert
         true
     }
     fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
         hint.light_gray().to_string().into()
-    }
-    fn has_continuation_prompt(&self) -> bool {
-        true
     }
 }
 
@@ -75,7 +69,7 @@ pub fn expression(
     let history_name = format!("migr_{}", &history_name);
     let config = Config::builder();
     let config = config.edit_mode(EditMode::Emacs);
-    let mut editor = Editor::<ExpressionHelper>::with_config(config.clone().build());
+    let mut editor = Editor::<ExpressionHelper, FileHistory>::with_config(config.clone().build())?;
     editor.bind_sequence(
         KeyEvent::new('\r', Modifiers::NONE),
         Cmd::AcceptOrInsertLine {
@@ -94,7 +88,7 @@ pub fn expression(
     let text = editor
         .readline_with_initial(prompt, (default, ""))
         .context("readline error")?;
-    editor.add_history_entry(&text);
+    editor.add_history_entry(&text)?;
     save_history(&mut editor, &history_name);
     Ok(text)
 }

--- a/src/migrations/rebase.rs
+++ b/src/migrations/rebase.rs
@@ -202,8 +202,9 @@ async fn rebase_migration_ids(
     rebase_migrations: &mut RebaseMigrations,
 ) -> anyhow::Result<()> {
     fn update_id(old: &str, new: &str, col: &mut IndexMap<String, DBMigration>) {
-        if let Some(value) = col.remove(old) {
-            col.insert(new.to_string(), value);
+        if let Some((old_index, _, value)) = col.shift_remove_full(old) {
+            let (new_index, _) = col.insert_full(new.to_string(), value);
+            col.move_index(new_index, old_index);
         }
     }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -655,10 +655,9 @@ fn term_width() -> usize {
     // calculate the acceptable term width ourselves and use
     // that to configure clap and to render subcommands help.
 
-    cmp::max(
-        cmp::min(textwrap::termwidth(), MAX_TERM_WIDTH),
-        MIN_TERM_WIDTH,
-    )
+    let width = terminal_size::terminal_size().map_or(80, |(terminal_size::Width(w), _)| w.into());
+
+    cmp::max(cmp::min(width, MAX_TERM_WIDTH), MIN_TERM_WIDTH)
 }
 
 impl Options {

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -74,8 +74,8 @@ pub fn format_config(version: &Query) -> String {
 #[context("error reading project config `{}`", path.display())]
 pub fn read(path: &Path) -> anyhow::Result<Config> {
     let text = fs::read_to_string(path)?;
-    let mut toml = toml::de::Deserializer::new(&text);
-    let val: SrcConfig = serde_path_to_error::deserialize(&mut toml)?;
+    let toml = toml::de::Deserializer::new(&text);
+    let val: SrcConfig = serde_path_to_error::deserialize(toml)?;
     warn_extra(&val.extra, "");
     warn_extra(&val.edgedb.extra, "edgedb.");
 
@@ -126,9 +126,9 @@ where
         write!(
             &mut out,
             "{}{:?}{}",
-            &input[..selected.start()],
+            &input[..selected.span().start],
             to_str(value),
-            &input[selected.end()..]
+            &input[selected.span().end..]
         )
         .unwrap();
 
@@ -153,8 +153,8 @@ where
     ToStr: FnOnce(&Val) -> String,
 {
     let input = fs::read_to_string(path)?;
-    let mut deserializer = toml::de::Deserializer::new(&input);
-    let parsed: Cfg = serde_path_to_error::deserialize(&mut deserializer)?;
+    let deserializer = toml::de::Deserializer::new(&input);
+    let parsed: Cfg = serde_path_to_error::deserialize(deserializer)?;
 
     if let Some(new_contents) = modify_config(&parsed, &input, selector, field_name, value, to_str)?
     {
@@ -276,8 +276,8 @@ mod test {
     ";
 
     fn set_toml_version(data: &str, version: &super::Query) -> anyhow::Result<Option<String>> {
-        let mut toml = toml::de::Deserializer::new(data);
-        let parsed: super::SrcConfig = serde_path_to_error::deserialize(&mut toml)?;
+        let toml = toml::de::Deserializer::new(data);
+        let parsed: super::SrcConfig = serde_path_to_error::deserialize(toml)?;
 
         super::modify_config(
             &parsed,

--- a/src/prompt/variable.rs
+++ b/src/prompt/variable.rs
@@ -723,13 +723,10 @@ impl Highlighter for VarHelper {
             Err(_) => line.light_red().to_string().into(),
         }
     }
-    fn has_continuation_prompt(&self) -> bool {
-        true
-    }
     fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
         hint.rgb(0x56, 0x56, 0x56).to_string().into()
     }
-    fn highlight_char(&self, _line: &str, _pos: usize) -> bool {
+    fn highlight_char(&self, _line: &str, _pos: usize, _forced: bool) -> bool {
         // needed to highlight hint
         true
     }

--- a/src/question.rs
+++ b/src/question.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::io::{stdin, BufRead};
 
 use anyhow::Context;
-use rustyline::{Config, Editor};
+use rustyline::{Config, DefaultEditor};
 use tokio::task::spawn_blocking;
 
 use crate::print;
@@ -60,7 +60,7 @@ impl<'a, T: Clone + 'a> Numeric<'a, T> {
         self
     }
     pub fn ask(&self) -> anyhow::Result<T> {
-        let mut editor = Editor::<()>::with_config(Config::builder().build());
+        let mut editor = DefaultEditor::with_config(Config::builder().build())?;
         loop {
             print::prompt(&self.question);
             for (idx, (title, _)) in self.options.iter().enumerate() {
@@ -110,7 +110,7 @@ impl<'a> String<'a> {
         } else {
             print::prompt(format!("{} [default: {}]: ", self.question, self.default));
         }
-        let mut editor = Editor::<()>::with_config(Config::builder().build());
+        let mut editor = DefaultEditor::with_config(Config::builder().build())?;
         let initial = self
             .initial
             .as_ref()
@@ -153,7 +153,7 @@ impl<'a> Confirm<'a> {
         self
     }
     pub fn ask(&self) -> anyhow::Result<bool> {
-        let mut editor = Editor::<()>::with_config(Config::builder().build());
+        let mut editor = DefaultEditor::with_config(Config::builder().build())?;
         if self.is_dangerous {
             print::prompt(format!("{} (type `Yes`)", self.question));
         } else {
@@ -227,7 +227,7 @@ impl<'a, T: Clone + 'a> Choice<'a, T> {
         self
     }
     pub fn ask(&self) -> anyhow::Result<T> {
-        let mut editor = Editor::<()>::with_config(Config::builder().build());
+        let mut editor = DefaultEditor::with_config(Config::builder().build())?;
         let options = self
             .choices
             .iter()

--- a/tests/func/interactive.rs
+++ b/tests/func/interactive.rs
@@ -34,7 +34,8 @@ fn test_switch_database() {
     cmd.exp_string(&format!("{main}>")).unwrap();
     cmd.send_line("create database _test_switch_asdf;").unwrap();
     cmd.send_line("\\c _test_switch_asdf").unwrap();
-    cmd.exp_string("_test_switch_asdf>").unwrap();
+    cmd.exp_string("_test_switch_asdf").unwrap();
+    cmd.exp_string(">").unwrap();
     cmd.send_line(&format!("\\c {main}")).unwrap();
     cmd.exp_string(&format!("{main}>")).unwrap();
     cmd.send_line("drop branch _test_switch_asdf;").unwrap();

--- a/tests/shared-client-tests/Cargo.toml
+++ b/tests/shared-client-tests/Cargo.toml
@@ -16,14 +16,11 @@ doctest = false
 [dev-dependencies]
 tempfile = "3.1.0"
 assert_cmd = "2.0.8"
-predicates = "2.1.1"
+predicates = "3.1.2"
 serde_json = "1.0"
 edgedb-protocol = { git = "https://github.com/edgedb/edgedb-rust/", features = [
     "all-types",
 ] }
 sha1 = "0.10.1"
-# we need slicing of indexmap, so need version 2.0
-indexmap = { git = "https://github.com/bluss/indexmap", rev = "11ac52c", features = [
-    "serde",
-] }
+indexmap = { workspace = true }
 hex = { version = "0.4.3", features = ["serde"] }


### PR DESCRIPTION
- **update base32, base64 and env_logger**
- **update minimad, termimad, terminal_size, colorful, ansi-escapes**
- **update dirs, which, fd-lock, open, notify, gethostname, nix, winreg**
- **update snafu, strsim, rpassword, immutable-chunkmap, bitflags**
- **update zstd, zip, libflate**
- **update toml**
- **update indexmap, heck**
- **update syn**
- **prune a few duplicated transitive dependencies**
