### PR TITLE
Add support for version query on nightlies

### DIFF
--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -274,6 +274,9 @@ mod test {
         edgedb = {server-version = \"nightly\"}\n\
         project = {schema-dir = \"custom-dir\"}\n\
     ";
+    const TOMLI_DEV: &str = "\
+        edgedb = {server-version = \"6.0-dev.8321\"}\n\
+    ";
 
     fn set_toml_version(data: &str, version: &super::Query) -> anyhow::Result<Option<String>> {
         let toml = toml::de::Deserializer::new(data);
@@ -320,6 +323,9 @@ mod test {
     #[test_case(TOMLI_BETA2, "nightly" => Some(TOMLI_NIGHTLY.into()))]
     #[test_case(TOMLI_BETA2_CUSTOM_SCHEMA_DIR, "nightly"=> Some(TOMLI_NIGHTLY_CUSTOM_SCHEMA_DIR.into()))]
     #[test_case(TOMLI_NIGHTLY, "nightly" => None)]
+    #[test_case(TOMLI_BETA1, "6.0-dev.8321" => Some(TOMLI_DEV.into()))]
+    #[test_case(TOMLI_DEV, "1.0-beta.1" => Some(TOMLI_BETA1.into()))]
+    #[test_case(TOMLI_DEV, "nightly" => Some(TOMLI_NIGHTLY.into()))]
     fn modify(src: &str, ver: &str) -> Option<String> {
         set_toml_version(src, &ver.parse().unwrap()).unwrap()
     }

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -609,10 +609,10 @@ impl Query {
         }
     }
     pub fn as_config_value(&self) -> String {
-        if self.channel == Channel::Nightly {
-            "nightly".into()
-        } else if let Some(ver) = &self.version {
+        if let Some(ver) = &self.version {
             ver.to_string()
+        } else if self.channel == Channel::Nightly {
+            "nightly".into()
         } else {
             "*".into()
         }

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -507,6 +507,12 @@ impl Query {
                 channel: Channel::Stable,
                 version: Some(ver.clone()),
             }),
+            Some(FilterMinor::Dev(_)) => {
+                Ok(Query {
+                    channel: Channel::Nightly,
+                    version: Some(ver.clone()),
+                })
+            }
             Some(FilterMinor::Alpha(_)) | Some(FilterMinor::Beta(_)) | Some(FilterMinor::Rc(_))
                 if ver.major == 1 || ver.major == 2 =>
             {
@@ -741,6 +747,7 @@ impl Channel {
                 Ok(Channel::Stable)
             }
             Some(Alpha(_) | Beta(_) | Rc(_)) => Ok(Channel::Testing),
+            Some(Dev(_)) => Ok(Channel::Nightly),
         }
     }
     pub fn as_str(&self) -> &str {
@@ -764,6 +771,7 @@ impl fmt::Display for QueryDisplay<'_> {
                 match ver.minor {
                     None => "0".fmt(f),
                     Some(Minor(m)) => m.fmt(f),
+                    Some(Dev(v)) => write!(f, "0-dev.{}", v),
                     Some(Alpha(v)) => write!(f, "0-alpha.{}", v),
                     Some(Beta(v)) => write!(f, "0-beta.{}", v),
                     Some(Rc(v)) => write!(f, "0-rc.{}", v),

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -507,12 +507,10 @@ impl Query {
                 channel: Channel::Stable,
                 version: Some(ver.clone()),
             }),
-            Some(FilterMinor::Dev(_)) => {
-                Ok(Query {
-                    channel: Channel::Nightly,
-                    version: Some(ver.clone()),
-                })
-            }
+            Some(FilterMinor::Dev(_)) => Ok(Query {
+                channel: Channel::Nightly,
+                version: Some(ver.clone()),
+            }),
             Some(FilterMinor::Alpha(_)) | Some(FilterMinor::Beta(_)) | Some(FilterMinor::Rc(_))
                 if ver.major == 1 || ver.major == 2 =>
             {


### PR DESCRIPTION
This PR allows specifying nightly server versions like `6.0-dev.8321`. The current `nightly` channel remains unchanged.

- [x] Pass CI
- [x] Add test
- [x] Double check upgrade behavior