### PR TITLE
Fix help output for `--version` option for `instance create`

### DIFF
--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -226,12 +226,11 @@ pub struct Create {
     #[arg(value_hint=ValueHint::Other)]
     pub name: Option<InstanceName>,
 
-    /// Create instance under latest nightly version.
+    /// Create instance using the latest nightly version.
     #[arg(long, conflicts_with_all=&["channel", "version"])]
     pub nightly: bool,
-    /// Create instance under latest nightly version.
-    #[arg(long, conflicts_with_all=&["nightly", "channel"])]
     /// Create instance with specified version.
+    #[arg(long, conflicts_with_all=&["nightly", "channel"])]
     pub version: Option<ver::Filter>,
     /// Indicate channel (stable, testing, or nightly) for instance to create.
     #[arg(long, conflicts_with_all=&["nightly", "version"])]


### PR DESCRIPTION
Current help output for `edgedb instance create` has wrong description for `--version` option, with it including the description for `--nightly` option. 

```
edgedb instance create --help
Initialize a new EdgeDB instance

Usage: edgedb instance create [OPTIONS] [NAME] [DEFAULT_BRANCH]

Arguments:
  [NAME]            Name of instance to create. Asked interactively if not specified
  [DEFAULT_BRANCH]  The default branch name. This defaults to 'main' on EdgeDB >=5.x; otherwise
                    'edgedb' is used

Options:
      --nightly
          Create instance under latest nightly version
      --version <VERSION>
          Create instance under latest nightly version. Create instance with specified version
      --channel <CHANNEL>
          Indicate channel (stable, testing, or nightly) for instance to create [possible values:
          stable, testing, nightly]
      --port <PORT>
          Indicate port for instance to create
      --region <REGION>
          The region in which to create the instance (for cloud instances)
      --tier <tier>
          Cloud instance subscription tier [possible values: pro, free]
      --compute-size <number>
          The size of compute to be allocated for the Cloud instance in Compute Units
      --storage-size <GiB>
          The size of storage to be allocated for the Cloud instance in Gigabytes
      --from-instance <FROM_INSTANCE>

      --from-backup-id <FROM_BACKUP_ID>

      --default-user <DEFAULT_USER>
          Default user name (created during initialization and saved in credentials file) [default:
          edgedb]
      --non-interactive
          Do not ask questions. Assume user wants to upgrade instance
  -h, --help
          Print help

Cloud Connection Options:
      --cloud-api-endpoint <URL>       Specify the EdgeDB Cloud API endpoint. Defaults to the
                                       current logged-in server, or <https://api.g.aws.edgedb.cloud>
                                       if unauthorized
      --cloud-secret-key <SECRET_KEY>  Specify EdgeDB Cloud API secret key to use instead of loading
                                       key from a remembered authentication
      --cloud-profile <PROFILE>        Specify authenticated EdgeDB Cloud profile. Defaults to
                                       "default"
```