### PR TITLE
Hook up uninstall/list commands

### DIFF
--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -90,14 +90,12 @@ pub struct ServerInstanceExtensionCommand {
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum InstanceExtensionCommand {
     /// List installed extensions for a local instance.
-    #[command(hide = true)]
     List(ExtensionList),
     /// List available extensions for a local instance.
     ListAvailable(ExtensionListExtensions),
     /// Install an extension for a local instance.
     Install(ExtensionInstall),
     /// Uninstall an extension from a local instance.
-    #[command(hide = true)]
     Uninstall(ExtensionUninstall),
 }
 


### PR DESCRIPTION
These are now supported in the extension loader, so we can hook them up to the CLI as well. These were previously hidden commands.

```
cargo run -- extension list -I testnightly3 
┌─────────┬─────────┐
│ Name    │ Version │
│ postgis │ 3.4.3   │
└─────────┴─────────┘
```
