### PR TITLE
Extension installation commands

### DIFF
--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -51,9 +51,9 @@ pub fn main(options: &Options) -> Result<(), anyhow::Error> {
             directory_check::check_and_error()?;
             portable::server_main(cmd)
         }
-        Command::Extension(c) => {
+        Command::Extension(cmd) => {
             directory_check::check_and_error()?;
-            portable::extension_main(c, options)
+            portable::extension_main(cmd)
         }
         Command::Instance(cmd) => {
             directory_check::check_and_error()?;

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -51,6 +51,10 @@ pub fn main(options: &Options) -> Result<(), anyhow::Error> {
             directory_check::check_and_error()?;
             portable::server_main(cmd)
         }
+        Command::Extension(c) => {
+            directory_check::check_and_error()?;
+            portable::extension_main(c, options)
+        }
         Command::Instance(cmd) => {
             directory_check::check_and_error()?;
             portable::instance_main(cmd, options)

--- a/src/options.rs
+++ b/src/options.rs
@@ -355,6 +355,8 @@ pub enum Command {
     Instance(portable::options::ServerInstanceCommand),
     /// Manage local EdgeDB installations
     Server(portable::options::ServerCommand),
+    /// Manage local extensions
+    Extension(portable::options::ServerInstanceExtensionCommand),
     /// Generate shell completions
     #[command(name = "_gen_completions")]
     #[command(hide = true)]

--- a/src/portable/control.rs
+++ b/src/portable/control.rs
@@ -111,7 +111,7 @@ fn write_lock_info(
     use std::io::Write;
 
     lock.set_len(0)?;
-    lock.write_all(marker.as_ref().map(|x| &x[..]).unwrap_or("user").as_bytes())?;
+    lock.write_all(marker.as_deref().unwrap_or("user").as_bytes())?;
     Ok(())
 }
 

--- a/src/portable/extension.rs
+++ b/src/portable/extension.rs
@@ -1,26 +1,34 @@
-use libc::option;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Context;
+use log::trace;
 use prettytable::{row, Table};
 
+use super::options::{
+    ExtensionInstall, ExtensionList, ExtensionListExtensions, ExtensionUninstall,
+};
 use crate::hint::HintExt;
-use crate::{platform, table};
+use crate::portable::install::download_package;
 use crate::portable::local::InstanceInfo;
 use crate::portable::options::{instance_arg, InstanceName, ServerInstanceExtensionCommand};
-use crate::options::Options;
 use crate::portable::platform::get_server;
 use crate::portable::repository::{get_platform_extension_packages, Channel};
-use super::options::{ExtensionInstall, ExtensionList, ExtensionListExtensions};
+use crate::table;
 
-pub fn extension_main(c: &ServerInstanceExtensionCommand, options: &Options) -> Result<(), anyhow::Error> {
+pub fn extension_main(c: &ServerInstanceExtensionCommand) -> Result<(), anyhow::Error> {
     use crate::portable::options::InstanceExtensionCommand::*;
     match &c.subcommand {
         Install(c) => install(c),
         List(c) => list(c),
         ListAvailable(c) => list_extensions(c),
+        Uninstall(c) => uninstall(c),
     }
 }
 
-fn list(options: &ExtensionList) -> Result<(), anyhow::Error> {
-    let name = match instance_arg(&None, &options.instance)? {
+fn get_local_instance(instance: &Option<InstanceName>) -> Result<InstanceInfo, anyhow::Error> {
+    let name = match instance_arg(&None, instance)? {
         InstanceName::Local(name) => name,
         inst_name => {
             return Err(anyhow::anyhow!(
@@ -47,60 +55,56 @@ fn list(options: &ExtensionList) -> Result<(), anyhow::Error> {
             )
         })?;
     };
-    eprintln!("{:?}", inst.extension_path()?);
-    for file in inst.extension_path()?.read_dir()? {
-        let file = file?;
-        if file.metadata()?.is_dir() {
-            eprintln!(" - {:?}", file.file_name());
-        }
-    }
+    Ok(inst)
+}
+
+fn list(options: &ExtensionList) -> Result<(), anyhow::Error> {
+    let inst = get_local_instance(&options.instance)?;
+    let extension_loader = inst.extension_loader_path()?;
+    run_extension_loader(&extension_loader, Some("--list"), None::<&str>)?;
+    Ok(())
+}
+
+fn uninstall(options: &ExtensionUninstall) -> Result<(), anyhow::Error> {
+    let inst = get_local_instance(&options.instance)?;
+    let extension_loader = inst.extension_loader_path()?;
+    run_extension_loader(
+        &extension_loader,
+        Some("--uninstall".to_string()),
+        Some(Path::new(&options.extension)),
+    )?;
     Ok(())
 }
 
 fn install(options: &ExtensionInstall) -> Result<(), anyhow::Error> {
-    let name = match instance_arg(&None, &options.instance)? {
-        InstanceName::Local(name) => name,
-        inst_name => {
-            return Err(anyhow::anyhow!(
-                "cannot install extensions in cloud instance {}.",
-                inst_name
-            ))
-            .with_hint(|| {
-                format!(
-                    "only local instances can install extensions ({} is remote)",
-                    inst_name
-                )
-            })?;
-        }
-    };
-    let Some(inst) = InstanceInfo::try_read(&name)? else {
-        return Err(anyhow::anyhow!(
-            "cannot install extensions in cloud instance {}.",
-            name
-        ))
-        .with_hint(|| {
-            format!(
-                "only local instances can install extensions ({} is remote)",
-                name
-            )
-        })?;
-    };
+    let inst = get_local_instance(&options.instance)?;
+    let extension_loader = inst.extension_loader_path()?;
 
     let version = inst.get_version()?.specific();
     let channel = options.channel.unwrap_or(Channel::from_version(&version)?);
     let slot = options.slot.clone().unwrap_or(version.slot());
-    eprintln!("{version} {channel:?} {slot}");
+    trace!("Instance: {version} {channel:?} {slot}");
     let packages = get_platform_extension_packages(channel, &slot, get_server()?)?;
-    
-    let package = packages.iter().find(|pkg| {
-        pkg.tags.get("extension").cloned().unwrap_or_default() == options.extension
-    });
+
+    let package = packages
+        .iter()
+        .find(|pkg| pkg.tags.get("extension").cloned().unwrap_or_default() == options.extension);
 
     match package {
         Some(pkg) => {
-            println!("Found extension package: {} version {}", options.extension, pkg.version);
-            // TODO: Implement the installation logic here
-        },
+            println!(
+                "Found extension package: {} version {}",
+                options.extension, pkg.version
+            );
+            let zip = download_package(&pkg)?;
+            let command = if options.reinstall {
+                Some("--reinstall")
+            } else {
+                None
+            };
+            run_extension_loader(&extension_loader, command, Some(&zip))?;
+            println!("Extension '{}' installed successfully.", options.extension);
+        }
         None => {
             return Err(anyhow::anyhow!(
                 "Extension '{}' not found in available packages.",
@@ -112,39 +116,47 @@ fn install(options: &ExtensionInstall) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-fn list_extensions(options: &ExtensionListExtensions) -> Result<(), anyhow::Error> {
-    let name = match instance_arg(&None, &options.instance)? {
-        InstanceName::Local(name) => name,
-        inst_name => {
-            return Err(anyhow::anyhow!(
-                "cannot install extensions in cloud instance {}.",
-                inst_name
-            ))
-            .with_hint(|| {
-                format!(
-                    "only local instances can install extensions ({} is remote)",
-                    inst_name
-                )
-            })?;
-        }
-    };
-    let Some(inst) = InstanceInfo::try_read(&name)? else {
+fn run_extension_loader(
+    extension_installer: &Path,
+    command: Option<impl AsRef<OsStr>>,
+    file: Option<impl AsRef<OsStr>>,
+) -> Result<(), anyhow::Error> {
+    let mut cmd = Command::new(extension_installer);
+
+    if let Some(cmd_str) = command {
+        cmd.arg(cmd_str);
+    }
+
+    if let Some(file_path) = file {
+        cmd.arg(file_path);
+    }
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("Failed to execute {}", extension_installer.display()))?;
+
+    if !output.status.success() {
+        eprintln!("STDOUT:\n{}", String::from_utf8_lossy(&output.stdout));
+        eprintln!("STDERR:\n{}", String::from_utf8_lossy(&output.stderr));
         return Err(anyhow::anyhow!(
-            "cannot install extensions in cloud instance {}.",
-            name
-        ))
-        .with_hint(|| {
-            format!(
-                "only local instances can install extensions ({} is remote)",
-                name
-            )
-        })?;
-    };
+            "Extension installation failed with exit code: {}",
+            output.status
+        ));
+    } else {
+        trace!("STDOUT:\n{}", String::from_utf8_lossy(&output.stdout));
+        trace!("STDERR:\n{}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    Ok(())
+}
+
+fn list_extensions(options: &ExtensionListExtensions) -> Result<(), anyhow::Error> {
+    let inst = get_local_instance(&options.instance)?;
 
     let version = inst.get_version()?.specific();
     let channel = options.channel.unwrap_or(Channel::from_version(&version)?);
     let slot = options.slot.clone().unwrap_or(version.slot());
-    eprintln!("{version} {channel:?} {slot}");
+    trace!("Instance: {version} {channel:?} {slot}");
     let packages = get_platform_extension_packages(channel, &slot, get_server()?)?;
 
     let mut table = Table::new();

--- a/src/portable/extension.rs
+++ b/src/portable/extension.rs
@@ -1,0 +1,159 @@
+use libc::option;
+use prettytable::{row, Table};
+
+use crate::hint::HintExt;
+use crate::{platform, table};
+use crate::portable::local::InstanceInfo;
+use crate::portable::options::{instance_arg, InstanceName, ServerInstanceExtensionCommand};
+use crate::options::Options;
+use crate::portable::platform::get_server;
+use crate::portable::repository::{get_platform_extension_packages, Channel};
+use super::options::{ExtensionInstall, ExtensionList, ExtensionListExtensions};
+
+pub fn extension_main(c: &ServerInstanceExtensionCommand, options: &Options) -> Result<(), anyhow::Error> {
+    use crate::portable::options::InstanceExtensionCommand::*;
+    match &c.subcommand {
+        Install(c) => install(c),
+        List(c) => list(c),
+        ListAvailable(c) => list_extensions(c),
+    }
+}
+
+fn list(options: &ExtensionList) -> Result<(), anyhow::Error> {
+    let name = match instance_arg(&None, &options.instance)? {
+        InstanceName::Local(name) => name,
+        inst_name => {
+            return Err(anyhow::anyhow!(
+                "cannot install extensions in cloud instance {}.",
+                inst_name
+            ))
+            .with_hint(|| {
+                format!(
+                    "only local instances can install extensions ({} is remote)",
+                    inst_name
+                )
+            })?;
+        }
+    };
+    let Some(inst) = InstanceInfo::try_read(&name)? else {
+        return Err(anyhow::anyhow!(
+            "cannot install extensions in cloud instance {}.",
+            name
+        ))
+        .with_hint(|| {
+            format!(
+                "only local instances can install extensions ({} is remote)",
+                name
+            )
+        })?;
+    };
+    eprintln!("{:?}", inst.extension_path()?);
+    for file in inst.extension_path()?.read_dir()? {
+        let file = file?;
+        if file.metadata()?.is_dir() {
+            eprintln!(" - {:?}", file.file_name());
+        }
+    }
+    Ok(())
+}
+
+fn install(options: &ExtensionInstall) -> Result<(), anyhow::Error> {
+    let name = match instance_arg(&None, &options.instance)? {
+        InstanceName::Local(name) => name,
+        inst_name => {
+            return Err(anyhow::anyhow!(
+                "cannot install extensions in cloud instance {}.",
+                inst_name
+            ))
+            .with_hint(|| {
+                format!(
+                    "only local instances can install extensions ({} is remote)",
+                    inst_name
+                )
+            })?;
+        }
+    };
+    let Some(inst) = InstanceInfo::try_read(&name)? else {
+        return Err(anyhow::anyhow!(
+            "cannot install extensions in cloud instance {}.",
+            name
+        ))
+        .with_hint(|| {
+            format!(
+                "only local instances can install extensions ({} is remote)",
+                name
+            )
+        })?;
+    };
+
+    let version = inst.get_version()?.specific();
+    let channel = options.channel.unwrap_or(Channel::from_version(&version)?);
+    let slot = options.slot.clone().unwrap_or(version.slot());
+    eprintln!("{version} {channel:?} {slot}");
+    let packages = get_platform_extension_packages(channel, &slot, get_server()?)?;
+    
+    let package = packages.iter().find(|pkg| {
+        pkg.tags.get("extension").cloned().unwrap_or_default() == options.extension
+    });
+
+    match package {
+        Some(pkg) => {
+            println!("Found extension package: {} version {}", options.extension, pkg.version);
+            // TODO: Implement the installation logic here
+        },
+        None => {
+            return Err(anyhow::anyhow!(
+                "Extension '{}' not found in available packages.",
+                options.extension
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn list_extensions(options: &ExtensionListExtensions) -> Result<(), anyhow::Error> {
+    let name = match instance_arg(&None, &options.instance)? {
+        InstanceName::Local(name) => name,
+        inst_name => {
+            return Err(anyhow::anyhow!(
+                "cannot install extensions in cloud instance {}.",
+                inst_name
+            ))
+            .with_hint(|| {
+                format!(
+                    "only local instances can install extensions ({} is remote)",
+                    inst_name
+                )
+            })?;
+        }
+    };
+    let Some(inst) = InstanceInfo::try_read(&name)? else {
+        return Err(anyhow::anyhow!(
+            "cannot install extensions in cloud instance {}.",
+            name
+        ))
+        .with_hint(|| {
+            format!(
+                "only local instances can install extensions ({} is remote)",
+                name
+            )
+        })?;
+    };
+
+    let version = inst.get_version()?.specific();
+    let channel = options.channel.unwrap_or(Channel::from_version(&version)?);
+    let slot = options.slot.clone().unwrap_or(version.slot());
+    eprintln!("{version} {channel:?} {slot}");
+    let packages = get_platform_extension_packages(channel, &slot, get_server()?)?;
+
+    let mut table = Table::new();
+    table.set_format(*table::FORMAT);
+    table.add_row(row!["Name", "Version"]);
+    for pkg in packages {
+        let ext = pkg.tags.get("extension").cloned().unwrap_or_default();
+        table.add_row(row![ext, pkg.version]);
+    }
+    table.printstd();
+    Ok(())
+}

--- a/src/portable/install.rs
+++ b/src/portable/install.rs
@@ -209,6 +209,7 @@ pub fn package(pkg_info: &PackageInfo) -> anyhow::Result<InstallInfo> {
         package_url: pkg_info.url.clone(),
         package_hash: pkg_info.hash.clone(),
         installed_at: SystemTime::now(),
+        slot: pkg_info.slot.clone(),
     };
     write_json(&tmp_target.join("install_info.json"), "metadata", &info)?;
     fs::rename(&tmp_target, &target_dir)

--- a/src/portable/install.rs
+++ b/src/portable/install.rs
@@ -45,7 +45,7 @@ fn check_metadata(dir: &Path, pkg_info: &PackageInfo) -> anyhow::Result<InstallI
 }
 
 #[context("failed to download {}", pkg_info)]
-fn download_package(pkg_info: &PackageInfo) -> anyhow::Result<PathBuf> {
+pub fn download_package(pkg_info: &PackageInfo) -> anyhow::Result<PathBuf> {
     let cache_dir = platform::cache_dir()?;
     let download_dir = cache_dir.join("downloads");
     fs::create_dir_all(&download_dir)?;

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -454,7 +454,8 @@ pub fn unlink(options: &Unlink) -> anyhow::Result<()> {
     }
     with_projects(name, options.force, print_warning, || {
         let path = credentials::path(name)?;
-        fs::remove_file(&path).with_context(|| format!("Credentials for {name} missing from {path:?}"))
+        fs::remove_file(&path)
+            .with_context(|| format!("Credentials for {name} missing from {path:?}"))
     })?;
     Ok(())
 }

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -453,7 +453,8 @@ pub fn unlink(options: &Unlink) -> anyhow::Result<()> {
             .into());
     }
     with_projects(name, options.force, print_warning, || {
-        fs::remove_file(credentials::path(name)?).with_context(|| format!("cannot unlink {}", name))
+        let path = credentials::path(name)?;
+        fs::remove_file(&path).with_context(|| format!("Credentials for {name} missing from {path:?}"))
     })?;
     Ok(())
 }

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -14,6 +14,7 @@ use edgedb_tokio::Builder;
 
 use crate::bug;
 use crate::credentials;
+use crate::hint::HintExt;
 use crate::platform::{cache_dir, config_dir, data_dir, portable_dir};
 use crate::portable::repository::PackageHash;
 use crate::portable::ver;
@@ -404,9 +405,13 @@ impl InstallInfo {
             .join("data")
             .join("extensions");
         if !path.exists() {
-            Err(bug::error(
-                "no extension directory available for this server",
-            ))
+            Err(
+                bug::error("no extension directory available for this server")
+                    .with_hint(|| {
+                        format!("Extension installation requires EdgeDB server version 6 or later")
+                    })
+                    .into(),
+            )
         } else {
             Ok(path)
         }
@@ -417,9 +422,13 @@ impl InstallInfo {
         if path.exists() {
             Ok(path)
         } else {
-            Err(anyhow::anyhow!(
-                "edgedb-load-ext not found in the installation"
-            ))
+            Err(
+                anyhow::anyhow!("edgedb-load-ext not found in the installation")
+                    .with_hint(|| {
+                        format!("Extension installation requires EdgeDB server version 6 or later")
+                    })
+                    .into(),
+            )
         }
     }
 }

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -297,11 +297,9 @@ impl Paths {
 
 impl InstanceInfo {
     pub fn get_version(&self) -> anyhow::Result<&ver::Build> {
-        self.installation
-            .as_ref()
-            .map(|v| &v.version)
-            .ok_or_else(|| bug::error("no installation info at this point"))
+        Ok(&self.get_installation()?.version)
     }
+
     pub fn try_read(name: &str) -> anyhow::Result<Option<InstanceInfo>> {
         if cfg!(windows) {
             let data = match windows::get_instance_info(name) {
@@ -346,29 +344,31 @@ impl InstanceInfo {
         data.name = name.into();
         Ok(data)
     }
+
     pub fn data_dir(&self) -> anyhow::Result<PathBuf> {
         instance_data_dir(&self.name)
     }
 
-    pub fn server_path(&self) -> anyhow::Result<PathBuf> {
+    fn get_installation(&self) -> anyhow::Result<&InstallInfo> {
         self.installation
             .as_ref()
-            .ok_or_else(|| bug::error("installation should be set"))?
-            .server_path()
+            .ok_or_else(|| bug::error("installation should be set"))
+    }
+
+    pub fn server_path(&self) -> anyhow::Result<PathBuf> {
+        self.get_installation()?.server_path()
     }
 
     pub fn base_path(&self) -> anyhow::Result<PathBuf> {
-        self.installation
-            .as_ref()
-            .ok_or_else(|| bug::error("installation should be set"))?
-            .base_path()
+        self.get_installation()?.base_path()
     }
 
     pub fn extension_path(&self) -> anyhow::Result<PathBuf> {
-        self.installation
-            .as_ref()
-            .ok_or_else(|| bug::error("installation should be set"))?
-            .extension_path()
+        self.get_installation()?.extension_path()
+    }
+
+    pub fn extension_loader_path(&self) -> anyhow::Result<PathBuf> {
+        self.get_installation()?.extension_loader_path()
     }
 
     pub fn admin_conn_params(&self) -> anyhow::Result<Builder> {
@@ -396,11 +396,28 @@ impl InstallInfo {
     }
 
     pub fn extension_path(&self) -> anyhow::Result<PathBuf> {
-        let path = self.base_path()?.join("share").join("data").join("extensions");
+        let path = self
+            .base_path()?
+            .join("share")
+            .join("data")
+            .join("extensions");
         if !path.exists() {
-            Err(bug::error("no extension directory available for this server"))
+            Err(bug::error(
+                "no extension directory available for this server",
+            ))
         } else {
             Ok(path)
+        }
+    }
+
+    pub fn extension_loader_path(&self) -> anyhow::Result<PathBuf> {
+        let path = self.base_path()?.join("bin").join("edgedb-load-ext");
+        if path.exists() {
+            Ok(path)
+        } else {
+            Err(anyhow::anyhow!(
+                "edgedb-load-ext not found in the installation"
+            ))
         }
     }
 }

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -359,10 +359,12 @@ impl InstanceInfo {
         self.get_installation()?.server_path()
     }
 
+    #[allow(unused)]
     pub fn base_path(&self) -> anyhow::Result<PathBuf> {
         self.get_installation()?.base_path()
     }
 
+    #[allow(unused)]
     pub fn extension_path(&self) -> anyhow::Result<PathBuf> {
         self.get_installation()?.extension_path()
     }

--- a/src/portable/mod.rs
+++ b/src/portable/mod.rs
@@ -29,6 +29,6 @@ pub mod status;
 mod uninstall;
 mod upgrade;
 
-pub use main::{instance_main, project_main, server_main};
 pub use extension::extension_main;
+pub use main::{instance_main, project_main, server_main};
 pub use reset_password::password_hash;

--- a/src/portable/mod.rs
+++ b/src/portable/mod.rs
@@ -16,6 +16,7 @@ mod control;
 mod create;
 mod credentials;
 mod destroy;
+mod extension;
 mod info;
 pub mod install;
 mod link;
@@ -29,4 +30,5 @@ mod uninstall;
 mod upgrade;
 
 pub use main::{instance_main, project_main, server_main};
+pub use extension::extension_main;
 pub use reset_password::password_hash;

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -83,10 +83,12 @@ pub struct ServerInstanceExtensionCommand {
 
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum InstanceExtensionCommand {
-    #[command(hide=true)]
+    #[command(hide = true)]
     List(ExtensionList),
     ListAvailable(ExtensionListExtensions),
     Install(ExtensionInstall),
+    #[command(hide = true)]
+    Uninstall(ExtensionUninstall),
 }
 
 #[derive(clap::Args, IntoArgs, Debug, Clone)]
@@ -103,9 +105,9 @@ pub struct ExtensionListExtensions {
     #[arg(short = 'I', long)]
     #[arg(value_hint=ValueHint::Other)] // TODO complete instance name
     pub instance: Option<InstanceName>,
-    #[arg(long, hide=true)]
+    #[arg(long, hide = true)]
     pub channel: Option<Channel>,
-    #[arg(long, hide=true)]
+    #[arg(long, hide = true)]
     pub slot: Option<String>,
 }
 
@@ -117,10 +119,21 @@ pub struct ExtensionInstall {
     pub instance: Option<InstanceName>,
     #[arg(short = 'E', long)]
     pub extension: String,
-    #[arg(long, hide=true)]
+    #[arg(long, hide = true)]
     pub channel: Option<Channel>,
-    #[arg(long, hide=true)]
+    #[arg(long, hide = true)]
     pub slot: Option<String>,
+    #[arg(long, hide = true)]
+    pub reinstall: bool,
+}
+
+#[derive(clap::Args, IntoArgs, Debug, Clone)]
+pub struct ExtensionUninstall {
+    /// Specify local instance name.
+    #[arg(short = 'I', long)]
+    pub instance: Option<InstanceName>,
+    #[arg(short = 'E', long)]
+    pub extension: String,
 }
 
 #[derive(clap::Subcommand, Clone, Debug)]

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -83,10 +83,14 @@ pub struct ServerInstanceExtensionCommand {
 
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum InstanceExtensionCommand {
+    /// List installed extensions for a local instance.
     #[command(hide = true)]
     List(ExtensionList),
+    /// List available extensions for a local instance.
     ListAvailable(ExtensionListExtensions),
+    /// Install an extension for a local instance.
     Install(ExtensionInstall),
+    /// Uninstall an extension from a local instance.
     #[command(hide = true)]
     Uninstall(ExtensionUninstall),
 }
@@ -105,8 +109,10 @@ pub struct ExtensionListExtensions {
     #[arg(short = 'I', long)]
     #[arg(value_hint=ValueHint::Other)] // TODO complete instance name
     pub instance: Option<InstanceName>,
+    /// Specify the channel override (stable, testing, or nightly)
     #[arg(long, hide = true)]
     pub channel: Option<Channel>,
+    /// Specify the slot override (for development use)
     #[arg(long, hide = true)]
     pub slot: Option<String>,
 }
@@ -117,21 +123,26 @@ pub struct ExtensionInstall {
     #[arg(short = 'I', long)]
     #[arg(value_hint=ValueHint::Other)] // TODO complete instance name
     pub instance: Option<InstanceName>,
+    /// Name of the extension to install
     #[arg(short = 'E', long)]
     pub extension: String,
+    /// Specify the channel override (stable, testing, or nightly)
     #[arg(long, hide = true)]
     pub channel: Option<Channel>,
+    /// Specify the slot override (for development use)
     #[arg(long, hide = true)]
     pub slot: Option<String>,
+    /// Reinstall the extension if it's already installed
     #[arg(long, hide = true)]
     pub reinstall: bool,
 }
-
+/// Represents the options for uninstalling an extension from a local EdgeDB instance.
 #[derive(clap::Args, IntoArgs, Debug, Clone)]
 pub struct ExtensionUninstall {
     /// Specify local instance name.
     #[arg(short = 'I', long)]
     pub instance: Option<InstanceName>,
+    /// The name of the extension to uninstall.
     #[arg(short = 'E', long)]
     pub extension: String,
 }

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -73,6 +73,56 @@ pub enum InstanceCommand {
     Credentials(ShowCredentials),
 }
 
+#[derive(clap::Args, Debug, Clone)]
+#[command(version = "help_expand")]
+#[command(disable_version_flag = true)]
+pub struct ServerInstanceExtensionCommand {
+    #[command(subcommand)]
+    pub subcommand: InstanceExtensionCommand,
+}
+
+#[derive(clap::Subcommand, Clone, Debug)]
+pub enum InstanceExtensionCommand {
+    #[command(hide=true)]
+    List(ExtensionList),
+    ListAvailable(ExtensionListExtensions),
+    Install(ExtensionInstall),
+}
+
+#[derive(clap::Args, IntoArgs, Debug, Clone)]
+pub struct ExtensionList {
+    /// Specify local instance name.
+    #[arg(short = 'I', long)]
+    #[arg(value_hint=ValueHint::Other)] // TODO complete instance name
+    pub instance: Option<InstanceName>,
+}
+
+#[derive(clap::Args, IntoArgs, Debug, Clone)]
+pub struct ExtensionListExtensions {
+    /// Specify local instance name.
+    #[arg(short = 'I', long)]
+    #[arg(value_hint=ValueHint::Other)] // TODO complete instance name
+    pub instance: Option<InstanceName>,
+    #[arg(long, hide=true)]
+    pub channel: Option<Channel>,
+    #[arg(long, hide=true)]
+    pub slot: Option<String>,
+}
+
+#[derive(clap::Args, IntoArgs, Debug, Clone)]
+pub struct ExtensionInstall {
+    /// Specify local instance name.
+    #[arg(short = 'I', long)]
+    #[arg(value_hint=ValueHint::Other)] // TODO complete instance name
+    pub instance: Option<InstanceName>,
+    #[arg(short = 'E', long)]
+    pub extension: String,
+    #[arg(long, hide=true)]
+    pub channel: Option<Channel>,
+    #[arg(long, hide=true)]
+    pub slot: Option<String>,
+}
+
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum Command {
     /// Show locally installed EdgeDB versions.

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -219,7 +219,11 @@ where
     }
 }
 
-fn filter_package(pkg_root: &Url, pkg: &PackageData, expected_package_type: PackageType) -> Option<PackageInfo> {
+fn filter_package(
+    pkg_root: &Url,
+    pkg: &PackageData,
+    expected_package_type: PackageType,
+) -> Option<PackageInfo> {
     let result = _filter_package(pkg_root, pkg, expected_package_type);
     if result.is_none() {
         log::info!("Skipping package {:?}", pkg);
@@ -227,18 +231,31 @@ fn filter_package(pkg_root: &Url, pkg: &PackageData, expected_package_type: Pack
     result
 }
 
-fn _filter_package(pkg_root: &Url, pkg: &PackageData, expected_package_type: PackageType) -> Option<PackageInfo> {
+fn _filter_package(
+    pkg_root: &Url,
+    pkg: &PackageData,
+    expected_package_type: PackageType,
+) -> Option<PackageInfo> {
     let iref = pkg.installrefs.iter().find(|r| {
         let matches_type = match expected_package_type {
-            PackageType::TarZst => r.kind == "application/x-tar" && r.encoding.as_deref() == Some("zstd"),
-            PackageType::Zip => r.kind == "application/zip" && r.encoding.as_deref() == Some("identity"),
+            PackageType::TarZst => {
+                r.kind == "application/x-tar" && r.encoding.as_deref() == Some("zstd")
+            }
+            PackageType::Zip => {
+                r.kind == "application/zip" && r.encoding.as_deref() == Some("identity")
+            }
         };
         if !matches_type {
-            log::trace!("Package type mismatch: expected {:?}, got kind '{}' and encoding '{:?}'", 
-                        expected_package_type, r.kind, r.encoding);
+            log::trace!(
+                "Package type mismatch: expected {:?}, got kind '{}' and encoding '{:?}'",
+                expected_package_type,
+                r.kind,
+                r.encoding
+            );
             return false;
         }
-        let valid_verification = r.verification
+        let valid_verification = r
+            .verification
             .blake2b
             .as_ref()
             .map(valid_hash)
@@ -392,7 +409,10 @@ pub fn get_platform_extension_packages(
     let packages = data
         .packages
         .iter()
-        .filter(|pkg| pkg.tags.contains_key("extension") && pkg.tags.get("server_slot").map(|s| s.as_str()) == Some(slot))
+        .filter(|pkg| {
+            pkg.tags.contains_key("extension")
+                && pkg.tags.get("server_slot").map(|s| s.as_str()) == Some(slot)
+        })
         .filter_map(|p| filter_package(pkg_root, p, PackageType::Zip))
         .collect();
     Ok(packages)

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -304,7 +304,7 @@ fn _filter_cli_package(pkg_root: &Url, pkg: &PackageData) -> Option<CliPackageIn
         .installrefs
         .iter()
         .find(|r| {
-            r.encoding.as_ref().map(|x| &x[..]) == Some("zstd")
+            r.encoding.as_deref() == Some("zstd")
                 && r.verification
                     .blake2b
                     .as_ref()
@@ -313,7 +313,7 @@ fn _filter_cli_package(pkg_root: &Url, pkg: &PackageData) -> Option<CliPackageIn
         })
         .or_else(|| {
             pkg.installrefs.iter().find(|r| {
-                r.encoding.as_ref().map(|x| &x[..]) == Some("identity")
+                r.encoding.as_deref() == Some("identity")
                     && r.verification
                         .blake2b
                         .as_ref()

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -1,4 +1,5 @@
 use std::cmp::min;
+use std::collections::HashMap;
 use std::env;
 use std::fmt;
 use std::future;
@@ -6,6 +7,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use anyhow::Context;
+use edgedb_cli_derive::IntoArgs;
 use fn_error_context::context;
 use indicatif::{ProgressBar, ProgressStyle};
 use is_terminal::IsTerminal;
@@ -19,6 +21,8 @@ use crate::async_util::timeout;
 use crate::portable::platform;
 use crate::portable::ver;
 use crate::portable::windows;
+use crate::process::IntoArg;
+use crate::process::IntoArgs;
 
 pub const USER_AGENT: &str = "edgedb";
 pub const DEFAULT_TIMEOUT: Duration = Duration::new(60, 0);
@@ -38,6 +42,7 @@ pub enum Channel {
 #[derive(Debug, Clone, serde::Serialize)]
 pub enum PackageType {
     TarZst,
+    Zip,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -82,6 +87,9 @@ pub struct PackageData {
     pub basename: String,
     pub version: String,
     pub installrefs: Vec<InstallRef>,
+    pub slot: String,
+    #[serde(default)]
+    pub tags: HashMap<String, String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -92,11 +100,14 @@ pub struct Verification {
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PackageInfo {
+    pub name: String,
     pub version: ver::Build,
     pub url: Url,
     pub size: u64,
     pub hash: PackageHash,
     pub kind: PackageType,
+    pub slot: String,
+    pub tags: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone)]
@@ -119,6 +130,7 @@ impl PackageType {
     fn as_ext(&self) -> &str {
         match self {
             PackageType::TarZst => ".tar.zst",
+            PackageType::Zip => ".zip",
         }
     }
 }
@@ -207,30 +219,60 @@ where
     }
 }
 
-fn filter_package(pkg_root: &Url, pkg: &PackageData) -> Option<PackageInfo> {
-    let result = _filter_package(pkg_root, pkg);
+fn filter_package(pkg_root: &Url, pkg: &PackageData, expected_package_type: PackageType) -> Option<PackageInfo> {
+    let result = _filter_package(pkg_root, pkg, expected_package_type);
     if result.is_none() {
         log::info!("Skipping package {:?}", pkg);
     }
     result
 }
 
-fn _filter_package(pkg_root: &Url, pkg: &PackageData) -> Option<PackageInfo> {
+fn _filter_package(pkg_root: &Url, pkg: &PackageData, expected_package_type: PackageType) -> Option<PackageInfo> {
     let iref = pkg.installrefs.iter().find(|r| {
-        r.kind == "application/x-tar"
-            && r.encoding.as_ref().map(|x| &x[..]) == Some("zstd")
-            && r.verification
-                .blake2b
-                .as_ref()
-                .map(valid_hash)
-                .unwrap_or(false)
+        let matches_type = match expected_package_type {
+            PackageType::TarZst => r.kind == "application/x-tar" && r.encoding.as_deref() == Some("zstd"),
+            PackageType::Zip => r.kind == "application/zip" && r.encoding.as_deref() == Some("identity"),
+        };
+        if !matches_type {
+            log::trace!("Package type mismatch: expected {:?}, got kind '{}' and encoding '{:?}'", 
+                        expected_package_type, r.kind, r.encoding);
+            return false;
+        }
+        let valid_verification = r.verification
+            .blake2b
+            .as_ref()
+            .map(valid_hash)
+            .unwrap_or(false);
+        if !valid_verification {
+            log::trace!("Invalid or missing blake2b hash for package");
+            return false;
+        }
+        true
     })?;
+    let version = match pkg.version.parse() {
+        Ok(v) => v,
+        Err(e) => {
+            log::trace!("Failed to parse package version: {}", e);
+            return None;
+        }
+    };
+    let url = match pkg_root.join(&iref.path) {
+        Ok(u) => u,
+        Err(e) => {
+            log::trace!("Failed to join package URL: {}", e);
+            return None;
+        }
+    };
+    let hash = PackageHash::Blake2b(iref.verification.blake2b.as_ref()?[..].into());
     Some(PackageInfo {
-        version: pkg.version.parse().ok()?,
-        url: pkg_root.join(&iref.path).ok()?,
-        hash: PackageHash::Blake2b(iref.verification.blake2b.as_ref()?[..].into()),
-        kind: PackageType::TarZst,
+        name: pkg.basename.clone(),
+        version,
+        url,
+        hash,
+        kind: expected_package_type,
         size: iref.verification.size,
+        slot: pkg.slot.clone(),
+        tags: pkg.tags.clone(),
     })
 }
 
@@ -264,7 +306,7 @@ fn _filter_cli_package(pkg_root: &Url, pkg: &PackageData) -> Option<CliPackageIn
                         .unwrap_or(false)
             })
         })?;
-    let cmpr = if iref.encoding.as_ref().map(|x| &x[..]) == Some("zstd") {
+    let cmpr = if iref.encoding.as_deref() == Some("zstd") {
         Some(Compression::Zstd)
     } else {
         None
@@ -330,7 +372,28 @@ fn get_platform_server_packages(
         .packages
         .iter()
         .filter(|pkg| pkg.basename == "edgedb-server")
-        .filter_map(|p| filter_package(pkg_root, p))
+        .filter_map(|p| filter_package(pkg_root, p, PackageType::TarZst))
+        .collect();
+    Ok(packages)
+}
+
+pub fn get_platform_extension_packages(
+    channel: Channel,
+    slot: &str,
+    platform: &str,
+) -> anyhow::Result<Vec<PackageInfo>> {
+    let pkg_root = pkg_root()?;
+
+    let data: RepositoryData = match get_json(&json_url(platform, channel)?, DEFAULT_TIMEOUT) {
+        Ok(data) => data,
+        Err(e) if e.is::<NotFound>() => RepositoryData { packages: vec![] },
+        Err(e) => return Err(e),
+    };
+    let packages = data
+        .packages
+        .iter()
+        .filter(|pkg| pkg.tags.contains_key("extension") && pkg.tags.get("server_slot").map(|s| s.as_str()) == Some(slot))
+        .filter_map(|p| filter_package(pkg_root, p, PackageType::Zip))
         .collect();
     Ok(packages)
 }
@@ -423,7 +486,7 @@ pub async fn download(
 
 impl fmt::Display for PackageInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "edgdb-server@{}", self.version)
+        write!(f, "{}@{}", self.name, self.version)
     }
 }
 
@@ -755,6 +818,12 @@ impl Channel {
             Channel::Stable => "stable",
             Channel::Testing => "testing",
         }
+    }
+}
+
+impl IntoArg for &Channel {
+    fn add_arg(self, process: &mut crate::process::Native) {
+        process.arg(self.as_str());
     }
 }
 

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -7,7 +7,6 @@ use std::path::Path;
 use std::time::Duration;
 
 use anyhow::Context;
-use edgedb_cli_derive::IntoArgs;
 use fn_error_context::context;
 use indicatif::{ProgressBar, ProgressStyle};
 use is_terminal::IsTerminal;
@@ -22,7 +21,6 @@ use crate::portable::platform;
 use crate::portable::ver;
 use crate::portable::windows;
 use crate::process::IntoArg;
-use crate::process::IntoArgs;
 
 pub const USER_AGENT: &str = "edgedb";
 pub const DEFAULT_TIMEOUT: Duration = Duration::new(60, 0);

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -50,7 +50,7 @@ pub enum FilterMinor {
 }
 
 static BUILD: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^\d+\.\d+(?:-(?:alpha|beta|rc|dev)\.\d+)?\+(?:[a-f0-9]{7}|local)$"#).unwrap()
+    Regex::new(r#"^\d+\.\d+(?:\.\d+)?(?:-(?:alpha|beta|rc|dev)\.\d+)?\+(?:[a-f0-9]{7}|local)$"#).unwrap()
 });
 
 static SPECIFIC: Lazy<Regex> = Lazy::new(|| {
@@ -211,6 +211,16 @@ impl Specific {
 
     pub fn is_stable(&self) -> bool {
         matches!(self.minor, MinorVersion::Minor(_))
+    }
+
+    pub fn slot(&self) -> String {
+        match self.minor {
+            MinorVersion::Minor(_) => self.major.to_string(),
+            MinorVersion::Dev(v) => format!("{}-dev{}", self.major, v),
+            MinorVersion::Alpha(v) => format!("{}-alpha{}", self.major, v),
+            MinorVersion::Beta(v) => format!("{}-beta{}", self.major, v),
+            MinorVersion::Rc(v) => format!("{}-rc{}", self.major, v),
+        }
     }
 }
 

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -50,7 +50,8 @@ pub enum FilterMinor {
 }
 
 static BUILD: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"^\d+\.\d+(?:\.\d+)?(?:-(?:alpha|beta|rc|dev)\.\d+)?\+(?:[a-f0-9]{7}|local)$"#).unwrap()
+    Regex::new(r#"^\d+\.\d+(?:\.\d+)?(?:-(?:alpha|beta|rc|dev)\.\d+)?\+(?:[a-f0-9]{7}|local)$"#)
+        .unwrap()
 });
 
 static SPECIFIC: Lazy<Regex> = Lazy::new(|| {


### PR DESCRIPTION
This PR adds two supported commands:

```
Manage local extensions

Usage: edgedb extension <COMMAND>

Commands:
  list-available  List available extensions for a local instance
  install         Install an extension for a local instance
  help            Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

install:

```
Install an extension for a local instance

Usage: edgedb extension install [OPTIONS] --extension <EXTENSION>

Options:
  -I, --instance <INSTANCE>    Specify local instance name
  -E, --extension <EXTENSION>  Name of the extension to install
  -h, --help                   Print help
```

Example run:

```
> extension install -E postgis -I testnightly --slot 6-dev8882
Found extension package: postgis version 3.5.0-dev.22+6c1775b
00:00:00 [====================] 22.51 MiB/22.51 MiB 32.22 MiB/s | ETA: 0s                                                                                     Extension 'postgis' installed successfully.
```

list-available:

```
List available extensions for a local instance

Usage: edgedb extension list-available [OPTIONS]

Options:
  -I, --instance <INSTANCE>  Specify local instance name
  -h, --help                 Print help
```

Example run:

```
> cargo run -- extension list-available -I testnightly --slot 6-dev8882
┌─────────┬──────────────────────┐
│ Name    │ Version              │
│ postgis │ 3.5.0-dev.22+6c1775b │
└─────────┴──────────────────────┘
```

Two hidden commands are added as well (`uninstall` and `list`) but these require server support before they can be unhidden.
