### PR TITLE
Use pgdsn for 6.x psql connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.5.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#42c94da5b286d40195a02be55dda679d12115d47"
+source = "git+https://github.com/edgedb/edgedb-rust/#ee2c03ab12ca16b9240f58b577e23448d66af362"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1229,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.4.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#42c94da5b286d40195a02be55dda679d12115d47"
+source = "git+https://github.com/edgedb/edgedb-rust/#ee2c03ab12ca16b9240f58b577e23448d66af362"
 dependencies = [
  "bytes",
 ]
@@ -1237,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.6.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#42c94da5b286d40195a02be55dda679d12115d47"
+source = "git+https://github.com/edgedb/edgedb-rust/#ee2c03ab12ca16b9240f58b577e23448d66af362"
 dependencies = [
  "bigdecimal",
  "bitflags 2.6.0",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.5.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#42c94da5b286d40195a02be55dda679d12115d47"
+source = "git+https://github.com/edgedb/edgedb-rust/#ee2c03ab12ca16b9240f58b577e23448d66af362"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1941,7 +1941,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -1,5 +1,5 @@
 use crate::connect::Connection;
-use edgedb_tokio::server_params::PostgresAddress;
+use edgedb_tokio::server_params::{PostgresAddress, PostgresDsn};
 
 use crate::analyze;
 use crate::commands::parser::{Common, DatabaseCmd, DescribeCmd, ListCmd};
@@ -67,10 +67,17 @@ pub async fn common(
         }
         Pgaddr => match cli.get_server_param::<PostgresAddress>() {
             Some(addr) => {
+                // < 6.x
                 println!("{}", serde_json::to_string_pretty(addr)?);
             }
             None => {
-                print::error("pgaddr requires EdgeDB to run in DEV mode");
+                // >= 6.x
+                match cli.get_server_param::<PostgresDsn>() {
+                    Some(addr) => {
+                        println!("{}", addr.0);
+                    }
+                    None => print::error("pgaddr requires EdgeDB to run in DEV mode"),
+                }
             }
         },
         Psql => {

--- a/src/commands/psql.rs
+++ b/src/commands/psql.rs
@@ -4,63 +4,70 @@ use std::process::Command;
 
 use crate::connect::Connection;
 use anyhow::Context;
-use edgedb_tokio::server_params::PostgresAddress;
+use edgedb_tokio::server_params::{PostgresAddress, PostgresDsn};
 
 use crate::commands::Options;
 use crate::interrupt;
 use crate::print;
 
 pub async fn psql<'x>(cli: &mut Connection, _options: &Options) -> Result<(), anyhow::Error> {
+    let mut cmd = Command::new("psql");
+    let path = if cfg!(feature = "dev_mode") {
+        use std::iter;
+        use std::path::{Path, PathBuf};
+
+        if let Some(dir) = option_env!("PSQL_DEFAULT_PATH") {
+            let psql_path = Path::new(dir).join("psql");
+            if !psql_path.exists() {
+                eprintln!("WARNING: {} does not exist", psql_path.display());
+            }
+            let npath = if let Some(path) = env::var_os("PATH") {
+                env::join_paths(iter::once(PathBuf::from(dir)).chain(env::split_paths(&path)))
+                    .unwrap_or_else(|e| {
+                        eprintln!("PSQL_DEFAULT_PATH error: {}", e);
+                        path
+                    })
+            } else {
+                dir.into()
+            };
+            Some(npath)
+        } else {
+            env::var_os("PATH")
+        }
+    } else {
+        env::var_os("PATH")
+    };
+
     match cli.get_server_param::<PostgresAddress>() {
         Some(addr) => {
-            let mut cmd = Command::new("psql");
-            let path = if cfg!(feature = "dev_mode") {
-                use std::iter;
-                use std::path::{Path, PathBuf};
-
-                if let Some(dir) = option_env!("PSQL_DEFAULT_PATH") {
-                    let psql_path = Path::new(dir).join("psql");
-                    if !psql_path.exists() {
-                        eprintln!("WARNING: {} does not exist", psql_path.display());
-                    }
-                    let npath = if let Some(path) = env::var_os("PATH") {
-                        env::join_paths(
-                            iter::once(PathBuf::from(dir)).chain(env::split_paths(&path)),
-                        )
-                        .unwrap_or_else(|e| {
-                            eprintln!("PSQL_DEFAULT_PATH error: {}", e);
-                            path
-                        })
-                    } else {
-                        dir.into()
-                    };
-                    Some(npath)
-                } else {
-                    env::var_os("PATH")
-                }
-            } else {
-                env::var_os("PATH")
-            };
             cmd.arg("-h").arg(&addr.host);
             cmd.arg("-U").arg(&addr.user);
             cmd.arg("-p").arg(addr.port.to_string());
             cmd.arg("-d").arg(&addr.database);
-            if let Some(path) = path.as_ref() {
-                cmd.env("PATH", path);
+        }
+        None => match cli.get_server_param::<PostgresDsn>() {
+            Some(addr) => {
+                cmd.arg("--");
+                cmd.arg(&addr.0);
             }
-
-            let _trap = interrupt::Trap::new(&[interrupt::Signal::Interrupt]);
-            cmd.status().with_context(|| {
-                format!(
-                    "Error running {:?} (path: {:?})",
-                    cmd,
-                    path.unwrap_or_else(OsString::new)
-                )
-            })?;
-        }
-        None => {
-            print::error("EdgeDB must be run in DEV mode to use psql.");
-        }
+            None => {
+                print::error("EdgeDB must be run in DEV mode to use psql.");
+                return Ok(());
+            }
+        },
     }
+
+    if let Some(path) = path.as_ref() {
+        cmd.env("PATH", path);
+    }
+
+    let _trap = interrupt::Trap::new(&[interrupt::Signal::Interrupt]);
+    cmd.status().with_context(|| {
+        format!(
+            "Error running {:?} (path: {:?})",
+            cmd,
+            path.unwrap_or_else(OsString::new)
+        )
+    })?;
     Ok(())
 }


### PR DESCRIPTION
Fix `\psql` and `pgaddr` commands to work with 6.x servers.

Requires:

https://github.com/edgedb/edgedb-rust/pull/349
https://github.com/edgedb/edgedb/pull/7826
