### PR TITLE
Prepare to rename EdgeDB -> Gel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1138,7 @@ dependencies = [
  "color-print",
  "colorful",
  "combine",
+ "const_format",
  "crossbeam-utils",
  "ctrlc",
  "dirs",
@@ -4238,6 +4259,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.5.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#7fd932b1bd4d861002a753ebd389ec79550ff2c0"
+source = "git+https://github.com/edgedb/edgedb-rust/#c54557603508acdd7256a36558b2f41d01834924"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.4.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#7fd932b1bd4d861002a753ebd389ec79550ff2c0"
+source = "git+https://github.com/edgedb/edgedb-rust/#c54557603508acdd7256a36558b2f41d01834924"
 dependencies = [
  "bytes",
 ]
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.6.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#7fd932b1bd4d861002a753ebd389ec79550ff2c0"
+source = "git+https://github.com/edgedb/edgedb-rust/#c54557603508acdd7256a36558b2f41d01834924"
 dependencies = [
  "bigdecimal",
  "bitflags 2.6.0",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.5.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#7fd932b1bd4d861002a753ebd389ec79550ff2c0"
+source = "git+https://github.com/edgedb/edgedb-rust/#c54557603508acdd7256a36558b2f41d01834924"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.5.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#66b8284848f076a829a066632c1d2be516ede493"
+source = "git+https://github.com/edgedb/edgedb-rust/#54522611d0149625082be89c4f8f0e7abdb2e378"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.4.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#66b8284848f076a829a066632c1d2be516ede493"
+source = "git+https://github.com/edgedb/edgedb-rust/#54522611d0149625082be89c4f8f0e7abdb2e378"
 dependencies = [
  "bytes",
 ]
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.6.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#66b8284848f076a829a066632c1d2be516ede493"
+source = "git+https://github.com/edgedb/edgedb-rust/#54522611d0149625082be89c4f8f0e7abdb2e378"
 dependencies = [
  "bigdecimal",
  "bitflags 2.6.0",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.5.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#66b8284848f076a829a066632c1d2be516ede493"
+source = "git+https://github.com/edgedb/edgedb-rust/#54522611d0149625082be89c4f8f0e7abdb2e378"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.5.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#14f2914ca1e40a78b6fa22d0beb3e4caf3dfd01d"
+source = "git+https://github.com/edgedb/edgedb-rust/#66b8284848f076a829a066632c1d2be516ede493"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.4.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#14f2914ca1e40a78b6fa22d0beb3e4caf3dfd01d"
+source = "git+https://github.com/edgedb/edgedb-rust/#66b8284848f076a829a066632c1d2be516ede493"
 dependencies = [
  "bytes",
 ]
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.6.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#14f2914ca1e40a78b6fa22d0beb3e4caf3dfd01d"
+source = "git+https://github.com/edgedb/edgedb-rust/#66b8284848f076a829a066632c1d2be516ede493"
 dependencies = [
  "bigdecimal",
  "bitflags 2.6.0",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.5.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#14f2914ca1e40a78b6fa22d0beb3e4caf3dfd01d"
+source = "git+https://github.com/edgedb/edgedb-rust/#66b8284848f076a829a066632c1d2be516ede493"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,20 @@ name = "concolor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b946244a988c390a94667ae0e3958411fa40cc46ea496a929b263d883f5f9c3"
+dependencies = [
+ "bitflags 1.3.2",
+ "concolor-query",
+ "is-terminal",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -4586,6 +4600,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -4609,6 +4632,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4644,6 +4682,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -4656,6 +4700,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -4665,6 +4715,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4686,6 +4742,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -4695,6 +4757,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4710,6 +4778,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -4719,6 +4793,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.5.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#54522611d0149625082be89c4f8f0e7abdb2e378"
+source = "git+https://github.com/edgedb/edgedb-rust/#7fd932b1bd4d861002a753ebd389ec79550ff2c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.4.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#54522611d0149625082be89c4f8f0e7abdb2e378"
+source = "git+https://github.com/edgedb/edgedb-rust/#7fd932b1bd4d861002a753ebd389ec79550ff2c0"
 dependencies = [
  "bytes",
 ]
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.6.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#54522611d0149625082be89c4f8f0e7abdb2e378"
+source = "git+https://github.com/edgedb/edgedb-rust/#7fd932b1bd4d861002a753ebd389ec79550ff2c0"
 dependencies = [
  "bigdecimal",
  "bitflags 2.6.0",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.5.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#54522611d0149625082be89c4f8f0e7abdb2e378"
+source = "git+https://github.com/edgedb/edgedb-rust/#7fd932b1bd4d861002a753ebd389ec79550ff2c0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,17 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,18 +638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
-name = "clicolors-control"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
-dependencies = [
- "atty",
- "lazy_static",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +714,12 @@ dependencies = [
  "nix 0.27.1",
  "thiserror",
 ]
+
+[[package]]
+name = "concolor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b946244a988c390a94667ae0e3958411fa40cc46ea496a929b263d883f5f9c3"
 
 [[package]]
 name = "concurrent-queue"
@@ -1133,11 +1116,11 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
- "clicolors-control",
  "codespan-reporting",
  "color-print",
  "colorful",
  "combine",
+ "concolor",
  "const_format",
  "crossbeam-utils",
  "ctrlc",
@@ -1811,15 +1794,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ pem = "3.0.3"
 rustls = { version = "0.23", features = ["ring"], default-features = false }
 tokio-stream = "0.1.11"
 futures-util = "0.3.15" # used for signals
-concolor = "0.1.1"
+concolor = { version = "0.1.1", features = ["auto"] }
 backtrace = "0.3.61"
 arc-swap = "1.4.0"
 ctrlc = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ pem = "3.0.3"
 rustls = { version = "0.23", features = ["ring"], default-features = false }
 tokio-stream = "0.1.11"
 futures-util = "0.3.15" # used for signals
-clicolors-control = "1.0.1"
+concolor = "0.1.1"
 backtrace = "0.3.61"
 arc-swap = "1.4.0"
 ctrlc = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ rustyline = { version = "14.0.0" }
 clap = {workspace = true, features=["derive", "cargo", "deprecated", "wrap_help"]}
 clap_complete = "4.4.3"
 color-print = "0.3.5"
+const_format = "0.2.33"
 strsim = "0.11.0"
 whoami = "1.1"
 is-terminal = "0.4.4"

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -1,5 +1,6 @@
 use edgedb_tokio::{get_project_path, get_stash_path};
 
+use crate::branding::{BRANDING, BRANDING_CLOUD};
 use crate::commands::Options;
 use crate::connect::Connection;
 use crate::credentials;
@@ -55,7 +56,7 @@ impl Context {
                 InstanceName::Cloud { org_slug, name } => anyhow::bail!(
                     // should never occur because of the above check
                     format!(
-                        "cannot use Cloud instance {}/{}: instance is not linked to a project",
+                        "cannot use {BRANDING_CLOUD} instance {}/{}: instance is not linked to a project",
                         org_slug, name
                     )
                 ),
@@ -137,7 +138,7 @@ impl Context {
                 name: inst,
             } => {
                 anyhow::bail!(
-                    format!("cannot switch branches on Cloud instance {}/{}: instance is not linked to a project", org, inst)
+                    format!("cannot switch branches on {BRANDING_CLOUD} instance {}/{}: instance is not linked to a project", org, inst)
                 )
             }
         }

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -68,7 +68,7 @@ impl Context {
             }
         } else if let Some(project_dir) = project_dir.as_ref() {
             // try read from the database file
-            let stash_dir = get_stash_path(&fs::canonicalize(project_dir)?)?;
+            let stash_dir = get_stash_path(project_dir)?;
             branch = project::database_name(&stash_dir)?;
         }
 

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -149,8 +149,6 @@ impl Context {
         let Some(path) = &project_dir else {
             return Ok(None);
         };
-        Ok(Some(crate::portable::config::read(
-            &path,
-        )?))
+        Ok(Some(crate::portable::config::read(&path)?))
     }
 }

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -1,6 +1,6 @@
 use edgedb_tokio::{get_project_path, get_stash_path};
 
-use crate::branding::{BRANDING, BRANDING_CLOUD};
+use crate::branding::BRANDING_CLOUD;
 use crate::commands::Options;
 use crate::connect::Connection;
 use crate::credentials;

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -1,4 +1,4 @@
-use edgedb_tokio::get_project_path;
+use edgedb_tokio::{get_project_path, get_stash_path};
 
 use crate::commands::Options;
 use crate::connect::Connection;
@@ -37,7 +37,7 @@ impl Context {
 
         if instance_name.is_none() {
             instance_name = if let Some(project_dir) = project_dir.as_ref() {
-                let stash_dir = project::stash_path(&fs::canonicalize(project_dir)?)?;
+                let stash_dir = get_stash_path(project_dir)?;
                 project::instance_name(&stash_dir).ok()
             } else {
                 None
@@ -68,7 +68,7 @@ impl Context {
             }
         } else if let Some(project_dir) = project_dir.as_ref() {
             // try read from the database file
-            let stash_dir = project::stash_path(&fs::canonicalize(project_dir)?)?;
+            let stash_dir = get_stash_path(&fs::canonicalize(project_dir)?)?;
             branch = project::database_name(&stash_dir)?;
         }
 
@@ -123,8 +123,7 @@ impl Context {
             } if self.project_dir.is_some() => {
                 // only place to store the branch is the database file in the project
                 let stash_path =
-                    project::stash_path(&fs::canonicalize(self.project_dir.as_ref().unwrap())?)?
-                        .join("database");
+                    get_stash_path(self.project_dir.as_ref().unwrap())?.join("database");
 
                 // ensure that the temp file is created in the same directory as the 'database' file
                 let tmp = tmp_file_path(&stash_path);

--- a/src/branch/main.rs
+++ b/src/branch/main.rs
@@ -1,6 +1,7 @@
 use crate::branch::context::Context;
 use crate::branch::option::{BranchCommand, Command};
 use crate::branch::{create, current, drop, list, merge, rebase, rename, switch, wipe};
+use crate::branding::BRANDING;
 use crate::commands::{CommandResult, Options};
 use crate::connect::{Connection, Connector};
 
@@ -62,7 +63,7 @@ pub async fn verify_server_can_use_branches(connection: &mut Connection) -> anyh
     let server_version = connection.get_version().await?;
     if server_version.specific().major < 5 {
         anyhow::bail!(
-            "Branches are not supported on server version {}, please upgrade to EdgeDB 5+",
+            "Branches are not supported on server version {}, please upgrade to {BRANDING} 5+",
             server_version
         );
     }

--- a/src/branding.rs
+++ b/src/branding.rs
@@ -1,4 +1,7 @@
+#![allow(unused)]
+
 pub const BRANDING: &str = "EdgeDB";
+pub const BRANDING_CLI: &str = "EdgeDB CLI";
 pub const BRANDING_CLOUD: &str = "EdgeDB Cloud";
-pub const BRANDING_CLI: &str = "edgedb";
+pub const BRANDING_CLI_CMD: &str = "edgedb";
 pub const CONFIG_FILE_DISPLAY_NAME: &str = "`gel.toml` (or `edgedb.toml`)";

--- a/src/branding.rs
+++ b/src/branding.rs
@@ -1,3 +1,4 @@
 pub const BRANDING: &str = "EdgeDB";
+pub const BRANDING_CLOUD: &str = "EdgeDB Cloud";
 pub const BRANDING_CLI: &str = "edgedb";
 pub const CONFIG_FILE_DISPLAY_NAME: &str = "`gel.toml` (or `edgedb.toml`)";

--- a/src/branding.rs
+++ b/src/branding.rs
@@ -4,4 +4,5 @@ pub const BRANDING: &str = "EdgeDB";
 pub const BRANDING_CLI: &str = "EdgeDB CLI";
 pub const BRANDING_CLOUD: &str = "EdgeDB Cloud";
 pub const BRANDING_CLI_CMD: &str = "edgedb";
+pub const BRANDING_WSL: &str = "EdgeDB.WSL.1";
 pub const CONFIG_FILE_DISPLAY_NAME: &str = "`gel.toml` (or `edgedb.toml`)";

--- a/src/branding.rs
+++ b/src/branding.rs
@@ -1,0 +1,3 @@
+pub const BRANDING: &str = "EdgeDB";
+pub const BRANDING_CLI: &str = "edgedb";
+pub const CONFIG_FILE_DISPLAY_NAME: &str = "`gel.toml` (or `edgedb.toml`)";

--- a/src/cli/directory_check.rs
+++ b/src/cli/directory_check.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 
+use crate::branding::{BRANDING_CLI, BRANDING_CLI_CMD};
 use crate::commands::ExitCode;
 use crate::platform::home_dir;
 use crate::print;
@@ -34,16 +35,17 @@ pub fn check_and_error() -> anyhow::Result<()> {
     match _check().context("failed directory check")? {
         Some(dir) => {
             print::error(format!(
-                "Edgedb CLI no longer uses `{dir}` to store data \
+                "{BRANDING_CLI} no longer uses `{dir}` to store data \
                 and now uses standard locations of your OS.",
                 dir = dir.display()
             ));
             print_markdown!(
                 "To upgrade the directory layout, run: \n\
                 ```\n\
-                edgedb cli migrate\n\
+                ${cmd} cli migrate\n\
                 ```
-            "
+            ",
+                cmd = BRANDING_CLI_CMD
             );
             Err(ExitCode::new(11).into())
         }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -10,6 +10,7 @@ use std::str::FromStr;
 
 use anyhow::Context;
 use clap_complete::{generate, shells};
+use edgedb_tokio::get_stash_path;
 use fn_error_context::context;
 use prettytable::{Cell, Row, Table};
 
@@ -396,7 +397,7 @@ fn try_project_init(new_layout: bool) -> anyhow::Result<InitResult> {
 
     let base_dir = env::current_dir().context("failed to get current directory")?;
     if let Some((project_dir, config_path)) = project_dir(Some(&base_dir))? {
-        if project::stash_path(&project_dir)?.exists() {
+        if get_stash_path(&project_dir)?.exists() {
             log::info!("Project already initialized. Skipping...");
             return Ok(Already);
         }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -14,7 +14,7 @@ use edgedb_tokio::get_stash_path;
 use fn_error_context::context;
 use prettytable::{Cell, Row, Table};
 
-use crate::branding::BRANDING;
+use crate::branding::{BRANDING, BRANDING_CLI, BRANDING_CLI_CMD};
 use crate::cli::{migrate, upgrade};
 use crate::commands::ExitCode;
 use crate::options::Options;
@@ -284,9 +284,10 @@ fn print_post_install_message(settings: &Settings, init_result: anyhow::Result<I
                 "\n\
                 To initialize a new project, run:\n\
                 ```\n\
-                    edgedb project init\n\
+                    ${cmd} project init\n\
                 ```\
-            "
+            ",
+                cmd = BRANDING_CLI_CMD
             );
         }
         Ok(InitResult::NotAProject) => {
@@ -294,17 +295,19 @@ fn print_post_install_message(settings: &Settings, init_result: anyhow::Result<I
                 "\n\
                 To initialize a new project, run:\n\
                 ```\n\
-                    edgedb project init\n\
+                    ${cmd} project init\n\
                 ```\
-            "
+            ",
+                cmd = BRANDING_CLI_CMD,
             );
         }
         Ok(InitResult::Already) => {
             print_markdown!(
                 "\n\
-                `edgedb` without parameters will automatically\n\
+                `${cmd}` without parameters will automatically\n\
                 connect to the current project.\n\
-            "
+            ",
+                cmd = BRANDING_CLI_CMD,
             );
         }
         Ok(InitResult::OldLayout) => {
@@ -312,10 +315,11 @@ fn print_post_install_message(settings: &Settings, init_result: anyhow::Result<I
                 "\n\
                 To initialize a project run:\n\
                 ```\n\
-                    edgedb cli migrate\n\
-                    edgedb project init\n\
+                    ${cmd} cli migrate\n\
+                    ${cmd} project init\n\
                 ```\
-            "
+            ",
+                cmd = BRANDING_CLI_CMD,
             );
         }
         Err(e) => {
@@ -325,9 +329,10 @@ fn print_post_install_message(settings: &Settings, init_result: anyhow::Result<I
                 \n\
                 To restart project initialization, run:\n\
                 ```\n\
-                    edgedb project init\n\
+                    ${cmd} project init\n\
                 ```\
                 ",
+                cmd = BRANDING_CLI_CMD,
                 err = format!("{:#}", e),
             );
         }
@@ -557,7 +562,7 @@ fn _main(options: &CliInstall) -> anyhow::Result<()> {
     let new_layout = if base.exists() {
         eprintln!(
             "\
-            Edgedb CLI no longer uses '{}' to store data \
+                {BRANDING_CLI} no longer uses '{}' to store data \
                 and now uses standard locations of your OS. \
         ",
             base.display()

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -494,7 +494,7 @@ fn _main(options: &CliInstall) -> anyhow::Result<()> {
     }
 
     if cfg!(all(target_os = "macos", target_arch = "x86_64")) && platform::is_arm64_hardware() {
-        echo!("EdgeDB now supports native M1 build. Downloading binary...");
+        echo!("{BRANDING} now supports native M1 build. Downloading binary...");
         return upgrade::upgrade_to_arm64();
     }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -499,7 +499,10 @@ fn _main(options: &CliInstall) -> anyhow::Result<()> {
     }
 
     if cfg!(all(target_os = "macos", target_arch = "x86_64")) && platform::is_arm64_hardware() {
-        echo!("{BRANDING} now supports native M1 build. Downloading binary...");
+        echo!(
+            BRANDING,
+            "now supports native M1 build. Downloading binary..."
+        );
         return upgrade::upgrade_to_arm64();
     }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -13,6 +13,7 @@ use clap_complete::{generate, shells};
 use fn_error_context::context;
 use prettytable::{Cell, Row, Table};
 
+use crate::branding::BRANDING;
 use crate::cli::{migrate, upgrade};
 use crate::commands::ExitCode;
 use crate::options::Options;
@@ -409,7 +410,7 @@ fn try_project_init(new_layout: bool) -> anyhow::Result<InitResult> {
         println!("Command-line tools are installed successfully.");
         println!();
         let q = question::Confirm::new(format!(
-            "Do you want to initialize an EdgeDB server instance for the project \
+            "Do you want to initialize a new {BRANDING} server instance for the project \
              defined in `{}`?",
             config_path.display(),
         ));

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -435,9 +435,7 @@ fn try_project_init(new_layout: bool) -> anyhow::Result<InitResult> {
             server_start_conf: None,
             cloud_opts: options.clone(),
         };
-        let dir = fs::canonicalize(&project_dir)
-            .with_context(|| format!("failed to canonicalize dir {:?}", project_dir))?;
-        project::init_existing(&init, &dir, config_path, &options)?;
+        project::init_existing(&init, &project_dir, config_path, &options)?;
         Ok(Initialized)
     } else {
         Ok(NotAProject)

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 use fn_error_context::context;
 use fs_err as fs;
 
+use crate::branding::BRANDING_CLI_CMD;
 use crate::cli::install::{get_rc_files, no_dir_in_path};
 use crate::commands::ExitCode;
 use crate::credentials;
@@ -340,7 +341,7 @@ pub fn migrate(base: &Path, dry_run: bool) -> anyhow::Result<()> {
     if !dry_run && dir_is_non_empty(base)? {
         eprintln!(
             "\
-            Directory {:?} is no longer used by EdgeDB tools and must be \
+            Directory {:?} is no longer used by {BRANDING} tools and must be \
             removed to finish migration, but some files or directories \
             remain after all known files have moved. \
             The files may have been left by a third party tool. \
@@ -358,9 +359,10 @@ pub fn migrate(base: &Path, dry_run: bool) -> anyhow::Result<()> {
                 Once all files are backed up, run one of:\n\
                 ```\n\
                 rm -rf ~/.edgedb\n\
-                edgedb cli migrate\n\
+                ${cmd} cli migrate\n\
                 ```\
-            "
+            ",
+                cmd = BRANDING_CLI_CMD
             );
             return Err(ExitCode::new(2).into());
         }

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -210,7 +210,7 @@ fn update_path(base: &Path, new_bin_path: &Path) -> anyhow::Result<()> {
             )
         })?;
         if modified && no_dir_in_path(&new_bin_dir) {
-            print::success("The `{BRANDING_CLI}` executable has moved!");
+            print::success("The `{BRANDING_CLI_CMD}` executable has moved!");
             print_markdown!(
                 "\
                 \n\

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -6,7 +6,6 @@ use anyhow::Context;
 use fn_error_context::context;
 use fs_err as fs;
 
-use crate::branding::BRANDING_CLI;
 use crate::cli::install::{get_rc_files, no_dir_in_path};
 use crate::commands::ExitCode;
 use crate::credentials;

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -211,7 +211,11 @@ fn update_path(base: &Path, new_bin_path: &Path) -> anyhow::Result<()> {
             )
         })?;
         if modified && no_dir_in_path(&new_bin_dir) {
-            print::success("The `{BRANDING_CLI_CMD}` executable has moved!");
+            print::success(concatcp!(
+                "The `",
+                BRANDING_CLI_CMD,
+                "` executable has moved!"
+            ));
             print_markdown!(
                 "\
                 \n\

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 use fn_error_context::context;
 use fs_err as fs;
 
+use crate::branding::BRANDING_CLI;
 use crate::cli::install::{get_rc_files, no_dir_in_path};
 use crate::commands::ExitCode;
 use crate::credentials;
@@ -210,7 +211,7 @@ fn update_path(base: &Path, new_bin_path: &Path) -> anyhow::Result<()> {
             )
         })?;
         if modified && no_dir_in_path(&new_bin_dir) {
-            print::success("The `edgedb` executable has moved!");
+            print::success("The `{BRANDING_CLI}` executable has moved!");
             print_markdown!(
                 "\
                 \n\

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -3,6 +3,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
+use const_format::concatcp;
 use fn_error_context::context;
 use fs_err as fs;
 
@@ -221,9 +222,10 @@ fn update_path(base: &Path, new_bin_path: &Path) -> anyhow::Result<()> {
                 \n\
                 `${dir}` has been added to your `PATH`.\n\
                 You may need to reopen the terminal for this change to\n\
-                take effect, and for the `edgedb` command to become\n\
+                take effect, and for the `${cmd}` command to become\n\
                 available.\
                 ",
+                cmd = BRANDING_CLI_CMD,
                 dir = new_bin_dir.display(),
             );
         }
@@ -247,7 +249,11 @@ fn update_path(base: &Path, new_bin_path: &Path) -> anyhow::Result<()> {
             .with_context(|| format!("failed to write env file {:?}", env_file))?;
 
         if modified && no_dir_in_path(new_bin_dir) {
-            print::success("The `edgedb` executable has moved!");
+            print::success(concatcp!(
+                "The `",
+                BRANDING_CLI_CMD,
+                "` executable has moved!"
+            ));
             print_markdown!(
                 "\
                 \n\
@@ -276,7 +282,7 @@ pub fn migrate(base: &Path, dry_run: bool) -> anyhow::Result<()> {
             let new_bin_path = binary_path()?;
             try_move_bin(&exe_path, &new_bin_path).map_err(|e| {
                 print::error("Cannot move executable to new location.");
-                eprintln!("  Try `edgedb cli upgrade` instead.");
+                eprintln!("  Try `{BRANDING_CLI_CMD} cli upgrade` instead.");
                 e
             })?;
             update_path(base, &new_bin_path)?;

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -6,7 +6,7 @@ use anyhow::Context;
 use fn_error_context::context;
 use fs_err as fs;
 
-use crate::branding::BRANDING_CLI_CMD;
+use crate::branding::{BRANDING, BRANDING_CLI_CMD};
 use crate::cli::install::{get_rc_files, no_dir_in_path};
 use crate::commands::ExitCode;
 use crate::credentials;

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -1,3 +1,5 @@
+#[cfg(doc)]
+use crate::branding::BRANDING_CLI_CMD;
 use crate::cli::install;
 use crate::cli::migrate;
 use crate::cli::upgrade;
@@ -12,9 +14,9 @@ pub struct CliCommand {
 
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum Command {
-    /// Upgrade the 'edgedb' command-line tool
+    /// Upgrade the [`BRANDING_CLI_CMD`] command-line tool
     Upgrade(upgrade::CliUpgrade),
-    /// Install the 'edgedb' command-line tool
+    /// Install the [`BRANDING_CLI_CMD`] command-line tool
     #[command(hide = true)]
     Install(install::CliInstall),
     /// Migrate files from `~/.edgedb` to the new directory layout

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -7,6 +7,7 @@ use anyhow::Context;
 use fs_err as fs;
 use tokio::time::sleep;
 
+use crate::branding::{BRANDING, BRANDING_CLOUD};
 use crate::cloud::client::{
     cloud_config_dir, cloud_config_file, CloudClient, CloudConfig, ErrorResponse,
 };
@@ -120,7 +121,7 @@ pub async fn _do_login(client: &mut CloudClient) -> anyhow::Result<()> {
 
                 let user: User = client.get("user").await?;
                 print::success(format!(
-                    "Successfully logged in to EdgeDB Cloud as {}.",
+                    "Successfully logged in to {BRANDING_CLOUD} as {}.",
                     user.name
                 ));
                 return Ok(());
@@ -212,7 +213,7 @@ pub fn logout(c: &options::Logout, options: &CloudOptions) -> anyhow::Result<()>
             removed = true;
             fs::remove_file(cloud_creds.join(item.file_name()))?;
             print::success(format!(
-                "You are now logged out from EdgeDB Cloud profile {:?}.",
+                "You are now logged out from {BRANDING_CLOUD} profile {:?}.",
                 profile
             ));
         }
@@ -241,14 +242,14 @@ pub fn logout(c: &options::Logout, options: &CloudOptions) -> anyhow::Result<()>
             if removed {
                 fs::remove_file(path).with_context(|| "failed to log out")?;
                 print::success(format!(
-                    "You are now logged out from EdgeDB Cloud for profile \"{}\".",
+                    "You are now logged out from {BRANDING_CLOUD} for profile \"{}\".",
                     client.profile.as_deref().unwrap_or("default")
                 ));
             }
             skipped = !removed;
         } else {
             print::warn(format!(
-                "Already logged out from EdgeDB Cloud for profile \"{}\".",
+                "Already logged out from {BRANDING_CLOUD} for profile \"{}\".",
                 client.profile.as_deref().unwrap_or("default")
             ));
         }

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -278,7 +278,7 @@ pub fn logout(c: &options::Logout, options: &CloudOptions) -> anyhow::Result<()>
 
 fn make_project_warning(profile: &str, projects: Vec<PathBuf>) -> String {
     format!(
-        "Cloud profile {:?} is still used by the following projects:\n    {}",
+        "{BRANDING_CLOUD} profile {:?} is still used by the following projects:\n    {}",
         profile,
         projects
             .iter()

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 use fs_err as fs;
 use tokio::time::sleep;
 
-use crate::branding::{BRANDING, BRANDING_CLOUD};
+use crate::branding::BRANDING_CLOUD;
 use crate::cloud::client::{
     cloud_config_dir, cloud_config_file, CloudClient, CloudConfig, ErrorResponse,
 };

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -12,6 +12,7 @@ use base64::Engine;
 use anyhow::Context;
 use reqwest::{header, StatusCode};
 
+use crate::branding::BRANDING_CLI_CMD;
 use crate::options::CloudOptions;
 use crate::platform::config_dir;
 
@@ -295,7 +296,7 @@ y4u6fdOVhgIhAJ4pJLfdoWQsHPUOcnVG5fBgdSnoCJhGQyuGyp+NDu1q
         if self.is_logged_in {
             Ok(())
         } else {
-            anyhow::bail!("Run `edgedb cloud login` first.")
+            anyhow::bail!("Run `{BRANDING_CLI_CMD} cloud login` first.")
         }
     }
 

--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -407,7 +407,7 @@ pub async fn destroy_cloud_instance(
 async fn get_instances(client: &CloudClient) -> anyhow::Result<Vec<CloudInstance>> {
     timeout(Duration::from_secs(30), client.get("instances/"))
         .await
-        .or_else(|_| anyhow::bail!("timed out with {BRANDING_CLOUD} API"))?
+        .or_else(|_| anyhow::bail!("{BRANDING_CLOUD} instances API timed out"))?
         .context(concatcp!(
             "failed to list instances in ",
             BRANDING_CLOUD,

--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -3,11 +3,13 @@ use std::fmt;
 use std::time::{Duration, Instant};
 
 use anyhow::Context;
+use const_format::concatcp;
 use edgedb_tokio::credentials::Credentials;
 use edgedb_tokio::Builder;
 use indicatif::ProgressBar;
 use tokio::time::{sleep, timeout};
 
+use crate::branding::BRANDING_CLOUD;
 use crate::cloud::client::{CloudClient, ErrorResponse};
 use crate::collect::Collector;
 use crate::options::CloudOptions;
@@ -354,7 +356,11 @@ pub async fn upgrade_cloud_instance(
 }
 
 pub fn prompt_cloud_login(client: &mut CloudClient) -> anyhow::Result<()> {
-    let mut q = question::Confirm::new("Not authenticated to EdgeDB Cloud yet, log in now?");
+    let mut q = question::Confirm::new(concatcp!(
+        "Not authenticated to ",
+        BRANDING_CLOUD,
+        " yet, log in now?"
+    ));
     if q.default(true).ask()? {
         crate::cloud::auth::do_login(client)?;
         client.reinit()?;
@@ -401,8 +407,12 @@ pub async fn destroy_cloud_instance(
 async fn get_instances(client: &CloudClient) -> anyhow::Result<Vec<CloudInstance>> {
     timeout(Duration::from_secs(30), client.get("instances/"))
         .await
-        .or_else(|_| anyhow::bail!("timed out with Cloud API"))?
-        .context("failed with Cloud API")
+        .or_else(|_| anyhow::bail!("timed out with {BRANDING_CLOUD} API"))?
+        .context(concatcp!(
+            "failed to list instances in ",
+            BRANDING_CLOUD,
+            " API"
+        ))
 }
 
 pub async fn list(

--- a/src/cloud/secret_keys.rs
+++ b/src/cloud/secret_keys.rs
@@ -141,7 +141,7 @@ pub async fn _do_create(c: &options::CreateSecretKey, client: &CloudClient) -> a
         if c.non_interactive {
             print!("{}", sk);
         } else {
-            echo!("\nYour new EdgeDB.Cloud secret key is printed below. \
+            echo!("\nYour new {BRANDING}.Cloud secret key is printed below. \
                  Be sure to copy and store it securely, as you will \
                  not be able to see it again.\n"
                 .green());

--- a/src/cloud/secret_keys.rs
+++ b/src/cloud/secret_keys.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use colorful::Colorful;
 
+use crate::branding::BRANDING_CLOUD;
 use crate::cloud::client::CloudClient;
 use crate::cloud::options;
 use crate::cloud::options::SecretKeyCommand;
@@ -141,10 +142,14 @@ pub async fn _do_create(c: &options::CreateSecretKey, client: &CloudClient) -> a
         if c.non_interactive {
             print!("{}", sk);
         } else {
-            echo!("\nYour new {BRANDING}.Cloud secret key is printed below. \
+            echo!(
+                "\nYour new ",
+                BRANDING_CLOUD,
+                " secret key is printed below. \
                  Be sure to copy and store it securely, as you will \
                  not be able to see it again.\n"
-                .green());
+                    .green()
+            );
             echo!(sk.emphasize());
         }
     }

--- a/src/cloud/versions.rs
+++ b/src/cloud/versions.rs
@@ -1,3 +1,4 @@
+use crate::branding::{BRANDING, BRANDING_CLOUD};
 use crate::cloud::client::CloudClient;
 use crate::cloud::ops::get_versions;
 use crate::portable::repository::{Channel, Query};
@@ -30,7 +31,7 @@ pub fn get_version(query: &Query, client: &CloudClient) -> anyhow::Result<ver::S
 
     if versions.is_empty() {
         anyhow::bail!(
-            "no EdgeDB versions matching '{}' supported by EdgeDB Cloud",
+            "no {BRANDING} versions matching '{}' supported by {BRANDING_CLOUD}",
             query.display(),
         );
     }

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 
 use clap::{CommandFactory, FromArgMatches};
+use const_format::concatcp;
 use once_cell::sync::Lazy;
 use prettytable::{Cell, Row, Table};
 use regex::Regex;
@@ -12,6 +13,7 @@ use edgedb_errors::Error;
 use edgedb_protocol::model::Duration;
 
 use crate::analyze;
+use crate::branding::BRANDING;
 use crate::commands::execute;
 use crate::commands::parser::{Backslash, BackslashCmd, Setting, StateParam};
 use crate::commands::Options;
@@ -29,8 +31,11 @@ pub enum ExecuteResult {
     Input(String),
 }
 
-const HELP: &str = r###"
-                            Edgedb REPL Commands
+const HELP: &str = concatcp!(
+    r###"
+                            "###,
+    BRANDING,
+    r###" REPL Commands
 
 Introspection
   Options:
@@ -72,7 +77,8 @@ Help
   \?, \h, \help             Show help on backslash commands
   \set                      Describe current settings
   \q, \quit, \exit, Ctrl+D  Quit REPL
-"###;
+"###
+);
 
 #[derive(Debug)]
 pub struct ParseError {

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -1,5 +1,6 @@
 use edgeql_parser::helpers::quote_name;
 
+use crate::branding::BRANDING;
 use crate::commands::parser::{CreateDatabase, DropDatabase, WipeDatabase};
 use crate::commands::{ExitCode, Options};
 use crate::connect::Connection;
@@ -14,7 +15,7 @@ pub async fn create(
     _: &Options,
 ) -> Result<(), anyhow::Error> {
     if cli.get_version().await?.specific().major >= 5 {
-        eprintln!("'edgedb database create' is deprecated in EdgeDB 5+. Please use 'edgedb branch create'");
+        eprintln!("'edgedb database create' is deprecated in {BRANDING} 5+. Please use 'edgedb branch create'");
     }
 
     let (status, _warnings) = cli
@@ -34,7 +35,7 @@ pub async fn drop(
 ) -> Result<(), anyhow::Error> {
     if cli.get_version().await?.specific().major >= 5 {
         eprintln!(
-            "'edgedb database drop' is deprecated in EdgeDB 5+. Please use 'edgedb branch drop'"
+            "'edgedb database drop' is deprecated in {BRANDING} 5+. Please use 'edgedb branch drop'"
         );
     }
 
@@ -65,14 +66,14 @@ pub async fn wipe(
 ) -> Result<(), anyhow::Error> {
     if cli.get_version().await?.specific().major >= 5 {
         eprintln!(
-            "'edgedb database wipe' is deprecated in EdgeDB 5+. Please use 'edgedb branch wipe'"
+            "'edgedb database wipe' is deprecated in {BRANDING} 5+. Please use 'edgedb branch wipe'"
         );
     }
 
     if cli.get_version().await?.specific() < "3.0-alpha.2".parse().unwrap() {
         return Err(anyhow::anyhow!(
             "The `database wipe` command is only \
-                            supported in EdgeDB >= 3.0"
+                            supported in {BRANDING} >= 3.0"
         ))
         .hint("Use `edgedb database drop`, `edgedb database create`")?;
     }

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -15,7 +15,7 @@ pub async fn create(
     _: &Options,
 ) -> Result<(), anyhow::Error> {
     if cli.get_version().await?.specific().major >= 5 {
-        eprintln!("'edgedb database create' is deprecated in {BRANDING} 5+. Please use 'edgedb branch create'");
+        eprintln!("'database create' is deprecated in {BRANDING} 5+. Please use 'branch create'");
     }
 
     let (status, _warnings) = cli
@@ -34,9 +34,7 @@ pub async fn drop(
     _: &Options,
 ) -> Result<(), anyhow::Error> {
     if cli.get_version().await?.specific().major >= 5 {
-        eprintln!(
-            "'edgedb database drop' is deprecated in {BRANDING} 5+. Please use 'edgedb branch drop'"
-        );
+        eprintln!("'database drop' is deprecated in {BRANDING} 5+. Please use 'branch drop'");
     }
 
     if !options.non_interactive {
@@ -65,9 +63,7 @@ pub async fn wipe(
     _: &Options,
 ) -> Result<(), anyhow::Error> {
     if cli.get_version().await?.specific().major >= 5 {
-        eprintln!(
-            "'edgedb database wipe' is deprecated in {BRANDING} 5+. Please use 'edgedb branch wipe'"
-        );
+        eprintln!("'database wipe' is deprecated in {BRANDING} 5+. Please use 'branch wipe'");
     }
 
     if cli.get_version().await?.specific() < "3.0-alpha.2".parse().unwrap() {
@@ -75,7 +71,7 @@ pub async fn wipe(
             "The `database wipe` command is only \
                             supported in {BRANDING} >= 3.0"
         ))
-        .hint("Use `edgedb database drop`, `edgedb database create`")?;
+        .hint("Use `database drop`, `database create`")?;
     }
     if !options.non_interactive {
         let q = question::Confirm::new_dangerous(format!(

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -1,4 +1,5 @@
 use crate::connect::Connection;
+use const_format::concatcp;
 use edgedb_tokio::server_params::{PostgresAddress, PostgresDsn};
 
 use crate::analyze;
@@ -76,7 +77,11 @@ pub async fn common(
                     Some(addr) => {
                         println!("{}", addr.0);
                     }
-                    None => print::error("pgaddr requires {BRANDING} to run in DEV mode"),
+                    None => print::error(concatcp!(
+                        "pgaddr requires ",
+                        BRANDING,
+                        " to run in DEV mode"
+                    )),
                 }
             }
         },

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -3,6 +3,7 @@ use const_format::concatcp;
 use edgedb_tokio::server_params::{PostgresAddress, PostgresDsn};
 
 use crate::analyze;
+use crate::branding::BRANDING;
 use crate::commands::parser::{Common, DatabaseCmd, DescribeCmd, ListCmd};
 use crate::commands::{self, branching, CommandResult, Options};
 use crate::migrations;

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -76,7 +76,7 @@ pub async fn common(
                     Some(addr) => {
                         println!("{}", addr.0);
                     }
-                    None => print::error("pgaddr requires EdgeDB to run in DEV mode"),
+                    None => print::error("pgaddr requires {BRANDING} to run in DEV mode"),
                 }
             }
         },

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -2,6 +2,7 @@ use std::path::{PathBuf, MAIN_SEPARATOR};
 
 use prettytable::{Cell, Row, Table};
 
+use crate::branding::BRANDING;
 use crate::options::{Info, Options};
 use crate::platform;
 use crate::table;
@@ -97,7 +98,7 @@ pub fn info(_options: &Options, info: &Info) -> Result<(), anyhow::Error> {
 
     table.set_format(*table::FORMAT);
 
-    println!("EdgeDB uses the following local paths:");
+    println!("{BRANDING} uses the following local paths:");
     table.printstd();
 
     Ok(())

--- a/src/commands/list_branches.rs
+++ b/src/commands/list_branches.rs
@@ -1,3 +1,4 @@
+use crate::branding::BRANDING;
 use crate::commands::list_databases::get_databases;
 use crate::commands::{list, list_databases, Options};
 use crate::connect::Connection;
@@ -12,7 +13,7 @@ pub async fn list_branches(cli: &mut Connection, options: &Options) -> Result<()
 
     if version.specific().major <= 4 {
         print::warn(format!(
-            "Branches are not supported in EdgeDB {}, printing list of databases instead",
+            "Branches are not supported in {BRANDING} {}, printing list of databases instead",
             version
         ));
         return list_databases(cli, options).await;

--- a/src/commands/list_databases.rs
+++ b/src/commands/list_databases.rs
@@ -1,3 +1,4 @@
+use crate::branding::BRANDING;
 use crate::commands::list;
 use crate::commands::list_branches::list_branches0;
 use crate::commands::Options;
@@ -19,7 +20,7 @@ pub async fn list_databases(cli: &mut Connection, options: &Options) -> Result<(
 
     if version.specific().major >= 5 {
         print::warn(format!(
-            "Databases are not supported in EdgeDB {}, printing list of branches instead",
+            "Databases are not supported in {BRANDING} {}, printing list of branches instead",
             version
         ));
         return list_branches0(cli, options).await;

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -22,7 +22,7 @@ pub enum Common {
 
     /// Migration management subcommands
     Migration(Box<Migration>),
-    /// Apply migration (alias for `edgedb migration apply`)
+    /// Apply migration (alias for [`BRANDING_CLI_CMD`] migration apply)
     Migrate(Migrate),
 
     /// Database commands
@@ -141,9 +141,8 @@ pub enum BranchingCmd {
     Create(crate::branch::option::Create),
     /// Delete a branch along with its data
     Drop(crate::branch::option::Drop),
-    /// Delete a branches data and reset its schema while
-    /// preserving the branch itself (its cfg::DatabaseConfig)
-    /// and existing migration scripts
+    /// Delete a branch's data and reset its schema while preserving the branch
+    /// itself (its `cfg::DatabaseConfig`) and existing migration scripts
     Wipe(crate::branch::option::Wipe),
     /// List all branches.
     List(crate::branch::option::List),
@@ -170,9 +169,9 @@ pub enum DatabaseCmd {
     Create(CreateDatabase),
     /// Delete a database along with its data
     Drop(DropDatabase),
-    /// Delete a database's data and reset its schema while
-    /// preserving the database itself (its cfg::DatabaseConfig)
-    /// and existing migration scripts
+    /// Delete a database's data and reset its schema while preserving the
+    /// database itself (its `cfg::DatabaseConfig`) and existing migration
+    /// scripts
     Wipe(WipeDatabase),
 }
 

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -105,15 +105,15 @@ pub enum ListCmd {
     Aliases(ListAliases),
     /// Display list of casts defined in the schema
     Casts(ListCasts),
-    /// On EdgeDB < 5.x: Display list of databases for an EdgeDB instance
+    /// On EdgeDB < 5.x: Display list of databases for an instance
     Databases,
-    /// On EdgeDB >= 5.x: Display list of branches for an EdgeDB instance
+    /// On EdgeDB/Gel >= 5.x: Display list of branches for an instance
     Branches,
     /// Display list of indexes defined in the schema
     Indexes(ListIndexes),
     /// Display list of modules defined in the schema
     Modules(ListModules),
-    /// Display list of roles for an EdgeDB instance
+    /// Display list of roles for an instance
     Roles(ListRoles),
     /// Display list of scalar types defined in the schema
     Scalars(ListTypes),

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -2,9 +2,12 @@ use std::path::PathBuf;
 
 use clap::ValueHint;
 
+use crate::branding::BRANDING_CLI_CMD;
 use crate::migrations::options::{Migrate, Migration};
 use crate::options::ConnectionOptions;
 use crate::repl::{self, VectorLimit};
+
+use const_format::concatcp;
 
 use edgedb_cli_derive::EdbSettings;
 
@@ -417,11 +420,11 @@ pub struct Dump {
 }
 
 #[derive(clap::Args, Clone, Debug)]
-#[command(override_usage(
-    "edgedb restore [OPTIONS] <path>\n    \
-     Pre 5.0: edgedb restore -d <database-name> <path>\n    \
-     >=5.0:   edgedb restore -b <branch-name> <path>"
-))]
+#[command(override_usage(concatcp!(
+    BRANDING_CLI_CMD, " restore [OPTIONS] <path>\n    \
+     Pre 5.0: ", BRANDING_CLI_CMD, " restore -d <database-name> <path>\n    \
+     >=5.0:   ", BRANDING_CLI_CMD, " restore -b <branch-name> <path>"
+)))]
 pub struct Restore {
     #[command(flatten)]
     pub conn: Option<ConnectionOptions>,

--- a/src/commands/psql.rs
+++ b/src/commands/psql.rs
@@ -51,7 +51,7 @@ pub async fn psql<'x>(cli: &mut Connection, _options: &Options) -> Result<(), an
                 cmd.arg(&addr.0);
             }
             None => {
-                print::error("EdgeDB must be run in DEV mode to use psql.");
+                print::error("{BRANDING} must be run in DEV mode to use psql.");
                 return Ok(());
             }
         },

--- a/src/commands/psql.rs
+++ b/src/commands/psql.rs
@@ -2,8 +2,10 @@ use std::env;
 use std::ffi::OsString;
 use std::process::Command;
 
+use crate::branding::BRANDING;
 use crate::connect::Connection;
 use anyhow::Context;
+use const_format::concatcp;
 use edgedb_tokio::server_params::{PostgresAddress, PostgresDsn};
 
 use crate::commands::Options;
@@ -51,7 +53,7 @@ pub async fn psql<'x>(cli: &mut Connection, _options: &Options) -> Result<(), an
                 cmd.arg(&addr.0);
             }
             None => {
-                print::error("{BRANDING} must be run in DEV mode to use psql.");
+                print::error(concatcp!(BRANDING, " must be run in DEV mode to use psql."));
                 return Ok(());
             }
         },

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -19,6 +19,7 @@ use edgedb_errors::{Error, ErrorKind, UserError};
 use edgeql_parser::helpers::quote_name;
 use edgeql_parser::preparser::is_empty;
 
+use crate::branding::BRANDING;
 use crate::commands::list_databases;
 use crate::commands::parser::Restore as RestoreCmd;
 use crate::commands::Options;
@@ -187,7 +188,7 @@ async fn restore_db<'x>(
         .with_context(file_ctx)?;
     if &buf[..17] != b"\xFF\xD8\x00\x00\xD8EDGEDB\x00DUMP\x00" {
         Err(anyhow::anyhow!(
-            "Incorrect header; file is not an EdgeDB dump"
+            "Incorrect header; file is not a dump from {BRANDING}"
         ))
         .with_context(file_ctx)?
     }

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -3,6 +3,7 @@ use std::io::{stdout, Write};
 use anyhow::Context;
 use const_format::concatcp;
 
+use crate::branding::BRANDING;
 use crate::cloud;
 use crate::commands::ExitCode;
 use crate::options::{Options, UI};

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -119,7 +119,7 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
                         " server."
                     ));
                     print::echo!(
-                        "  If you have {BRANDING} 2.0 and above, try running the \
+                        "  Try running the \
                         server with `--admin-ui=enabled`."
                     );
                     return Err(ExitCode::new(2).into());

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -1,6 +1,7 @@
 use std::io::{stdout, Write};
 
 use anyhow::Context;
+use const_format::concatcp;
 
 use crate::cloud;
 use crate::commands::ExitCode;
@@ -111,7 +112,11 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
             match open_url(&url).map(|r| r.status()) {
                 Ok(reqwest::StatusCode::OK) => {}
                 Ok(reqwest::StatusCode::NOT_FOUND) => {
-                    print::error("Web UI not served correctly by specified {BRANDING} server.");
+                    print::error(concatcp!(
+                        "Web UI not served correctly by specified ",
+                        BRANDING,
+                        " server."
+                    ));
                     print::echo!(
                         "  If you have {BRANDING} 2.0 and above, try running the \
                         server with `--admin-ui=enabled`."

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -37,7 +37,7 @@ pub fn show_ui(cmd: &UI, opts: &Options) -> anyhow::Result<()> {
             Err(e) => {
                 print::error(format!("Cannot launch browser: {:#}", e));
                 print::prompt(
-                    "Please paste the URL below into your browser to launch the EdgeDB UI:",
+                    "Please paste the URL below into your browser to launch the {BRANDING} UI:",
                 );
                 println!("{}", url);
                 Err(ExitCode::new(1).into())
@@ -111,9 +111,9 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
             match open_url(&url).map(|r| r.status()) {
                 Ok(reqwest::StatusCode::OK) => {}
                 Ok(reqwest::StatusCode::NOT_FOUND) => {
-                    print::error("Web UI not served correctly by specified EdgeDB server.");
+                    print::error("Web UI not served correctly by specified {BRANDING} server.");
                     print::echo!(
-                        "  If you have EdgeDB 2.0 and above, try running the \
+                        "  If you have {BRANDING} 2.0 and above, try running the \
                         server with `--admin-ui=enabled`."
                     );
                     return Err(ExitCode::new(2).into());
@@ -121,7 +121,7 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
                 Ok(status) => {
                     log::info!("GET {} returned status code {}", url, status);
                     print::error(
-                        "Web UI not served correctly by specified EdgeDB server. \
+                        "Web UI not served correctly by specified {BRANDING} server. \
                         Try `edgedb instance logs -I <instance_name>` to see details.",
                     );
                     return Err(ExitCode::new(3).into());

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -28,6 +28,7 @@ use edgedb_tokio::raw::{self, PoolState, Response};
 use edgedb_tokio::server_params::ServerParam;
 use edgedb_tokio::Config;
 
+use crate::branding::{BRANDING, BRANDING_CLOUD};
 use crate::hint::ArcError;
 use crate::portable::ver;
 
@@ -181,11 +182,11 @@ impl Connector {
             Some(edgedb_tokio::InstanceName::Cloud {
                 org_slug: org,
                 name,
-            }) => format!("EdgeDB Cloud instance '{}/{}'", org, name),
+            }) => format!("{BRANDING_CLOUD} instance '{}/{}'", org, name),
             Some(edgedb_tokio::InstanceName::Local(name)) => {
-                format!("EdgeDB instance '{}' at {}", name, cfg.display_addr())
+                format!("{BRANDING} instance '{}' at {}", name, cfg.display_addr())
             }
-            _ => format!("EdgeDB instance at {}", cfg.display_addr()),
+            _ => format!("{BRANDING} instance at {}", cfg.display_addr()),
         };
         format!("Connecting to {}...", desc)
     }

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -5,11 +5,13 @@ use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term::emit;
 use colorful::core::color_string::CString;
 use colorful::Colorful;
+use const_format::concatcp;
 use edgedb_protocol::annotations::Warning;
 use termcolor::{ColorChoice, StandardStream};
 
 use edgedb_errors::{Error, InternalServerError};
 
+use crate::branding::BRANDING_CLI;
 use crate::print;
 
 pub fn print_query_error(
@@ -110,7 +112,7 @@ pub fn print_query_warning(
 }
 
 fn print_query_warning_plain(warning: &Warning) {
-    let marker = "edgedb warning:";
+    let marker = concatcp!(BRANDING_CLI, " warning:");
     let marker = if print::use_color() {
         marker.bold().yellow()
     } else {

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -11,7 +11,7 @@ use termcolor::{ColorChoice, StandardStream};
 
 use edgedb_errors::{Error, InternalServerError};
 
-use crate::branding::BRANDING_CLI;
+use crate::branding::BRANDING_CLI_CMD;
 use crate::print;
 
 pub fn print_query_error(
@@ -112,7 +112,7 @@ pub fn print_query_warning(
 }
 
 fn print_query_warning_plain(warning: &Warning) {
-    let marker = concatcp!(BRANDING_CLI, " warning:");
+    let marker = concatcp!(BRANDING_CLI_CMD, " warning:");
     let marker = if print::use_color() {
         marker.bold().yellow()
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use crate::options::{Options, UsageError};
 mod analyze;
 mod async_util;
 mod branch;
+mod branding;
 mod bug;
 mod classify;
 mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::env;
 use std::path::Path;
 use std::process::exit;
 
+use crate::branding::BRANDING;
 use crate::options::{Options, UsageError};
 
 mod analyze;
@@ -87,7 +88,7 @@ fn main() {
                     );
                 } else if item.is::<bug::Bug>() {
                     eprintln!(
-                        "  Hint: This is most likely a bug in EdgeDB \
+                        "  Hint: This is most likely a bug in {BRANDING} \
                         or command-line tools. Please consider opening an \
                         issue at \
                         https://github.com/edgedb/edgedb-cli/issues/new\

--- a/src/migrations/context.rs
+++ b/src/migrations/context.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::migrations::options::MigrationConfig;
 use crate::portable::config;
 
-use edgedb_tokio::get_project_dir;
+use edgedb_tokio::get_project_path;
 
 pub struct Context {
     pub schema_dir: PathBuf,
@@ -18,8 +18,7 @@ impl Context {
     ) -> anyhow::Result<Context> {
         let schema_dir = if let Some(schema_dir) = &cfg.schema_dir {
             schema_dir.clone()
-        } else if let Some(cfg_dir) = get_project_dir(None, true).await? {
-            let config_path = cfg_dir.join("edgedb.toml");
+        } else if let Some(config_path) = get_project_path(None, true).await? {
             let config = config::read(&config_path)?;
             config.project.schema_dir
         } else {
@@ -32,8 +31,7 @@ impl Context {
 
         Ok(Context { schema_dir, quiet })
     }
-    pub fn for_watch(project_dir: &Path) -> anyhow::Result<Context> {
-        let config_path = project_dir.join("edgedb.toml");
+    pub fn for_watch(config_path: &Path) -> anyhow::Result<Context> {
         let config = config::read(&config_path)?;
         Context::for_project(&config)
     }

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -21,6 +21,7 @@ use tokio::io::{self, AsyncWriteExt};
 use tokio::task::spawn_blocking as unblock;
 
 use crate::async_try;
+use crate::branding::BRANDING;
 use crate::bug;
 use crate::commands::{ExitCode, Options};
 use crate::connect::Connection;
@@ -139,7 +140,7 @@ struct SplitMigration;
 
 #[derive(Debug, thiserror::Error)]
 #[error(
-    "EdgeDB could not resolve migration automatically. \
+    "{BRANDING} could not resolve migration automatically. \
          Please run `edgedb migration create` in interactive mode."
 )]
 struct CantResolve;
@@ -466,7 +467,7 @@ async fn non_interactive_populate(
                     execute(cli, &statement.text, None).await?;
                 }
             } else {
-                eprintln!("EdgeDB intended to apply the following migration:");
+                eprintln!("{BRANDING} intended to apply the following migration:");
                 for statement in proposal.statements {
                     for line in statement.text.lines() {
                         eprintln!("    {}", line);
@@ -477,14 +478,14 @@ async fn non_interactive_populate(
                     proposal.confidence, SAFE_CONFIDENCE
                 );
                 anyhow::bail!(
-                    "EdgeDB is unable to make a decision. Please run in \
+                    "{BRANDING} is unable to make a decision. Please run in \
                     interactive mode to confirm changes, \
                     or use `--allow-unsafe`"
                 );
             }
         } else {
             anyhow::bail!(
-                "EdgeDB could not resolve \
+                "{BRANDING} could not resolve \
                 migration automatically. Please run in \
                 interactive mode to confirm changes, \
                 or use `--allow-unsafe`"
@@ -698,13 +699,13 @@ impl InteractiveMigration<'_> {
         // TODO(tailhook) allow rollback
         let msg = match debug_info {
             Some(e) => format!(
-                "EdgeDB could not resolve migration with the provided answers. \
+                "{BRANDING} could not resolve migration with the provided answers. \
                 Please retry with different answers.\n\n \
                 Debug info:\n\n {}",
                 e
             ),
             None => String::from(
-                "EdgeDB could not resolve migration with the \
+                "{BRANDING} could not resolve migration with the \
             provided answers. Please retry with different answers.",
             ),
         };

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -21,7 +21,7 @@ use tokio::io::{self, AsyncWriteExt};
 use tokio::task::spawn_blocking as unblock;
 
 use crate::async_try;
-use crate::branding::BRANDING;
+use crate::branding::{BRANDING, BRANDING_CLI_CMD};
 use crate::bug;
 use crate::commands::{ExitCode, Options};
 use crate::connect::Connection;
@@ -141,7 +141,7 @@ struct SplitMigration;
 #[derive(Debug, thiserror::Error)]
 #[error(
     "{BRANDING} could not resolve migration automatically. \
-         Please run `edgedb migration create` in interactive mode."
+         Please run `{BRANDING_CLI_CMD} migration create` in interactive mode."
 )]
 struct CantResolve;
 
@@ -878,7 +878,7 @@ pub async fn normal_migration(
             if db_migration != ensure_parent {
                 anyhow::bail!("Database must be updated to the last migration \
                     on the filesystem for `migration create`. Run:\n  \
-                    edgedb migrate");
+                    {BRANDING_CLI_CMD} migrate");
             }
 
             if create.non_interactive {

--- a/src/migrations/dev_mode.rs
+++ b/src/migrations/dev_mode.rs
@@ -7,6 +7,7 @@ use indicatif::ProgressBar;
 use once_cell::sync::Lazy;
 
 use crate::async_try;
+use crate::branding::BRANDING;
 use crate::bug;
 use crate::commands::Options;
 use crate::migrations::context::Context;
@@ -59,7 +60,7 @@ pub async fn check_client(cli: &mut Connection) -> anyhow::Result<bool> {
 pub async fn migrate(cli: &mut Connection, ctx: &Context, bar: &ProgressBar) -> anyhow::Result<()> {
     if !check_client(cli).await? {
         anyhow::bail!(
-            "Dev mode is not supported on EdgeDB {}. Please upgrade.",
+            "Dev mode is not supported on {BRANDING} {}. Please upgrade.",
             cli.get_version().await?
         );
     }

--- a/src/migrations/options.rs
+++ b/src/migrations/options.rs
@@ -52,7 +52,7 @@ pub enum MigrationCmd {
 pub struct MigrationConfig {
     /// Project schema directory.  The default is `dbschema/`,
     /// which can be changed by setting `project.schema-dir`
-    /// in `edgedb.toml`.
+    /// in `{gel,edgedb}.toml`.
     #[arg(long, value_hint=ValueHint::DirPath)]
     pub schema_dir: Option<PathBuf>,
 }

--- a/src/migrations/options.rs
+++ b/src/migrations/options.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use clap::ValueHint;
 
+#[cfg(doc)]
+use crate::branding::BRANDING;
 use crate::options::ConnectionOptions;
 use crate::portable::repository::Channel;
 use crate::portable::ver;
@@ -23,7 +25,7 @@ pub struct Migration {
 pub enum MigrationCmd {
     /// Apply migration from latest migration script.
     Apply(Box<Migrate>),
-    /// Create migration script inside /migrations.
+    /// Create migration script inside `/migrations`.
     Create(CreateMigration),
     /// Show current migration status.
     Status(ShowStatus),
@@ -36,13 +38,14 @@ pub enum MigrationCmd {
     /// in Windows). Usually should be used for migrations that have
     /// not been applied yet.
     Edit(MigrationEdit),
-    /// Check if current schema is compatible with new EdgeDB version.
+    /// Check if current schema is compatible with new [`BRANDING`] version.
     UpgradeCheck(UpgradeCheck),
     /// Extract migration history from the database and write it to
-    /// <schema-dir>/migrations. Useful when a direct DDL command has
-    /// been used to change the schema and now `edgedb migrate` will not
-    /// comply because the database migration history is ahead of the
-    /// migration history inside <schema-dir>/migrations.
+    /// `<schema-dir>/migrations`.
+    ///
+    /// Useful when a direct DDL command has been used to change the schema and
+    /// now [`BRANDING_CLI`] fails because the database migration history is
+    /// ahead of the migration history inside `<schema-dir>/migrations`.
     Extract(ExtractMigrations),
     /// Upgrades the format of migration files.
     UpgradeFormat(MigrationUpgradeFormat),
@@ -67,7 +70,7 @@ pub struct CreateMigration {
     #[arg(long)]
     pub squash: bool,
     /// Do not ask questions. By default works only if "safe" changes are
-    /// to be done (those for which EdgeDB has a high degree of confidence).
+    /// to be done (those for which [`BRANDING`] has a high degree of confidence).
     /// This safe default can be overridden with `--allow-unsafe`.
     #[arg(long)]
     pub non_interactive: bool,

--- a/src/migrations/squash.rs
+++ b/src/migrations/squash.rs
@@ -6,6 +6,7 @@ use anyhow::Context as _;
 use tokio::fs;
 
 use crate::async_try;
+use crate::branding::BRANDING_CLI;
 use crate::bug;
 use crate::commands::{ExitCode, Options};
 use crate::connect::Connection;
@@ -135,7 +136,9 @@ async fn confirm_squashing(db_rev: &str) -> anyhow::Result<()> {
                 Hint: To see the current revision for a specific instance, run:"
     );
     echo!(
-        "       edgedb -I <name> migration log --from-db --newest-first --limit 1".command_hint()
+        "       ",
+        BRANDING_CLI,
+        " -I <name> migration log --from-db --newest-first --limit 1".command_hint()
     );
     echo!(
         "  3. Merge version control branches that contain schema changes \
@@ -175,7 +178,7 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
         echo!("    git add dbschema".command_hint());
         echo!("");
         echo!("The normal migration process will update your migration history:");
-        echo!("    edgedb migrate".command_hint());
+        echo!("    ", BRANDING_CLI, " migrate".command_hint());
     } else {
         echo!("Squash is complete.");
         echo!("");
@@ -186,8 +189,8 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
         echo!("    git add dbschema".command_hint());
         echo!("");
         echo!("You can now wipe your instances and apply the new schema:");
-        echo!("    edgedb database wipe".command_hint());
-        echo!("    edgedb migrate".command_hint());
+        echo!("    ", BRANDING_CLI, " database wipe".command_hint());
+        echo!("    ", BRANDING_CLI, " migrate".command_hint());
     }
     Ok(())
 }

--- a/src/migrations/squash.rs
+++ b/src/migrations/squash.rs
@@ -6,7 +6,7 @@ use anyhow::Context as _;
 use tokio::fs;
 
 use crate::async_try;
-use crate::branding::BRANDING_CLI;
+use crate::branding::BRANDING_CLI_CMD;
 use crate::bug;
 use crate::commands::{ExitCode, Options};
 use crate::connect::Connection;
@@ -137,7 +137,7 @@ async fn confirm_squashing(db_rev: &str) -> anyhow::Result<()> {
     );
     echo!(
         "       ",
-        BRANDING_CLI,
+        BRANDING_CLI_CMD,
         " -I <name> migration log --from-db --newest-first --limit 1".command_hint()
     );
     echo!(
@@ -178,7 +178,7 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
         echo!("    git add dbschema".command_hint());
         echo!("");
         echo!("The normal migration process will update your migration history:");
-        echo!("    ", BRANDING_CLI, " migrate".command_hint());
+        echo!("    ", BRANDING_CLI_CMD, " migrate".command_hint());
     } else {
         echo!("Squash is complete.");
         echo!("");
@@ -189,8 +189,8 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
         echo!("    git add dbschema".command_hint());
         echo!("");
         echo!("You can now wipe your instances and apply the new schema:");
-        echo!("    ", BRANDING_CLI, " database wipe".command_hint());
-        echo!("    ", BRANDING_CLI, " migrate".command_hint());
+        echo!("    ", BRANDING_CLI_CMD, " database wipe".command_hint());
+        echo!("    ", BRANDING_CLI_CMD, " migrate".command_hint());
     }
     Ok(())
 }

--- a/src/migrations/squash.rs
+++ b/src/migrations/squash.rs
@@ -178,7 +178,7 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
         echo!("    git add dbschema".command_hint());
         echo!("");
         echo!("The normal migration process will update your migration history:");
-        echo!("    ", BRANDING_CLI_CMD, " migrate".command_hint());
+        echo!("    ", BRANDING_CLI_CMD, "migrate".command_hint());
     } else {
         echo!("Squash is complete.");
         echo!("");
@@ -189,8 +189,8 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
         echo!("    git add dbschema".command_hint());
         echo!("");
         echo!("You can now wipe your instances and apply the new schema:");
-        echo!("    ", BRANDING_CLI_CMD, " database wipe".command_hint());
-        echo!("    ", BRANDING_CLI_CMD, " migrate".command_hint());
+        echo!("    ", BRANDING_CLI_CMD, "database wipe".command_hint());
+        echo!("    ", BRANDING_CLI_CMD, "migrate".command_hint());
     }
     Ok(())
 }

--- a/src/migrations/status.rs
+++ b/src/migrations/status.rs
@@ -2,6 +2,7 @@ use colorful::Colorful;
 use indexmap::IndexMap;
 
 use crate::async_try;
+use crate::branding::BRANDING_CLI_CMD;
 use crate::commands::{ExitCode, Options};
 use crate::connect::Connection;
 use crate::migrations::context::Context;
@@ -35,7 +36,7 @@ async fn ensure_diff_is_empty(cli: &mut Connection, ctx: &Context) -> Result<(),
                 eprintln!("... and {} more changes", changes - 3);
             }
             print::error("Some migrations are missing.");
-            eprintln!("  Use `edgedb migration create`.");
+            eprintln!("  Use `{BRANDING_CLI_CMD} migration create`.");
         }
         return Err(ExitCode::new(2).into());
     }
@@ -112,7 +113,7 @@ pub async fn migrations_applied(
                     have been found in the filesystem.",
                     migrations.len(),
                 ));
-                eprintln!("  Run `edgedb migrate` to apply.");
+                eprintln!("  Run `{BRANDING_CLI_CMD} migrate` to apply.");
             }
         }
         return Ok(None);

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -69,6 +69,10 @@ pub fn upgrade_check(_options: &Options, options: &UpgradeCheck) -> anyhow::Resu
 
 #[cfg(unix)]
 pub fn upgrade_check(_options: &Options, options: &UpgradeCheck) -> anyhow::Result<()> {
+    use const_format::concatcp;
+
+    use crate::branding::BRANDING;
+
     let (version, _) = Query::from_options(
         repository::QueryOptions {
             nightly: options.to_nightly,
@@ -82,7 +86,7 @@ pub fn upgrade_check(_options: &Options, options: &UpgradeCheck) -> anyhow::Resu
 
     let pkg = repository::get_server_package(&version)?
         .with_context(|| format!("no package matching {} found", version.display()))?;
-    let info = install::package(&pkg).context("error installing {BRANDING}")?;
+    let info = install::package(&pkg).context(concatcp!("error installing ", BRANDING))?;
 
     // This is run from windows to do the upgrade check
     if let Some(status_path) = &options.run_server_with_status {
@@ -114,7 +118,11 @@ pub fn to_version(_: &PackageInfo, _: &Config) -> anyhow::Result<()> {
 
 #[cfg(unix)]
 pub fn to_version(pkg: &PackageInfo, config: &Config) -> anyhow::Result<()> {
-    let info = install::package(pkg).context("error installing {BRANDING}")?;
+    use const_format::concatcp;
+
+    use crate::branding::BRANDING;
+
+    let info = install::package(pkg).context(concatcp!("error installing ", BRANDING))?;
     let ctx = Context::for_project(config)?;
     spawn_and_check(&info, ctx, false)
 }

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -9,7 +9,7 @@ use tokio::fs;
 use tokio::sync::watch;
 
 use crate::async_try;
-use crate::branding::BRANDING_CLI;
+use crate::branding::BRANDING_CLI_CMD;
 use crate::commands::{ExitCode, Options};
 use crate::connect::Connection;
 use crate::migrations::context::Context;
@@ -209,7 +209,7 @@ async fn do_check(ctx: &Context, status_file: &Path, watch: bool) -> anyhow::Res
                 echo!("For faster feedback loop use:");
                 echo!(
                     "    ",
-                    BRANDING_CLI,
+                    BRANDING_CLI_CMD,
                     " migration upgrade-check --watch".command_hint()
                 );
                 return Err(ExitCode::new(3))?;
@@ -289,7 +289,7 @@ fn print_apply_migration_error() {
     echo!("Please squash all migrations to fix the issue:");
     echo!(
         "    ",
-        BRANDING_CLI,
+        BRANDING_CLI_CMD,
         " migration create --squash".command_hint()
     );
 }

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -9,6 +9,7 @@ use tokio::fs;
 use tokio::sync::watch;
 
 use crate::async_try;
+use crate::branding::BRANDING_CLI;
 use crate::commands::{ExitCode, Options};
 use crate::connect::Connection;
 use crate::migrations::context::Context;
@@ -81,7 +82,7 @@ pub fn upgrade_check(_options: &Options, options: &UpgradeCheck) -> anyhow::Resu
 
     let pkg = repository::get_server_package(&version)?
         .with_context(|| format!("no package matching {} found", version.display()))?;
-    let info = install::package(&pkg).context("error installing EdgeDB")?;
+    let info = install::package(&pkg).context("error installing {BRANDING}")?;
 
     // This is run from windows to do the upgrade check
     if let Some(status_path) = &options.run_server_with_status {
@@ -113,7 +114,7 @@ pub fn to_version(_: &PackageInfo, _: &Config) -> anyhow::Result<()> {
 
 #[cfg(unix)]
 pub fn to_version(pkg: &PackageInfo, config: &Config) -> anyhow::Result<()> {
-    let info = install::package(pkg).context("error installing EdgeDB")?;
+    let info = install::package(pkg).context("error installing {BRANDING}")?;
     let ctx = Context::for_project(config)?;
     spawn_and_check(&info, ctx, false)
 }
@@ -206,7 +207,11 @@ async fn do_check(ctx: &Context, status_file: &Path, watch: bool) -> anyhow::Res
             Okay => {}
             SchemaIssue => {
                 echo!("For faster feedback loop use:");
-                echo!("    edgedb migration upgrade-check --watch".command_hint());
+                echo!(
+                    "    ",
+                    BRANDING_CLI,
+                    " migration upgrade-check --watch".command_hint()
+                );
                 return Err(ExitCode::new(3))?;
             }
             MigrationsIssue => {
@@ -282,7 +287,11 @@ fn print_apply_migration_error() {
          but some of the migrations are outdated.",
     );
     echo!("Please squash all migrations to fix the issue:");
-    echo!("    edgedb migration create --squash".command_hint());
+    echo!(
+        "    ",
+        BRANDING_CLI,
+        " migration create --squash".command_hint()
+    );
 }
 
 pub async fn watch_loop(

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -190,7 +190,7 @@ async fn do_check(ctx: &Context, status_file: &Path, watch: bool) -> anyhow::Res
             .ok();
             tx.send(()).unwrap();
         })?;
-        // TODO(tailhook) do we have to monitor `edgedb.toml` for the schema
+        // TODO(tailhook) do we have to monitor `{gel,edgedb}.toml` for the schema
         // dir change
         watch.watch(&ctx.schema_dir, RecursiveMode::Recursive)?;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -19,7 +19,7 @@ use crate::cli::options::CliCommand;
 
 use crate::branch::option::BranchCommand;
 use crate::branding::CONFIG_FILE_DISPLAY_NAME;
-use crate::branding::{BRANDING, BRANDING_CLI};
+use crate::branding::{BRANDING, BRANDING_CLI_CMD};
 use crate::cloud::options::CloudCommand;
 use crate::commands::parser::Common;
 use crate::commands::ExitCode;
@@ -40,14 +40,14 @@ const MIN_TERM_WIDTH: usize = 50;
 
 const CONN_OPTIONS_GROUP: &str = concatcp!(
     " Connection Options (",
-    BRANDING_CLI,
+    BRANDING_CLI_CMD,
     " --help-connect to see full list)"
 );
 const CLOUD_OPTIONS_GROUP: &str = "Cloud Connection Options";
 const CONNECTION_ARG_HINT: &str = concatcp!(
     "\
     Run `",
-    BRANDING_CLI,
+    BRANDING_CLI_CMD,
     " project init` or use any of `-H`, `-P`, `-I` arguments \
     to specify connection parameters. See `--help` for details"
 );
@@ -691,7 +691,7 @@ impl Options {
         //
         // to enable connection and/or cloud options for themselves
         // and their subcommands.
-        let tmp = clap::Command::new(BRANDING_CLI);
+        let tmp = clap::Command::new(BRANDING_CLI_CMD);
         let tmp = <RawOptions as clap::Args>::augment_args(tmp);
         let mut global_args: Vec<_> = tmp
             .get_groups()
@@ -708,7 +708,7 @@ impl Options {
             }
         });
 
-        let app = clap::Command::new(BRANDING_CLI)
+        let app = clap::Command::new(BRANDING_CLI_CMD)
             .term_width(term_width())
             .args(deglobalized);
 
@@ -744,7 +744,7 @@ impl Options {
         if args.json {
             say_option_is_deprecated(
                 "--json",
-                concatcp!(BRANDING_CLI, " query --output-format=json"),
+                concatcp!(BRANDING_CLI_CMD, " query --output-format=json"),
             );
         }
         if args.tab_separated {
@@ -754,7 +754,7 @@ impl Options {
             );
         }
         let subcommand = if let Some(query) = args.query {
-            say_option_is_deprecated("-c", concatcp!(BRANDING_CLI, " query"));
+            say_option_is_deprecated("-c", concatcp!(BRANDING_CLI_CMD, " query"));
             let output_format = if args.json {
                 Some(OutputFormat::Json)
             } else if args.tab_separated {

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use colorful::Colorful;
+use const_format::concatcp;
 use edgedb_errors::{ClientNoCredentialsError, ResultExt};
 use edgedb_protocol::model;
 use edgedb_tokio::credentials::TlsSecurity;
@@ -18,6 +19,7 @@ use crate::cli::options::CliCommand;
 
 use crate::branch::option::BranchCommand;
 use crate::branding::CONFIG_FILE_DISPLAY_NAME;
+use crate::branding::{BRANDING, BRANDING_CLI};
 use crate::cloud::options::CloudCommand;
 use crate::commands::parser::Common;
 use crate::commands::ExitCode;
@@ -36,11 +38,19 @@ use crate::watch::options::WatchCommand;
 const MAX_TERM_WIDTH: usize = 100;
 const MIN_TERM_WIDTH: usize = 50;
 
-const CONN_OPTIONS_GROUP: &str = "Connection Options (edgedb --help-connect to see full list)";
+const CONN_OPTIONS_GROUP: &str = concatcp!(
+    " Connection Options (",
+    BRANDING_CLI,
+    " --help-connect to see full list)"
+);
 const CLOUD_OPTIONS_GROUP: &str = "Cloud Connection Options";
-const CONNECTION_ARG_HINT: &str = "\
-    Run `edgedb project init` or use any of `-H`, `-P`, `-I` arguments \
-    to specify connection parameters. See `--help` for details";
+const CONNECTION_ARG_HINT: &str = concatcp!(
+    "\
+    Run `",
+    BRANDING_CLI,
+    " project init` or use any of `-H`, `-P`, `-I` arguments \
+    to specify connection parameters. See `--help` for details"
+);
 
 #[derive(clap::Args, Clone, Debug)]
 #[group(id = "connopts")]
@@ -681,7 +691,7 @@ impl Options {
         //
         // to enable connection and/or cloud options for themselves
         // and their subcommands.
-        let tmp = clap::Command::new("edgedb");
+        let tmp = clap::Command::new(BRANDING_CLI);
         let tmp = <RawOptions as clap::Args>::augment_args(tmp);
         let mut global_args: Vec<_> = tmp
             .get_groups()
@@ -698,7 +708,7 @@ impl Options {
             }
         });
 
-        let app = clap::Command::new("edgedb")
+        let app = clap::Command::new(BRANDING_CLI)
             .term_width(term_width())
             .args(deglobalized);
 
@@ -720,7 +730,7 @@ impl Options {
         }
 
         if args.print_version {
-            println!("EdgeDB CLI {}", clap::crate_version!());
+            println!("{BRANDING} CLI {}", clap::crate_version!());
             return Err(ExitCode::new(0).into());
         }
 
@@ -732,7 +742,10 @@ impl Options {
         let interactive = args.query.is_none() && subcommand.is_none() && stdin().is_terminal();
 
         if args.json {
-            say_option_is_deprecated("--json", "edgedb query --output-format=json");
+            say_option_is_deprecated(
+                "--json",
+                concatcp!(BRANDING_CLI, " query --output-format=json"),
+            );
         }
         if args.tab_separated {
             say_option_is_deprecated(
@@ -741,7 +754,7 @@ impl Options {
             );
         }
         let subcommand = if let Some(query) = args.query {
-            say_option_is_deprecated("-c", "edgedb query");
+            say_option_is_deprecated("-c", concatcp!(BRANDING_CLI, " query"));
             let output_format = if args.json {
                 Some(OutputFormat::Json)
             } else if args.tab_separated {

--- a/src/options.rs
+++ b/src/options.rs
@@ -16,8 +16,8 @@ use edgedb_cli_derive::IntoArgs;
 use crate::cli;
 use crate::cli::options::CliCommand;
 
-use crate::branding::CONFIG_FILE_DISPLAY_NAME;
 use crate::branch::option::BranchCommand;
+use crate::branding::CONFIG_FILE_DISPLAY_NAME;
 use crate::cloud::options::CloudCommand;
 use crate::commands::parser::Common;
 use crate::commands::ExitCode;
@@ -841,10 +841,13 @@ impl Options {
                     let project_dir = get_project_path(None, true).await?;
                     let message = if project_dir.is_some() {
                         "project is not initialized and no connection options \
-                            are specified".to_owned()
+                            are specified"
+                            .to_owned()
                     } else {
-                        format!("no {CONFIG_FILE_DISPLAY_NAME} found and no connection options \
-                            are specified")
+                        format!(
+                            "no {CONFIG_FILE_DISPLAY_NAME} found and no connection options \
+                            are specified"
+                        )
                     };
                     Ok(Connector::new(
                         Err(anyhow::anyhow!(message))

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,7 +7,7 @@ use colorful::Colorful;
 use edgedb_errors::{ClientNoCredentialsError, ResultExt};
 use edgedb_protocol::model;
 use edgedb_tokio::credentials::TlsSecurity;
-use edgedb_tokio::{get_project_dir, Builder, Config};
+use edgedb_tokio::{get_project_path, Builder, Config};
 use is_terminal::IsTerminal;
 use tokio::task::spawn_blocking as unblock;
 
@@ -16,6 +16,7 @@ use edgedb_cli_derive::IntoArgs;
 use crate::cli;
 use crate::cli::options::CliCommand;
 
+use crate::branding::CONFIG_FILE_DISPLAY_NAME;
 use crate::branch::option::BranchCommand;
 use crate::cloud::options::CloudCommand;
 use crate::commands::parser::Common;
@@ -837,13 +838,13 @@ impl Options {
                 with_password(&self.conn_options, cfg).await?;
 
                 if e.is::<ClientNoCredentialsError>() {
-                    let project_dir = get_project_dir(None, true).await?;
+                    let project_dir = get_project_path(None, true).await?;
                     let message = if project_dir.is_some() {
                         "project is not initialized and no connection options \
-                            are specified"
+                            are specified".to_owned()
                     } else {
-                        "no `edgedb.toml` found and no connection options \
-                            are specified"
+                        format!("no {CONFIG_FILE_DISPLAY_NAME} found and no connection options \
+                            are specified")
                     };
                     Ok(Connector::new(
                         Err(anyhow::anyhow!(message))

--- a/src/options.rs
+++ b/src/options.rs
@@ -832,7 +832,7 @@ impl Options {
                 Ok(Connector::new(Ok(cfg)))
             }
             Err(e) => {
-                let (_, cfg, _) = builder.build_no_fail().await;
+                let (_, cfg, errors) = builder.build_no_fail().await;
                 // ask password anyways, so input that fed as a password
                 // never goes to anywhere else
                 with_password(&self.conn_options, cfg).await?;
@@ -840,9 +840,10 @@ impl Options {
                 if e.is::<ClientNoCredentialsError>() {
                     let project_dir = get_project_path(None, true).await?;
                     let message = if project_dir.is_some() {
-                        "project is not initialized and no connection options \
-                            are specified"
-                            .to_owned()
+                        format!(
+                            "project is not initialized and no connection options \
+                            are specified: {errors:?}"
+                        )
                     } else {
                         format!(
                             "no {CONFIG_FILE_DISPLAY_NAME} found and no connection options \

--- a/src/options.rs
+++ b/src/options.rs
@@ -18,8 +18,7 @@ use crate::cli;
 use crate::cli::options::CliCommand;
 
 use crate::branch::option::BranchCommand;
-use crate::branding::CONFIG_FILE_DISPLAY_NAME;
-use crate::branding::{BRANDING, BRANDING_CLI_CMD};
+use crate::branding::{BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD, CONFIG_FILE_DISPLAY_NAME};
 use crate::cloud::options::CloudCommand;
 use crate::commands::parser::Common;
 use crate::commands::ExitCode;
@@ -39,11 +38,11 @@ const MAX_TERM_WIDTH: usize = 100;
 const MIN_TERM_WIDTH: usize = 50;
 
 const CONN_OPTIONS_GROUP: &str = concatcp!(
-    " Connection Options (",
+    "Connection Options (",
     BRANDING_CLI_CMD,
     " --help-connect to see full list)"
 );
-const CLOUD_OPTIONS_GROUP: &str = "Cloud Connection Options";
+const CLOUD_OPTIONS_GROUP: &str = concatcp!(BRANDING_CLOUD, " Connection Options");
 const CONNECTION_ARG_HINT: &str = concatcp!(
     "\
     Run `",
@@ -268,19 +267,19 @@ pub struct HelpConnect {
 #[derive(clap::Args, IntoArgs, Clone, Debug)]
 #[group(id = "cloudopts")]
 pub struct CloudOptions {
-    /// Specify the EdgeDB Cloud API endpoint. Defaults to the current logged-in
+    /// Specify the API endpoint. Defaults to the current logged-in
     /// server, or <https://api.g.aws.edgedb.cloud> if unauthorized
     #[arg(long, value_name="URL", help_heading=Some(CLOUD_OPTIONS_GROUP))]
     #[arg(global = true)]
     pub cloud_api_endpoint: Option<String>,
 
-    /// Specify EdgeDB Cloud API secret key to use instead of loading
+    /// Specify the API secret key to use instead of loading
     /// key from a remembered authentication.
     #[arg(long, value_name="SECRET_KEY", help_heading=Some(CLOUD_OPTIONS_GROUP))]
     #[arg(global = true)]
     pub cloud_secret_key: Option<String>,
 
-    /// Specify authenticated EdgeDB Cloud profile. Defaults to "default".
+    /// Specify the authenticated profile. Defaults to "default".
     #[arg(long, value_name="PROFILE", help_heading=Some(CLOUD_OPTIONS_GROUP))]
     #[arg(global = true)]
     pub cloud_profile: Option<String>,

--- a/src/portable/backup.rs
+++ b/src/portable/backup.rs
@@ -151,6 +151,6 @@ fn restore_cloud_cmd(
         "has been restored successfully."
     );
     echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI_CMD, " -I", inst_name);
+    echo!("  ", BRANDING_CLI_CMD, "-I", inst_name);
     Ok(())
 }

--- a/src/portable/backup.rs
+++ b/src/portable/backup.rs
@@ -1,6 +1,6 @@
 use color_print::cformat;
 
-use crate::branding::{BRANDING, BRANDING_CLI, BRANDING_CLOUD};
+use crate::branding::{BRANDING_CLI, BRANDING_CLOUD};
 use crate::cloud;
 use crate::portable::options::{Backup, InstanceName, ListBackups, Restore};
 use crate::print::echo;

--- a/src/portable/backup.rs
+++ b/src/portable/backup.rs
@@ -61,7 +61,7 @@ fn backup_cloud_cmd(
     };
 
     let prompt = format!(
-        "Will create a backup for the \"{inst_name}\" {BRANDING_CLOUD} instance:\
+        "Will create a backup for the {BRANDING_CLOUD} instance \"{inst_name}\":\
         \n\nContinue?",
     );
 
@@ -116,7 +116,7 @@ fn restore_cloud_cmd(
     let source_inst = match &cmd.source_instance {
         Some(InstanceName::Local(_)) => Err(opts.error(
             clap::error::ErrorKind::InvalidValue,
-            cformat!("--source-instance can only be a {BRANDING_CLOUD} instance"),
+            cformat!("--source-instance can only be a valid {BRANDING_CLOUD} instance"),
         ))?,
         Some(InstanceName::Cloud { org_slug, name }) => {
             let inst = cloud::ops::find_cloud_instance_by_name(name, org_slug, &client)?
@@ -127,7 +127,7 @@ fn restore_cloud_cmd(
     };
 
     let prompt = format!(
-        "Will restore the \"{inst_name}\" {BRANDING_CLOUD} instance from the specified backup:\
+        "Will restore the {BRANDING_CLOUD} instance \"{inst_name}\" from the specified backup:\
         \n\nContinue?",
     );
 

--- a/src/portable/backup.rs
+++ b/src/portable/backup.rs
@@ -1,6 +1,6 @@
 use color_print::cformat;
 
-use crate::branding::{BRANDING_CLI, BRANDING_CLOUD};
+use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::cloud;
 use crate::portable::options::{Backup, InstanceName, ListBackups, Restore};
 use crate::print::echo;
@@ -151,6 +151,6 @@ fn restore_cloud_cmd(
         "has been restored successfully."
     );
     echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI, " -I", inst_name);
+    echo!("  ", BRANDING_CLI_CMD, " -I", inst_name);
     Ok(())
 }

--- a/src/portable/backup.rs
+++ b/src/portable/backup.rs
@@ -1,5 +1,6 @@
 use color_print::cformat;
 
+use crate::branding::{BRANDING, BRANDING_CLI, BRANDING_CLOUD};
 use crate::cloud;
 use crate::portable::options::{Backup, InstanceName, ListBackups, Restore};
 use crate::print::echo;
@@ -9,7 +10,7 @@ pub fn list(cmd: &ListBackups, opts: &crate::options::Options) -> anyhow::Result
     match &cmd.instance {
         InstanceName::Local(_) => Err(opts.error(
             clap::error::ErrorKind::InvalidValue,
-            cformat!("list-backups can only operate on Cloud instances."),
+            cformat!("list-backups can only operate on {BRANDING_CLOUD} instances."),
         ))?,
         InstanceName::Cloud {
             org_slug: org,
@@ -36,7 +37,7 @@ pub fn backup(cmd: &Backup, opts: &crate::options::Options) -> anyhow::Result<()
     match &cmd.instance {
         InstanceName::Local(_) => Err(opts.error(
             clap::error::ErrorKind::InvalidValue,
-            cformat!("Only Cloud instances can be backed up using this command."),
+            cformat!("Only {BRANDING_CLOUD} instances can be backed up using this command."),
         ))?,
         InstanceName::Cloud {
             org_slug: org,
@@ -60,7 +61,7 @@ fn backup_cloud_cmd(
     };
 
     let prompt = format!(
-        "Will create a backup for the \"{inst_name}\" Cloud instance:\
+        "Will create a backup for the \"{inst_name}\" {BRANDING_CLOUD} instance:\
         \n\nContinue?",
     );
 
@@ -75,7 +76,9 @@ fn backup_cloud_cmd(
     cloud::backups::backup_cloud_instance(&client, &request)?;
 
     echo!(
-        "Successfully created a backup for EdgeDB Cloud instance",
+        "Successfully created a backup for ",
+        BRANDING_CLOUD,
+        " instance",
         inst_name,
     );
     Ok(())
@@ -85,7 +88,7 @@ pub fn restore(cmd: &Restore, opts: &crate::options::Options) -> anyhow::Result<
     match &cmd.instance {
         InstanceName::Local(_) => Err(opts.error(
             clap::error::ErrorKind::InvalidValue,
-            cformat!("Only Cloud instances can be restored."),
+            cformat!("Only {BRANDING_CLOUD} instances can be restored."),
         ))?,
         InstanceName::Cloud {
             org_slug: org,
@@ -113,7 +116,7 @@ fn restore_cloud_cmd(
     let source_inst = match &cmd.source_instance {
         Some(InstanceName::Local(_)) => Err(opts.error(
             clap::error::ErrorKind::InvalidValue,
-            cformat!("--source-instance can only be a Cloud instance"),
+            cformat!("--source-instance can only be a {BRANDING_CLOUD} instance"),
         ))?,
         Some(InstanceName::Cloud { org_slug, name }) => {
             let inst = cloud::ops::find_cloud_instance_by_name(name, org_slug, &client)?
@@ -124,7 +127,7 @@ fn restore_cloud_cmd(
     };
 
     let prompt = format!(
-        "Will restore the \"{inst_name}\" Cloud instance from the specified backup:\
+        "Will restore the \"{inst_name}\" {BRANDING_CLOUD} instance from the specified backup:\
         \n\nContinue?",
     );
 
@@ -142,11 +145,12 @@ fn restore_cloud_cmd(
     cloud::backups::restore_cloud_instance(&client, &request)?;
 
     echo!(
-        "EdgeDB Cloud instance",
+        BRANDING_CLOUD,
+        " instance",
         inst_name,
         "has been restored successfully."
     );
     echo!("To connect to the instance run:");
-    echo!("  edgedb -I", inst_name);
+    echo!("  ", BRANDING_CLI, " -I", inst_name);
     Ok(())
 }

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -6,6 +6,7 @@ use fn_error_context::context;
 
 use toml::Spanned;
 
+use crate::branding::CONFIG_FILE_DISPLAY_NAME;
 use crate::commands::ExitCode;
 use crate::platform::tmp_file_path;
 use crate::portable::exit_codes;
@@ -136,7 +137,7 @@ where
         return Ok(Some(out));
     }
 
-    print::error(format!("Invalid `edgedb.toml`: missing {}", field_name));
+    print::error(format!("Invalid {CONFIG_FILE_DISPLAY_NAME}: missing {}", field_name));
     Err(ExitCode::new(exit_codes::INVALID_CONFIG).into())
 }
 
@@ -175,7 +176,7 @@ pub fn modify_server_ver(config: &Path, ver: &Query) -> anyhow::Result<bool> {
     echo!(
         "Setting `server-version = ",
         format_args!("{:?}", ver.as_config_value()).emphasize(),
-        "` in `edgedb.toml`"
+        "` in `{}`", config.file_name().unwrap_or_default().to_string_lossy()
     );
     read_modify_write(
         config,

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -137,7 +137,10 @@ where
         return Ok(Some(out));
     }
 
-    print::error(format!("Invalid {CONFIG_FILE_DISPLAY_NAME}: missing {}", field_name));
+    print::error(format!(
+        "Invalid {CONFIG_FILE_DISPLAY_NAME}: missing {}",
+        field_name
+    ));
     Err(ExitCode::new(exit_codes::INVALID_CONFIG).into())
 }
 
@@ -176,7 +179,8 @@ pub fn modify_server_ver(config: &Path, ver: &Query) -> anyhow::Result<bool> {
     echo!(
         "Setting `server-version = ",
         format_args!("{:?}", ver.as_config_value()).emphasize(),
-        "` in `{}`", config.file_name().unwrap_or_default().to_string_lossy()
+        "` in `{}`",
+        config.file_name().unwrap_or_default().to_string_lossy()
     );
     read_modify_write(
         config,

--- a/src/portable/control.rs
+++ b/src/portable/control.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use fn_error_context::context;
 
+use crate::branding::BRANDING;
 use crate::bug;
 use crate::commands::ExitCode;
 use crate::credentials;
@@ -376,7 +377,7 @@ pub fn do_stop(name: &str) -> anyhow::Result<()> {
         if supervisor && is_run_by_supervisor(lock) {
             supervisor_stop(name)
         } else if let Some(pid) = read_pid(name)? {
-            log::info!("Stopping EdgeDB with pid {}", pid);
+            log::info!("Stopping {BRANDING} with pid {}", pid);
             process::term(pid)?;
             // wait for unlock
             let _ = open_lock(name)?
@@ -392,7 +393,7 @@ pub fn do_stop(name: &str) -> anyhow::Result<()> {
             supervisor_stop(name)
         } else {
             if let Some(pid) = read_pid(name)? {
-                log::info!("Stopping EdgeDB with pid {}", pid);
+                log::info!("Stopping {BRANDING} with pid {}", pid);
                 process::term(pid)?;
                 // wait for unlock
                 let _ = open_lock(name)?.read()?;
@@ -441,7 +442,7 @@ pub fn stop_and_disable(instance: &str) -> anyhow::Result<bool> {
             // properly running
             if !supervisor || !is_run_by_supervisor(lock) {
                 if let Some(pid) = read_pid(instance)? {
-                    log::info!("Stopping EdgeDB with pid {}", pid);
+                    log::info!("Stopping {BRANDING} with pid {}", pid);
                     process::term(pid)?;
                     // wait for unlock
                     let _ = open_lock(instance)?.read()?;
@@ -478,7 +479,7 @@ pub fn do_restart(inst: &InstanceInfo) -> anyhow::Result<()> {
             supervisor_restart(inst)
         } else {
             if let Some(pid) = read_pid(&inst.name)? {
-                log::info!("Stopping EdgeDB with pid {}", pid);
+                log::info!("Stopping {BRANDING} with pid {}", pid);
                 process::term(pid)?;
                 // wait for unlock
                 let _ = open_lock(&inst.name)?.read()?;
@@ -497,7 +498,7 @@ pub fn do_restart(inst: &InstanceInfo) -> anyhow::Result<()> {
             supervisor_restart(inst)
         } else {
             if let Some(pid) = read_pid(&inst.name)? {
-                log::info!("Stopping EdgeDB with pid {}", pid);
+                log::info!("Stopping {BRANDING} with pid {}", pid);
                 process::term(pid)?;
                 // wait for unlock
                 let _ = lock.read()?;

--- a/src/portable/control.rs
+++ b/src/portable/control.rs
@@ -3,9 +3,10 @@ use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
+use const_format::concatcp;
 use fn_error_context::context;
 
-use crate::branding::BRANDING;
+use crate::branding::{BRANDING, BRANDING_CLOUD};
 use crate::bug;
 use crate::commands::ExitCode;
 use crate::credentials;
@@ -227,7 +228,11 @@ pub fn start(options: &Start) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error("Stopping cloud instances is not yet supported.");
+            print::error(concatcp!(
+                "Starting ",
+                BRANDING_CLOUD,
+                " instances is not yet supported."
+            ));
             return Err(ExitCode::new(1))?;
         }
     };
@@ -413,7 +418,11 @@ pub fn stop(options: &Stop) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error("Stopping cloud instances is not yet supported.");
+            print::error(concatcp!(
+                "Stopping ",
+                BRANDING_CLOUD,
+                " instances is not yet supported."
+            ));
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -7,7 +7,7 @@ use fn_error_context::context;
 
 use color_print::cformat;
 
-use crate::branding::{BRANDING, BRANDING_CLI, BRANDING_CLOUD};
+use crate::branding::{BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::cloud;
 use crate::commands::ExitCode;
 use crate::credentials;
@@ -70,7 +70,7 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
     if optional_docker_check()? {
         print::error(concatcp!(
             "`",
-            BRANDING_CLI,
+            BRANDING_CLI_CMD,
             " instance create` is not supported in Docker containers."
         ));
         Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
@@ -138,7 +138,7 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
         .with_context(|| format!("instance {:?} detected", name))
         .with_hint(|| {
             format!(
-                "Use `{BRANDING_CLI} instance destroy -I {}` \
+                "Use `{BRANDING_CLI_CMD} instance destroy -I {}` \
                               to remove rest of unused instance",
                 name
             )
@@ -207,7 +207,7 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
 
     echo!("Instance", name.emphasize(), "is up and running.");
     echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI, " -I", name);
+    echo!("  ", BRANDING_CLI_CMD, " -I", name);
     Ok(())
 }
 
@@ -395,7 +395,7 @@ fn create_cloud(
     cloud::ops::create_cloud_instance(client, &request)?;
     echo!(BRANDING_CLOUD, " instance", inst_name, "is up and running.");
     echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI, " -I", inst_name);
+    echo!("  ", BRANDING_CLI_CMD, " -I", inst_name);
     Ok(())
 }
 

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -207,7 +207,7 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
 
     echo!("Instance", name.emphasize(), "is up and running.");
     echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI_CMD, " -I", name);
+    echo!("  ", BRANDING_CLI_CMD, "-I", name);
     Ok(())
 }
 
@@ -393,9 +393,9 @@ fn create_cloud(
         source_backup_id: cmd.cloud_backup_source.from_backup_id.clone(),
     };
     cloud::ops::create_cloud_instance(client, &request)?;
-    echo!(BRANDING_CLOUD, " instance", inst_name, "is up and running.");
+    echo!(BRANDING_CLOUD, "instance", inst_name, "is up and running.");
     echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI_CMD, " -I", inst_name);
+    echo!("  ", BRANDING_CLI_CMD, "-I", inst_name);
     Ok(())
 }
 
@@ -449,7 +449,7 @@ pub fn bootstrap(
     let password = generate_password();
     let script = bootstrap_script(user, &password);
 
-    echo!("Initializing ", BRANDING, " instance...");
+    echo!("Initializing", BRANDING, "instance...");
     let mut cmd = process::Native::new("bootstrap", "edgedb", server_path);
     cmd.arg("--bootstrap-only");
     cmd.env_default("EDGEDB_SERVER_LOG_LEVEL", "warn");

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -110,7 +110,7 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
     if cp.region.is_some() {
         Err(opts.error(
             clap::error::ErrorKind::ArgumentConflict,
-            cformat!("The <bold>--region</bold> option is only applicable to cloud instances."),
+            cformat!("The <bold>--region</bold> option is only applicable to {BRANDING_CLOUD} instances."),
         ))?;
     }
 
@@ -118,7 +118,7 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
         Err(opts.error(
             clap::error::ErrorKind::ArgumentConflict,
             cformat!(
-                "The <bold>--compute-size</bold> option is only applicable to cloud instances."
+                "The <bold>--compute-size</bold> option is only applicable to {BRANDING_CLOUD} instances."
             ),
         ))?;
     }
@@ -127,7 +127,7 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
         Err(opts.error(
             clap::error::ErrorKind::ArgumentConflict,
             cformat!(
-                "The <bold>--storage-size</bold> option is only applicable to cloud instances."
+                "The <bold>--storage-size</bold> option is only applicable to {BRANDING_CLOUD} instances."
             ),
         ))?;
     }
@@ -344,7 +344,7 @@ fn create_cloud(
 
     if !cmd.non_interactive
         && !question::Confirm::new(format!(
-            "This will create a new {BRANDING} cloud instance with the following parameters:\
+            "This will create a new {BRANDING_CLOUD} instance with the following parameters:\
         \n\
         \nTier: {tier:?}\
         \nRegion: {region}\
@@ -376,7 +376,7 @@ fn create_cloud(
             clap::error::ErrorKind::InvalidValue,
             cformat!(
                 "The instance specified by <bold>--from-instance</bold> does \
-                not specify a cloud instance, a name in the 'org/instance' format is expected."
+                not specify a valid {BRANDING_CLOUD} instance, a name in the 'org/instance' format is expected."
             ),
         ))?,
         None => Ok(None),

--- a/src/portable/destroy.rs
+++ b/src/portable/destroy.rs
@@ -151,7 +151,7 @@ fn do_destroy(options: &Destroy, opts: &Options, name: &InstanceName) -> anyhow:
             org_slug,
             name: inst_name,
         } => {
-            log::info!("Removing cloud instance {}", name);
+            log::info!("Removing {BRANDING_CLOUD} instance {}", name);
             if let Err(e) =
                 crate::cloud::ops::destroy_cloud_instance(inst_name, org_slug, &opts.cloud_options)
             {

--- a/src/portable/destroy.rs
+++ b/src/portable/destroy.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use fs_err as fs;
 
+use crate::branding::{BRANDING_CLI, BRANDING_CLOUD};
 use crate::commands::ExitCode;
 use crate::options::Options;
 use crate::portable::control;
@@ -20,7 +21,7 @@ pub struct InstanceNotFound(#[source] pub anyhow::Error);
 pub fn print_warning(name: &str, project_dirs: &[PathBuf]) {
     project::print_instance_in_use_warning(name, project_dirs);
     eprintln!("If you really want to destroy the instance, run:");
-    eprintln!("  edgedb instance destroy -I {:?} --force", name);
+    eprintln!("  {BRANDING_CLI} instance destroy -I {:?} --force", name);
 }
 
 pub fn with_projects(
@@ -151,7 +152,7 @@ fn do_destroy(options: &Destroy, opts: &Options, name: &InstanceName) -> anyhow:
             if let Err(e) =
                 crate::cloud::ops::destroy_cloud_instance(inst_name, org_slug, &opts.cloud_options)
             {
-                let msg = format!("Could not destroy EdgeDB Cloud instance: {:#}", e);
+                let msg = format!("Could not destroy {BRANDING_CLOUD} instance: {:#}", e);
                 if options.force {
                     print::warn(msg);
                 } else {

--- a/src/portable/destroy.rs
+++ b/src/portable/destroy.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use fs_err as fs;
 
-use crate::branding::{BRANDING_CLI, BRANDING_CLOUD};
+use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::commands::ExitCode;
 use crate::options::Options;
 use crate::portable::control;
@@ -21,7 +21,10 @@ pub struct InstanceNotFound(#[source] pub anyhow::Error);
 pub fn print_warning(name: &str, project_dirs: &[PathBuf]) {
     project::print_instance_in_use_warning(name, project_dirs);
     eprintln!("If you really want to destroy the instance, run:");
-    eprintln!("  {BRANDING_CLI} instance destroy -I {:?} --force", name);
+    eprintln!(
+        "  {BRANDING_CLI_CMD} instance destroy -I {:?} --force",
+        name
+    );
 }
 
 pub fn with_projects(

--- a/src/portable/extension.rs
+++ b/src/portable/extension.rs
@@ -9,6 +9,8 @@ use prettytable::{row, Table};
 use super::options::{
     ExtensionInstall, ExtensionList, ExtensionListExtensions, ExtensionUninstall,
 };
+
+use crate::branding::BRANDING_CLOUD;
 use crate::hint::HintExt;
 use crate::portable::install::download_package;
 use crate::portable::local::InstanceInfo;
@@ -32,7 +34,7 @@ fn get_local_instance(instance: &Option<InstanceName>) -> Result<InstanceInfo, a
         InstanceName::Local(name) => name,
         inst_name => {
             return Err(anyhow::anyhow!(
-                "cannot install extensions in cloud instance {}.",
+                "cannot install extensions in {BRANDING_CLOUD} instance {}.",
                 inst_name
             ))
             .with_hint(|| {
@@ -45,7 +47,7 @@ fn get_local_instance(instance: &Option<InstanceName>) -> Result<InstanceInfo, a
     };
     let Some(inst) = InstanceInfo::try_read(&name)? else {
         return Err(anyhow::anyhow!(
-            "cannot install extensions in cloud instance {}.",
+            "cannot install extensions in {BRANDING_CLOUD} instance {}.",
             name
         ))
         .with_hint(|| {

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -19,7 +19,7 @@ use edgedb_tokio::{tls, Client};
 use edgedb_tokio::{Builder, Config};
 use rustyline::error::ReadlineError;
 
-use crate::branding::BRANDING_CLI_CMD;
+use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::credentials;
 use crate::hint::HintExt;
 use crate::options;
@@ -431,7 +431,7 @@ pub fn unlink(options: &Unlink) -> anyhow::Result<()> {
         InstanceName::Local(name) => name,
         inst_name => {
             return Err(anyhow::anyhow!(
-                "cannot unlink cloud instance {}.",
+                "cannot unlink {BRANDING_CLOUD} instance {}.",
                 inst_name
             ))
             .with_hint(|| {

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -19,6 +19,7 @@ use edgedb_tokio::{tls, Client};
 use edgedb_tokio::{Builder, Config};
 use rustyline::error::ReadlineError;
 
+use crate::branding::BRANDING_CLI_CMD;
 use crate::credentials;
 use crate::hint::HintExt;
 use crate::options;
@@ -212,7 +213,7 @@ pub fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
         anyhow::bail!(
             "cloud instances cannot be linked\
             \nTo connect run:\
-            \n  edgedb -I {}",
+            \n  {BRANDING_CLI_CMD} -I {}",
             cmd.name.as_ref().unwrap()
         );
     }
@@ -336,7 +337,7 @@ pub fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
         }
         eprintln!(
             "{} To connect run:\
-            \n  edgedb -I {}",
+            \n  {BRANDING_CLI_CMD} -I {}",
             msg,
             instance_name.escape_default(),
         );
@@ -422,7 +423,7 @@ async fn prompt_conn_params(
 pub fn print_warning(name: &str, project_dirs: &[PathBuf]) {
     project::print_instance_in_use_warning(name, project_dirs);
     eprintln!("If you really want to unlink the instance, run:");
-    eprintln!("  edgedb instance unlink -I {:?} --force", name);
+    eprintln!("  {BRANDING_CLI_CMD} instance unlink -I {:?} --force", name);
 }
 
 pub fn unlink(options: &Unlink) -> anyhow::Result<()> {

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -211,7 +211,7 @@ async fn get_default_branch(connection: &mut Client) -> anyhow::Result<String> {
 pub fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
     if matches!(cmd.name, Some(InstanceName::Cloud { .. })) {
         anyhow::bail!(
-            "cloud instances cannot be linked\
+            "{BRANDING_CLOUD} instances cannot be linked\
             \nTo connect run:\
             \n  {BRANDING_CLI_CMD} -I {}",
             cmd.name.as_ref().unwrap()

--- a/src/portable/linux.rs
+++ b/src/portable/linux.rs
@@ -3,8 +3,10 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::Context;
+use const_format::concatcp;
 use fn_error_context::context;
 
+use crate::branding::BRANDING_CLOUD;
 use crate::commands::ExitCode;
 use crate::platform::{current_exe, detect_ipv6, home_dir};
 use crate::portable::destroy::InstanceNotFound;
@@ -423,7 +425,11 @@ pub fn logs(options: &Logs) -> anyhow::Result<()> {
     let name = match instance_arg(&options.name, &options.instance)? {
         InstanceName::Local(name) => name,
         InstanceName::Cloud { .. } => {
-            print::error("This operation is not yet supported on cloud instances.");
+            print::error(concatcp!(
+                "This operation is not yet supported on ",
+                BRANDING_CLOUD,
+                " instances."
+            ));
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -12,6 +12,7 @@ use fn_error_context::context;
 
 use edgedb_tokio::Builder;
 
+use crate::branding::BRANDING;
 use crate::bug;
 use crate::credentials;
 use crate::hint::HintExt;
@@ -408,7 +409,9 @@ impl InstallInfo {
             Err(
                 bug::error("no extension directory available for this server")
                     .with_hint(|| {
-                        format!("Extension installation requires EdgeDB server version 6 or later")
+                        format!(
+                            "Extension installation requires {BRANDING} server version 6 or later"
+                        )
                     })
                     .into(),
             )
@@ -425,7 +428,9 @@ impl InstallInfo {
             Err(
                 anyhow::anyhow!("edgedb-load-ext not found in the installation")
                     .with_hint(|| {
-                        format!("Extension installation requires EdgeDB server version 6 or later")
+                        format!(
+                            "Extension installation requires {BRANDING} server version 6 or later"
+                        )
                     })
                     .into(),
             )

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::thread;
 use std::time;
 
+use const_format::concatcp;
 use fn_error_context::context;
 
 use crate::branding::BRANDING;
@@ -371,7 +372,7 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
             Inactive { .. } | Ready => {
                 thread::sleep(time::Duration::from_millis(30));
                 if time::SystemTime::now() > cut_off {
-                    print::error("{BRANDING} failed to start for 30 seconds");
+                    print::error(concatcp!(BRANDING, " failed to start for 30 seconds"));
                     break;
                 }
                 continue;
@@ -390,7 +391,7 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
                 );
             }
             Failed { exit_code: None } => {
-                echo!(print::err_marker(), "{BRANDING} failed".emphasize());
+                echo!(print::err_marker(), BRANDING, "failed".emphasize());
             }
         }
     }

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -5,6 +5,7 @@ use std::time;
 
 use fn_error_context::context;
 
+use crate::branding::BRANDING;
 use crate::commands::ExitCode;
 use crate::platform::{current_exe, detect_ipv6};
 use crate::platform::{data_dir, get_current_uid, home_dir};
@@ -370,7 +371,7 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
             Inactive { .. } | Ready => {
                 thread::sleep(time::Duration::from_millis(30));
                 if time::SystemTime::now() > cut_off {
-                    print::error("EdgeDB failed to start for 30 seconds");
+                    print::error("{BRANDING} failed to start for 30 seconds");
                     break;
                 }
                 continue;
@@ -383,13 +384,13 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
             } => {
                 echo!(
                     print::err_marker(),
-                    "EdgeDB failed".emphasize(),
+                    "{BRANDING} failed".emphasize(),
                     "with exit code",
                     code
                 );
             }
             Failed { exit_code: None } => {
-                echo!(print::err_marker(), "EdgeDB failed".emphasize());
+                echo!(print::err_marker(), "{BRANDING} failed".emphasize());
             }
         }
     }
@@ -402,7 +403,7 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
         .map_err(|e| log::warn!("Cannot show log: {}", e))
         .ok();
     println!("--- End of log ---");
-    anyhow::bail!("Failed to start EdgeDB");
+    anyhow::bail!("Failed to start {BRANDING}");
 }
 
 pub fn stop_service(name: &str) -> anyhow::Result<()> {

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -149,13 +149,13 @@ pub struct ExtensionUninstall {
 
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum Command {
-    /// Show locally installed EdgeDB versions.
+    /// Show locally installed server versions.
     Info(Info),
-    /// Install an EdgeDB version locally.
+    /// Install a server version locally.
     Install(Install),
-    /// Uninstall an EdgeDB version locally.
+    /// Uninstall a server version locally.
     Uninstall(Uninstall),
-    /// List available and installed versions of EdgeDB.
+    /// List available and installed versions of the server.
     ListVersions(ListVersions),
 }
 

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -5,7 +5,9 @@ use clap::ValueHint;
 use edgedb_cli_derive::IntoArgs;
 use serde::{Deserialize, Serialize};
 
-use crate::branding::{BRANDING, BRANDING_CLOUD};
+#[cfg(doc)]
+use crate::branding::BRANDING;
+use crate::branding::BRANDING_CLOUD;
 use crate::cloud::ops::CloudTier;
 use crate::commands::ExitCode;
 use crate::options::{CloudOptions, ConnectionOptions};

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -5,6 +5,7 @@ use clap::ValueHint;
 use edgedb_cli_derive::IntoArgs;
 use serde::{Deserialize, Serialize};
 
+use crate::branding::BRANDING_CLOUD;
 use crate::cloud::ops::CloudTier;
 use crate::commands::ExitCode;
 use crate::options::{CloudOptions, ConnectionOptions};
@@ -895,7 +896,7 @@ impl FromStr for InstanceName {
             }
             if name.len() > CLOUD_INSTANCE_NAME_MAX_LENGTH {
                 anyhow::bail!(
-                    "invalid cloud instance name \"{}\": \
+                    "invalid {BRANDING_CLOUD} instance name \"{}\": \
                     length cannot exceed {} characters",
                     name,
                     CLOUD_INSTANCE_NAME_MAX_LENGTH,
@@ -910,7 +911,7 @@ impl FromStr for InstanceName {
                 anyhow::bail!(
                     "instance name must be a valid identifier, \
                      regex: ^[a-zA-Z_0-9]+(-[a-zA-Z_0-9]+)*$ or \
-                     a cloud instance name ORG/INST."
+                     {BRANDING_CLOUD} instance name ORG/INST."
                 );
             }
             Ok(InstanceName::Local(name.into()))

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -5,7 +5,7 @@ use clap::ValueHint;
 use edgedb_cli_derive::IntoArgs;
 use serde::{Deserialize, Serialize};
 
-use crate::branding::BRANDING_CLOUD;
+use crate::branding::{BRANDING, BRANDING_CLOUD};
 use crate::cloud::ops::CloudTier;
 use crate::commands::ExitCode;
 use crate::options::{CloudOptions, ConnectionOptions};
@@ -36,7 +36,7 @@ pub struct ServerInstanceCommand {
 
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum InstanceCommand {
-    /// Initialize a new EdgeDB instance.
+    /// Initialize a new [`BRANDING`] instance.
     Create(Create),
     /// Show all instances.
     List(List),
@@ -56,13 +56,13 @@ pub enum InstanceCommand {
     Unlink(Unlink),
     /// Show logs for an instance.
     Logs(Logs),
-    /// Resize a Cloud instance.
+    /// Resize an instance ([`BRANDING_CLOUD`] only).
     Resize(Resize),
-    /// Create a Cloud instance backup.
+    /// Create a backup for an instance ([`BRANDING_CLOUD`] only).
     Backup(Backup),
-    /// Restore a Cloud instance from a backup.
+    /// Restore an instance from a backup ([`BRANDING_CLOUD`] only).
     Restore(Restore),
-    /// Restore a Cloud instance from a backup.
+    /// Restore an instance from a backup ([`BRANDING_CLOUD`] only).
     ListBackups(ListBackups),
     /// Upgrade installations and instances.
     Upgrade(Upgrade),

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -377,7 +377,7 @@ pub struct Destroy {
 }
 
 #[derive(clap::Args, Clone, Debug)]
-#[command(long_about = "Link to a remote EdgeDB instance and
+#[command(long_about = "Link to a remote {BRANDING} instance and
 assign an instance name to simplify future connections.")]
 pub struct Link {
     #[command(flatten)]
@@ -409,7 +409,7 @@ pub struct Link {
 }
 
 #[derive(clap::Args, Clone, Debug)]
-#[command(long_about = "Unlink from a remote EdgeDB instance.")]
+#[command(long_about = "Unlink from a remote {BRANDING} instance.")]
 pub struct Unlink {
     /// Specify remote instance name.
     #[arg(hide = true)]

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -50,9 +50,12 @@ pub enum InstanceCommand {
     Restart(Restart),
     /// Destroy an instance and remove the data.
     Destroy(Destroy),
-    /// Link a remote instance.
+    /// Link to a remote [`BRANDING`] instance.
+    #[command(
+        long_about = "Link to a remote [`BRANDING`] instance and assign an instance name to simplify future connections."
+    )]
     Link(Link),
-    /// Unlink a remote instance.
+    /// Unlink from a remote [`BRANDING`] instance.
     Unlink(Unlink),
     /// Show logs for an instance.
     Logs(Logs),
@@ -378,8 +381,6 @@ pub struct Destroy {
 }
 
 #[derive(clap::Args, Clone, Debug)]
-#[command(long_about = "Link to a remote {BRANDING} instance and
-assign an instance name to simplify future connections.")]
 pub struct Link {
     #[command(flatten)]
     pub conn: ConnectionOptions,
@@ -410,7 +411,6 @@ pub struct Link {
 }
 
 #[derive(clap::Args, Clone, Debug)]
-#[command(long_about = "Unlink from a remote {BRANDING} instance.")]
 pub struct Unlink {
     /// Specify remote instance name.
     #[arg(hide = true)]
@@ -811,11 +811,11 @@ pub struct Info {
     #[arg(conflicts_with_all=&["nightly", "version", "latest"])]
     pub channel: Option<Channel>,
 
-    #[arg(long, value_parser=["bin-path", "version"])]
     /// Get specific value:
     ///
     /// * `bin-path` -- Path to the server binary
     /// * `version` -- Server version
+    #[arg(long, value_parser=["bin-path", "version"])]
     pub get: Option<String>,
 }
 

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -319,10 +319,12 @@ fn ask_existing_instance_name(cloud_client: &mut CloudClient) -> anyhow::Result<
     let instances = credentials::all_instance_names()?;
 
     loop {
-        let mut q = question::String::new(
-            "Specify the name of {BRANDING} instance \
-                                   to link with this project",
-        );
+        let mut q = question::String::new(concatcp!(
+            "Specify the name of the ",
+            BRANDING,
+            " instance \
+                                   to link with this project"
+        ));
         let target_name = q.ask()?;
 
         let inst_name = match InstanceName::from_str(&target_name) {
@@ -547,15 +549,20 @@ fn ask_name(
         }
         return Ok((default_name, false));
     }
-    let mut q =
-        question::String::new("Specify the name of {BRANDING} instance to use with this project");
+    let mut q = question::String::new(concatcp!(
+        "Specify the name of the ",
+        BRANDING,
+        " instance to use with this project"
+    ));
     let default_name_str = default_name.to_string();
     q.default(&default_name_str);
     loop {
         let default_name_clone = default_name.clone();
-        let mut q = question::String::new(
-            "Specify the name of {BRANDING} instance to use with this project",
-        );
+        let mut q = question::String::new(concatcp!(
+            "Specify the name of the ",
+            BRANDING,
+            " instance to use with this project"
+        ));
         let default_name_str = default_name_clone.to_string();
         let target_name = q.default(&default_name_str).ask()?;
         let inst_name = match InstanceName::from_str(&target_name) {
@@ -1479,7 +1486,11 @@ fn ask_local_version(options: &Init) -> anyhow::Result<(Query, PackageInfo)> {
     } else {
         String::new()
     };
-    let mut q = question::String::new("Specify the version of {BRANDING} to use with this project");
+    let mut q = question::String::new(concatcp!(
+        "Specify the version of the ",
+        BRANDING,
+        " instance to use with this project"
+    ));
     q.default(&default_ver);
     loop {
         let value = q.ask()?;
@@ -1565,7 +1576,11 @@ fn ask_cloud_version(
     }
     let default = cloud::versions::get_version(&Query::stable(), client)?;
     let default_ver = Query::from_version(&default)?.as_config_value();
-    let mut q = question::String::new("Specify the version of {BRANDING} to use with this project");
+    let mut q = question::String::new(concatcp!(
+        "Specify the version of the ",
+        BRANDING,
+        " instance to use with this project"
+    ));
     q.default(&default_ver);
     loop {
         let value = q.ask()?;
@@ -2026,7 +2041,9 @@ pub fn upgrade_instance(options: &Upgrade, opts: &crate::options::Options) -> an
                 echo!("New major version is available:", available.emphasize());
                 echo!(
                     "To update `{}` and upgrade to this version, \
-                        run:\n    edgedb project upgrade --to-latest",
+                        run:\n    ",
+                    BRANDING_CLI_CMD,
+                    " project upgrade --to-latest",
                     config_path
                         .file_name()
                         .unwrap_or_default()

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -18,6 +18,7 @@ use edgedb_errors::DuplicateDatabaseDefinitionError;
 use edgedb_tokio::Builder;
 use edgeql_parser::helpers::quote_name;
 
+use crate::branding::BRANDING_CLOUD;
 use crate::branding::{BRANDING, BRANDING_CLI_CMD, CONFIG_FILE_DISPLAY_NAME};
 use crate::cloud;
 use crate::cloud::client::CloudClient;
@@ -666,7 +667,7 @@ pub fn init_existing(
 
     match &name {
         InstanceName::Cloud { org_slug, name } => {
-            echo!("Checking {BRANDING} cloud versions...");
+            echo!("Checking", BRANDING, "cloud versions...");
 
             let ver = cloud::versions::get_version(&ver_query, &client)
                 .with_context(|| "could not initialize project")?;
@@ -715,7 +716,7 @@ pub fn init_existing(
             )
         }
         InstanceName::Local(name) => {
-            echo!("Checking {BRANDING} versions...");
+            echo!("Checking", BRANDING, "versions...");
 
             let pkg = repository::get_server_package(&ver_query)?.with_context(|| {
                 format!(
@@ -997,7 +998,7 @@ pub fn init_new(
 
     match &inst_name {
         InstanceName::Cloud { org_slug, name } => {
-            echo!("Checking {BRANDING} cloud versions...");
+            echo!("Checking", BRANDING_CLOUD, "versions...");
             client.ensure_authenticated()?;
 
             let (ver_query, version) = ask_cloud_version(options, &client)?;
@@ -1046,7 +1047,7 @@ pub fn init_new(
             )
         }
         InstanceName::Local(name) => {
-            echo!("Checking {BRANDING} versions...");
+            echo!("Checking", BRANDING, "versions...");
             let (ver_query, pkg) = ask_local_version(options)?;
             let specific_version = &pkg.version.specific();
             ver::print_version_hint(specific_version, &ver_query);

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::env;
-use std::ffi::OsString;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -13,7 +12,6 @@ use edgedb_tokio::get_stash_path;
 use edgedb_tokio::PROJECT_FILES;
 use fn_error_context::context;
 use rand::{thread_rng, Rng};
-use sha1::Digest;
 
 use edgedb_errors::DuplicateDatabaseDefinitionError;
 use edgedb_tokio::Builder;

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -1718,7 +1718,7 @@ pub fn project_dir(cli_option: Option<&Path>) -> anyhow::Result<Option<(PathBuf,
     })
     .join()
     .unwrap()?;
-    Ok(res.map(|res| (res.clone(), res.parent().unwrap().to_owned())))
+    Ok(res.map(|res| (res.parent().unwrap().to_owned(), res)))
 }
 
 pub fn info(options: &Info) -> anyhow::Result<()> {

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -80,11 +80,13 @@ pub struct ProjectCommand {
 pub enum Command {
     /// Initialize project or link to existing unlinked project
     Init(Init),
-    /// Clean up project configuration. Use `edgedb project init` to relink
+    /// Clean up project configuration.
+    ///
+    /// Use [`BRANDING_CLI_CMD`] project init to relink.
     Unlink(Unlink),
     /// Get various metadata about project instance
     Info(Info),
-    /// Upgrade EdgeDB instance used for current project
+    /// Upgrade [`BRANDING`] instance used for current project
     ///
     /// Data is preserved using a dump/restore mechanism.
     ///

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -17,7 +17,7 @@ use edgedb_errors::DuplicateDatabaseDefinitionError;
 use edgedb_tokio::Builder;
 use edgeql_parser::helpers::quote_name;
 
-use crate::branding::{CONFIG_FILE_DISPLAY_NAME, BRANDING_CLI, BRANDING};
+use crate::branding::{BRANDING, BRANDING_CLI, CONFIG_FILE_DISPLAY_NAME};
 use crate::cloud;
 use crate::cloud::client::CloudClient;
 use crate::commands::ExitCode;
@@ -293,7 +293,10 @@ pub fn init(options: &Init, opts: &crate::options::Options) -> anyhow::Result<()
                 a project, run `{BRANDING_CLI}` command without `--link` flag"
             )
         }
-        let dir = options.project_dir.clone().unwrap_or_else(|| env::current_dir().unwrap());
+        let dir = options
+            .project_dir
+            .clone()
+            .unwrap_or_else(|| env::current_dir().unwrap());
         let config_path = dir.join(PROJECT_FILES[0]);
         init_new(options, &dir, config_path, opts)?;
         return Ok(());
@@ -409,7 +412,14 @@ fn link(
     config_path: PathBuf,
     cloud_options: &crate::options::CloudOptions,
 ) -> anyhow::Result<ProjectInfo> {
-    echo!("Found `{}` in", config_path.file_name().unwrap_or_default().to_string_lossy(), project_dir.display());
+    echo!(
+        "Found `{}` in",
+        config_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy(),
+        project_dir.display()
+    );
     echo!("Linking project...");
 
     let stash_dir = stash_path(project_dir)?;
@@ -583,7 +593,14 @@ pub fn init_existing(
     config_path: PathBuf,
     cloud_options: &crate::options::CloudOptions,
 ) -> anyhow::Result<ProjectInfo> {
-    echo!("Found `{}` in", config_path.file_name().unwrap_or_default().to_string_lossy(), project_dir.display());
+    echo!(
+        "Found `{}` in",
+        config_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy(),
+        project_dir.display()
+    );
     echo!("Initializing project...");
 
     let stash_dir = stash_path(project_dir)?;
@@ -1690,9 +1707,11 @@ pub fn unlink(options: &Unlink, opts: &crate::options::Options) -> anyhow::Resul
 
 pub fn project_dir(cli_option: Option<&Path>) -> anyhow::Result<Option<(PathBuf, PathBuf)>> {
     // Create a temporary runtime. Not efficient, but only called at CLI startup.
-    tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap().block_on(async {
-        project_dir(cli_option)
-    })
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async { project_dir(cli_option) })
 }
 
 pub fn info(options: &Info) -> anyhow::Result<()> {
@@ -2005,14 +2024,20 @@ pub fn upgrade_instance(options: &Upgrade, opts: &crate::options::Options) -> an
             echo!(
                 "EdgeDB instance is up to date with \
                 the specification in `{}`.",
-                config_path.file_name().unwrap_or_default().to_string_lossy()
+                config_path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
             );
             if let Some(available) = result.available_upgrade {
                 echo!("New major version is available:", available.emphasize());
                 echo!(
                     "To update `{}` and upgrade to this version, \
                         run:\n    edgedb project upgrade --to-latest",
-                        config_path.file_name().unwrap_or_default().to_string_lossy()
+                    config_path
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
                 );
             }
         }

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -18,7 +18,7 @@ use edgedb_errors::DuplicateDatabaseDefinitionError;
 use edgedb_tokio::Builder;
 use edgeql_parser::helpers::quote_name;
 
-use crate::branding::{BRANDING, BRANDING_CLI, CONFIG_FILE_DISPLAY_NAME};
+use crate::branding::{BRANDING, BRANDING_CLI_CMD, CONFIG_FILE_DISPLAY_NAME};
 use crate::cloud;
 use crate::cloud::client::CloudClient;
 use crate::commands::ExitCode;
@@ -276,7 +276,7 @@ pub fn init(options: &Init, opts: &crate::options::Options) -> anyhow::Result<()
     if optional_docker_check()? {
         print::error(concatcp!(
             "`",
-            BRANDING_CLI,
+            BRANDING_CLI_CMD,
             " project init` is not supported in Docker containers."
         ));
         Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
@@ -295,7 +295,7 @@ pub fn init(options: &Init, opts: &crate::options::Options) -> anyhow::Result<()
             anyhow::bail!(
                 "{CONFIG_FILE_DISPLAY_NAME} not found, unable to link an {BRANDING} \
                 instance without an initialized project. To initialize \
-                a project, run `{BRANDING_CLI}` command without `--link` flag"
+                a project, run `{BRANDING_CLI_CMD}` command without `--link` flag"
             )
         }
         let dir = options
@@ -485,12 +485,12 @@ fn do_link(inst: &Handle, options: &Init, stash_dir: &Path) -> anyhow::Result<Pr
     print::success("Project linked");
     if let Some(dir) = &options.project_dir {
         eprintln!(
-            "To connect to {}, navigate to {} and run `{BRANDING_CLI}`",
+            "To connect to {}, navigate to {} and run `{BRANDING_CLI_CMD}`",
             inst.name,
             dir.display()
         );
     } else {
-        eprintln!("To connect to {}, run `{BRANDING_CLI}`", inst.name);
+        eprintln!("To connect to {}, run `{BRANDING_CLI_CMD}`", inst.name);
     }
 
     Ok(ProjectInfo {
@@ -1225,7 +1225,7 @@ async fn migrate_async(inst: &Handle<'_>, ask_for_running: bool) -> anyhow::Resu
                         print::warn("Skipping migrations.");
                         echo!(
                             "You can use `",
-                            BRANDING_CLI,
+                            BRANDING_CLI_CMD,
                             " migrate` to apply migrations \
                                once the service is up and running."
                         );
@@ -1416,9 +1416,9 @@ fn print_initialized(name: &str, dir_option: &Option<PathBuf>) {
     print::success("Project initialized.");
     if let Some(dir) = dir_option {
         echo!("To connect to", name.emphasize();
-              ", navigate to", dir.display(), "and run `", BRANDING_CLI, "`");
+              ", navigate to", dir.display(), "and run `", BRANDING_CLI_CMD, "`");
     } else {
-        echo!("To connect to", name.emphasize(); ", run `", BRANDING_CLI, "`");
+        echo!("To connect to", name.emphasize(); ", run `", BRANDING_CLI_CMD, "`");
     }
 }
 
@@ -1890,7 +1890,7 @@ pub fn update_toml(
         }
         echo!(
             "Run",
-            BRANDING_CLI,
+            BRANDING_CLI_CMD,
             " project init".command_hint(),
             "to initialize an instance."
         );

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -832,7 +832,7 @@ fn do_init(
         })?;
         InstanceKind::Wsl(WslInfo {})
     } else {
-        let inst = install::package(pkg).context("error installing {BRANDING}")?;
+        let inst = install::package(pkg).context(concatcp!("error installing ", BRANDING))?;
         let info = InstanceInfo {
             name: name.into(),
             installation: Some(inst),

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -294,7 +294,7 @@ pub fn init(options: &Init, opts: &crate::options::Options) -> anyhow::Result<()
     let Some((project_dir, config_path)) = project_dir(options.project_dir.as_deref())? else {
         if options.link {
             anyhow::bail!(
-                "{CONFIG_FILE_DISPLAY_NAME} not found, unable to link an {BRANDING} \
+                "{CONFIG_FILE_DISPLAY_NAME} not found, unable to link an existing {BRANDING} \
                 instance without an initialized project. To initialize \
                 a project, run `{BRANDING_CLI_CMD}` command without `--link` flag"
             )
@@ -323,8 +323,7 @@ fn ask_existing_instance_name(cloud_client: &mut CloudClient) -> anyhow::Result<
         let mut q = question::String::new(concatcp!(
             "Specify the name of the ",
             BRANDING,
-            " instance \
-                                   to link with this project"
+            " instance to link with this project"
         ));
         let target_name = q.ask()?;
 
@@ -667,7 +666,7 @@ pub fn init_existing(
 
     match &name {
         InstanceName::Cloud { org_slug, name } => {
-            echo!("Checking", BRANDING, "cloud versions...");
+            echo!("Checking", BRANDING_CLOUD, "versions...");
 
             let ver = cloud::versions::get_version(&ver_query, &client)
                 .with_context(|| "could not initialize project")?;
@@ -1778,7 +1777,7 @@ pub fn info(options: &Info) -> anyhow::Result<()> {
         let mut rows: Vec<(&str, String)> =
             vec![("Instance name", instance_name), ("Project root", root)];
         if let Some(profile) = cloud_profile.as_deref() {
-            rows.push(("Cloud profile", profile.to_string()));
+            rows.push((concatcp!(BRANDING_CLOUD, " profile"), profile.to_string()));
         }
         table::settings(rows.as_slice());
     }

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -17,6 +17,7 @@ use tokio::io::AsyncWriteExt;
 use url::Url;
 
 use crate::async_util::timeout;
+use crate::branding::BRANDING;
 use crate::portable::platform;
 use crate::portable::ver;
 use crate::portable::windows;
@@ -206,7 +207,7 @@ where
                 eprintln!("  1. Internet connectivity is slow");
                 eprintln!("  2. A firewall is blocking internet access to this resource");
                 if windows::is_in_wsl() {
-                    eprintln!("Note: The EdgeDB CLI tool is running under \
+                    eprintln!("Note: The {BRANDING} CLI tool is running under \
                                Windows Subsystem for Linux (WSL).");
                     eprintln!("  Consider adding a Windows Defender Firewall \
                               rule for WSL.");

--- a/src/portable/reset_password.rs
+++ b/src/portable/reset_password.rs
@@ -3,12 +3,14 @@ use std::num::NonZeroU32;
 use std::path::Path;
 
 use base64::display::Base64Display;
+use const_format::concatcp;
 use fn_error_context::context;
 use rand::{Rng, SeedableRng};
 
 use edgedb_tokio::credentials::Credentials;
 use edgeql_parser::helpers::{quote_name, quote_string};
 
+use crate::branding::BRANDING_CLOUD;
 use crate::commands::ExitCode;
 use crate::connect::Connection;
 use crate::credentials;
@@ -46,7 +48,11 @@ pub fn reset_password(options: &ResetPassword) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error("This operation is not supported on cloud instances yet.");
+            print::error(concatcp!(
+                "This operation is not supported on ",
+                BRANDING_CLOUD,
+                " instances yet."
+            ));
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/resize.rs
+++ b/src/portable/resize.rs
@@ -160,7 +160,7 @@ fn resize_cloud_cmd(
     }
 
     let prompt = format!(
-        "Will resize the \"{inst_name}\" {BRANDING_CLOUD} instance as follows:\
+        "Will resize the {BRANDING_CLOUD} instance \"{inst_name}\" as follows:\
         \n\
         {resources_display}\
         \n\nContinue?",

--- a/src/portable/resize.rs
+++ b/src/portable/resize.rs
@@ -186,6 +186,6 @@ fn resize_cloud_cmd(
         "has been resized successfuly."
     );
     echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI_CMD, " -I", inst_name);
+    echo!("  ", BRANDING_CLI_CMD, "-I", inst_name);
     Ok(())
 }

--- a/src/portable/resize.rs
+++ b/src/portable/resize.rs
@@ -2,7 +2,7 @@ use color_print::cformat;
 
 use anyhow::Context;
 
-use crate::branding::{BRANDING, BRANDING_CLI, BRANDING_CLOUD};
+use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::cloud;
 use crate::portable::options::{InstanceName, Resize};
 use crate::print::echo;
@@ -186,6 +186,6 @@ fn resize_cloud_cmd(
         "has been resized successfuly."
     );
     echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI, " -I", inst_name);
+    echo!("  ", BRANDING_CLI_CMD, " -I", inst_name);
     Ok(())
 }

--- a/src/portable/resize.rs
+++ b/src/portable/resize.rs
@@ -2,6 +2,7 @@ use color_print::cformat;
 
 use anyhow::Context;
 
+use crate::branding::{BRANDING, BRANDING_CLI, BRANDING_CLOUD};
 use crate::cloud;
 use crate::portable::options::{InstanceName, Resize};
 use crate::print::echo;
@@ -11,7 +12,7 @@ pub fn resize(cmd: &Resize, opts: &crate::options::Options) -> anyhow::Result<()
     match &cmd.instance {
         InstanceName::Local(_) => Err(opts.error(
             clap::error::ErrorKind::InvalidValue,
-            cformat!("Only Cloud instances can be resized."),
+            cformat!("Only {BRANDING_CLOUD} instances can be resized."),
         ))?,
         InstanceName::Cloud {
             org_slug: org,
@@ -159,7 +160,7 @@ fn resize_cloud_cmd(
     }
 
     let prompt = format!(
-        "Will resize the \"{inst_name}\" Cloud instance as follows:\
+        "Will resize the \"{inst_name}\" {BRANDING_CLOUD} instance as follows:\
         \n\
         {resources_display}\
         \n\nContinue?",
@@ -179,11 +180,12 @@ fn resize_cloud_cmd(
         cloud::ops::resize_cloud_instance(&client, &request)?;
     }
     echo!(
-        "EdgeDB Cloud instance",
+        BRANDING_CLOUD,
+        " instance",
         inst_name,
         "has been resized successfuly."
     );
     echo!("To connect to the instance run:");
-    echo!("  edgedb -I", inst_name);
+    echo!("  ", BRANDING_CLI, " -I", inst_name);
     Ok(())
 }

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -102,7 +102,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
     }
 
     install::specific(&old_inst.get_version()?.specific())
-        .context("error installing old {BRANDING} version")?;
+        .context(concatcp!("error installing old ", BRANDING))?;
 
     let paths = Paths::get(name)?;
     let tmp_path = tmp_file_path(&paths.data_dir);

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -48,7 +48,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
             data_meta: Ok(d),
         } => (b, d),
     };
-    echo!("{BRANDING} version:", old_inst.get_version()?);
+    echo!(BRANDING, " version: ", old_inst.get_version()?);
     echo!(
         "Backup timestamp:",
         humantime::format_rfc3339(backup_info.timestamp),
@@ -105,7 +105,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
     fs::rename(&paths.backup_dir, &paths.data_dir)?;
 
     let inst = old_inst;
-    echo!("Starting {BRANDING}", inst.get_version()?, "...");
+    echo!("Starting ", BRANDING, " ", inst.get_version()?, "...");
 
     create::create_service(&inst)
         .map_err(|e| {

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -1,8 +1,9 @@
+use const_format::concatcp;
 use fs_err as fs;
 
 use anyhow::Context;
 
-use crate::branding::BRANDING;
+use crate::branding::{BRANDING, BRANDING_CLOUD};
 use crate::commands::ExitCode;
 use crate::format;
 use crate::platform::tmp_file_path;
@@ -29,7 +30,11 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error("This operation is not supported on cloud instances yet.");
+            print::error(concatcp!(
+                "This operation is not supported on ",
+                BRANDING_CLOUD,
+                " instances yet."
+            ));
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -48,7 +48,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
             data_meta: Ok(d),
         } => (b, d),
     };
-    echo!(BRANDING, " version: ", old_inst.get_version()?);
+    echo!(BRANDING, "version:", old_inst.get_version()?);
     echo!(
         "Backup timestamp:",
         humantime::format_rfc3339(backup_info.timestamp),
@@ -105,7 +105,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
     fs::rename(&paths.backup_dir, &paths.data_dir)?;
 
     let inst = old_inst;
-    echo!("Starting ", BRANDING, " ", inst.get_version()?, "...");
+    echo!("Starting", BRANDING, inst.get_version()?; "...");
 
     create::create_service(&inst)
         .map_err(|e| {

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -2,6 +2,7 @@ use fs_err as fs;
 
 use anyhow::Context;
 
+use crate::branding::BRANDING;
 use crate::commands::ExitCode;
 use crate::format;
 use crate::platform::tmp_file_path;
@@ -47,7 +48,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
             data_meta: Ok(d),
         } => (b, d),
     };
-    echo!("EdgeDB version:", old_inst.get_version()?);
+    echo!("{BRANDING} version:", old_inst.get_version()?);
     echo!(
         "Backup timestamp:",
         humantime::format_rfc3339(backup_info.timestamp),
@@ -96,7 +97,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
     }
 
     install::specific(&old_inst.get_version()?.specific())
-        .context("error installing old EdgeDB version")?;
+        .context("error installing old {BRANDING} version")?;
 
     let paths = Paths::get(name)?;
     let tmp_path = tmp_file_path(&paths.data_dir);
@@ -104,11 +105,11 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
     fs::rename(&paths.backup_dir, &paths.data_dir)?;
 
     let inst = old_inst;
-    echo!("Starting EdgeDB", inst.get_version()?, "...");
+    echo!("Starting {BRANDING}", inst.get_version()?, "...");
 
     create::create_service(&inst)
         .map_err(|e| {
-            log::warn!("Error running EdgeDB as a service: {e:#}");
+            log::warn!("Error running {BRANDING} as a service: {e:#}");
         })
         .ok();
 

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -18,6 +18,7 @@ use tokio::time::sleep;
 use crate::connect::Connection;
 use edgedb_tokio::{credentials::Credentials, Builder};
 
+use crate::branding::{BRANDING_CLI, BRANDING_CLOUD};
 use crate::cloud;
 use crate::cloud::client::CloudClient;
 use crate::collect::Collector;
@@ -845,7 +846,7 @@ impl RemoteStatus {
     pub fn print_extended(&self) {
         println!("{}:", self.name);
         let is_cloud = if let RemoteType::Cloud { instance_id } = &self.type_ {
-            println!("  Cloud Instance ID: {}", instance_id);
+            println!("  {BRANDING_CLOUD} Instance ID: {}", instance_id);
             true
         } else {
             false

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -18,7 +18,7 @@ use tokio::time::sleep;
 use crate::connect::Connection;
 use edgedb_tokio::{credentials::Credentials, Builder};
 
-use crate::branding::{BRANDING_CLI, BRANDING_CLOUD};
+use crate::branding::BRANDING_CLOUD;
 use crate::cloud;
 use crate::cloud::client::CloudClient;
 use crate::collect::Collector;

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -499,16 +499,19 @@ async fn _get_remote(
             get_remote_and_cloud(instances, cloud_client, errors),
             || {
                 if num > 0 {
-                    format!("Checking cloud and {} remote instances...", num)
+                    format!(
+                        "Checking {BRANDING_CLOUD} and {} remote instance(s)...",
+                        num
+                    )
                 } else {
-                    format!("Checking cloud instances...")
+                    format!("Checking {BRANDING_CLOUD} instances...")
                 }
             },
         )
         .await
     } else if num > 0 {
         intermediate_feedback(get_remote_async(instances, errors), || {
-            format!("Checking {} remote instances...", num)
+            format!("Checking {} remote instance(s)...", num)
         })
         .await
     } else {

--- a/src/portable/upgrade.rs
+++ b/src/portable/upgrade.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, SystemTime};
 use anyhow::Context;
 use fn_error_context::context;
 
+use crate::branding::{BRANDING, BRANDING_CLI, BRANDING_CLOUD};
 use crate::cloud;
 use crate::commands::{self, ExitCode};
 use crate::connect::{Connection, Connector};
@@ -58,7 +59,7 @@ pub fn print_project_upgrade_command(
     project_dir: &Path,
 ) {
     eprintln!(
-        "  edgedb project upgrade {}{}",
+        "  {BRANDING_CLI} project upgrade {}{}",
         match version.channel {
             Channel::Stable =>
                 if let Some(filt) = &version.version {
@@ -202,7 +203,7 @@ fn upgrade_cloud_cmd(
     match result.action {
         UpgradeAction::Upgraded => {
             echo!(format!(
-                "EdgeDB Cloud instance {inst_name} has been successfully \
+                "{BRANDING_CLOUD} instance {inst_name} has been successfully \
                 upgraded to version {target_ver_str}.",
             ));
         }
@@ -271,7 +272,7 @@ pub fn upgrade_cloud(
 
 pub fn upgrade_compatible(mut inst: InstanceInfo, pkg: PackageInfo) -> anyhow::Result<()> {
     echo!("Upgrading to a minor version", pkg.version.emphasize());
-    let install = install::package(&pkg).context("error installing EdgeDB")?;
+    let install = install::package(&pkg).context("error installing {BRANDING}")?;
     inst.installation = Some(install);
 
     let metapath = inst.data_dir()?.join("instance_info.json");
@@ -279,7 +280,7 @@ pub fn upgrade_compatible(mut inst: InstanceInfo, pkg: PackageInfo) -> anyhow::R
 
     create::create_service(&inst)
         .map_err(|e| {
-            log::warn!("Error running EdgeDB as a service: {e:#}");
+            log::warn!("Error running {BRANDING} as a service: {e:#}");
         })
         .ok();
     control::do_restart(&inst)?;
@@ -301,7 +302,7 @@ pub fn upgrade_incompatible(
 
     let old_version = inst.get_version()?.clone();
 
-    let install = install::package(&pkg).context("error installing EdgeDB")?;
+    let install = install::package(&pkg).context("error installing {BRANDING}")?;
 
     let paths = Paths::get(&inst.name)?;
     dump_and_stop(&inst, &paths.dump_path)?;
@@ -345,7 +346,10 @@ pub fn upgrade_incompatible(
 
     reinit_and_restore(&inst, &paths).map_err(|e| {
         print::error(format!("{:#}", e));
-        eprintln!("To undo run:\n  edgedb instance revert -I {:?}", inst.name);
+        eprintln!(
+            "To undo run:\n  {BRANDING_CLI} instance revert -I {:?}",
+            inst.name
+        );
         ExitCode::new(exit_codes::NEEDS_REVERT)
     })?;
 
@@ -354,7 +358,7 @@ pub fn upgrade_incompatible(
 
     create::create_service(&inst)
         .map_err(|e| {
-            log::warn!("Error running EdgeDB as a service: {e:#}");
+            log::warn!("Error running {BRANDING} as a service: {e:#}");
         })
         .ok();
     control::do_restart(&inst)?;

--- a/src/portable/upgrade.rs
+++ b/src/portable/upgrade.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, SystemTime};
 use anyhow::Context;
 use fn_error_context::context;
 
-use crate::branding::{BRANDING, BRANDING_CLI, BRANDING_CLOUD};
+use crate::branding::{BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::cloud;
 use crate::commands::{self, ExitCode};
 use crate::connect::{Connection, Connector};
@@ -59,7 +59,7 @@ pub fn print_project_upgrade_command(
     project_dir: &Path,
 ) {
     eprintln!(
-        "  {BRANDING_CLI} project upgrade {}{}",
+        "  {BRANDING_CLI_CMD} project upgrade {}{}",
         match version.channel {
             Channel::Stable =>
                 if let Some(filt) = &version.version {
@@ -347,7 +347,7 @@ pub fn upgrade_incompatible(
     reinit_and_restore(&inst, &paths).map_err(|e| {
         print::error(format!("{:#}", e));
         eprintln!(
-            "To undo run:\n  {BRANDING_CLI} instance revert -I {:?}",
+            "To undo run:\n  {BRANDING_CLI_CMD} instance revert -I {:?}",
             inst.name
         );
         ExitCode::new(exit_codes::NEEDS_REVERT)

--- a/src/portable/upgrade.rs
+++ b/src/portable/upgrade.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
 use anyhow::Context;
+use const_format::concatcp;
 use fn_error_context::context;
 
 use crate::branding::{BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD};
@@ -272,7 +273,7 @@ pub fn upgrade_cloud(
 
 pub fn upgrade_compatible(mut inst: InstanceInfo, pkg: PackageInfo) -> anyhow::Result<()> {
     echo!("Upgrading to a minor version", pkg.version.emphasize());
-    let install = install::package(&pkg).context("error installing {BRANDING}")?;
+    let install = install::package(&pkg).context(concatcp!("error installing ", BRANDING))?;
     inst.installation = Some(install);
 
     let metapath = inst.data_dir()?.join("instance_info.json");
@@ -302,7 +303,7 @@ pub fn upgrade_incompatible(
 
     let old_version = inst.get_version()?.clone();
 
-    let install = install::package(&pkg).context("error installing {BRANDING}")?;
+    let install = install::package(&pkg).context(concatcp!("error installing ", BRANDING))?;
 
     let paths = Paths::get(&inst.name)?;
     dump_and_stop(&inst, &paths.dump_path)?;

--- a/src/portable/upgrade.rs
+++ b/src/portable/upgrade.rs
@@ -84,7 +84,6 @@ fn check_project(name: &str, force: bool, ver_query: &Query) -> anyhow::Result<(
     }
 
     project::print_instance_in_use_warning(name, &project_dirs);
-    let current_project = project::project_dir_opt(None)?;
 
     if force {
         eprintln!(
@@ -96,7 +95,7 @@ fn check_project(name: &str, force: bool, ver_query: &Query) -> anyhow::Result<(
     }
     for pd in project_dirs {
         let pd = project::read_project_path(&pd)?;
-        print_project_upgrade_command(ver_query, &current_project, &pd);
+        print_project_upgrade_command(ver_query, &None, &pd);
     }
     if !force {
         anyhow::bail!("Upgrade aborted.");

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -3,9 +3,11 @@ use std::fmt;
 use std::str::FromStr;
 
 use anyhow::Context;
+use const_format::concatcp;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
+use crate::branding::BRANDING_CLI_CMD;
 use crate::connect::Connection;
 use crate::portable::repository::Query;
 use crate::print::{echo, Highlight};
@@ -97,11 +99,13 @@ impl FromStr for Build {
 impl FromStr for Specific {
     type Err = anyhow::Error;
     fn from_str(value: &str) -> anyhow::Result<Specific> {
-        let m = SPECIFIC.captures(value).context(
+        let m = SPECIFIC.captures(value).context(concatcp!(
             "unsupported version format.\n\t\
                     Examples: `1.15`, `7.0`, `4.0-rc.1`.\n\t\
-                    Use `edgedb server list-versions` to see all available versions.",
-        )?;
+                    Use `",
+            BRANDING_CLI_CMD,
+            " server list-versions` to see all available versions."
+        ))?;
         let major = m.get(1).unwrap().as_str().parse()?;
         let g3 = m.get(3).map(|m| m.as_str().parse()).transpose()?;
         let minor = match m.get(2).map(|m| m.as_str()) {
@@ -130,7 +134,7 @@ impl FromStr for Filter {
                 None => anyhow::bail!(
                     "unsupported version format.\n\t\
                     Examples: `1.15`, `7`, `4.0-rc.1`.\n\t\
-                    Use `edgedb server list-versions` to see all available versions."
+                    Use `{BRANDING_CLI_CMD} server list-versions` to see all available versions."
                 ),
             },
         };

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -15,7 +15,7 @@ use once_cell::sync::{Lazy, OnceCell};
 use url::Url;
 
 use crate::async_util;
-use crate::branding::BRANDING;
+use crate::branding::{BRANDING, BRANDING_CLI};
 use crate::bug;
 use crate::cli::upgrade::{self, self_version};
 use crate::collect::Collector;

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -15,6 +15,7 @@ use once_cell::sync::{Lazy, OnceCell};
 use url::Url;
 
 use crate::async_util;
+use crate::branding::BRANDING;
 use crate::bug;
 use crate::cli::upgrade::{self, self_version};
 use crate::collect::Collector;
@@ -34,7 +35,7 @@ use crate::portable::ver;
 use crate::print::{self, echo, Highlight};
 use crate::process;
 
-const CURRENT_DISTRO: &str = "EdgeDB.WSL.1";
+const CURRENT_DISTRO: &str = "{BRANDING}.WSL.1";
 static DISTRO_URL: Lazy<Url> = Lazy::new(|| {
     "https://aka.ms/wsl-debian-gnulinux"
         .parse()
@@ -330,7 +331,7 @@ fn wsl_cli_version(distro: &str) -> anyhow::Result<ver::Semver> {
         .get_stdout_text()?;
     let version = data
         .trim()
-        .strip_prefix("EdgeDB CLI ")
+        .strip_prefix("{BRANDING} CLI ")
         .with_context(|| format!("bad version info returned by linux CLI: {:?}", data))?
         .parse()?;
     Ok(version)
@@ -729,7 +730,7 @@ pub fn uninstall(options: &options::Uninstall) -> anyhow::Result<()> {
     } else {
         log::warn!(
             "WSL distribution is not installed, \
-                   so no EdgeDB server versions are present."
+                   so no {BRANDING} server versions are present."
         );
     }
     Ok(())
@@ -747,7 +748,7 @@ pub fn list_versions(options: &options::ListVersions) -> anyhow::Result<()> {
     } else {
         log::warn!(
             "WSL distribution is not installed, \
-                   so no EdgeDB server versions are present."
+                   so no {BRANDING} server versions are present."
         );
     }
     Ok(())
@@ -759,7 +760,7 @@ pub fn info(options: &options::Info) -> anyhow::Result<()> {
     } else {
         anyhow::bail!(
             "WSL distribution is not installed, \
-                       so no EdgeDB server versions are present."
+                       so no {BRANDING} server versions are present."
         );
     }
     Ok(())
@@ -776,7 +777,7 @@ pub fn reset_password(options: &options::ResetPassword, name: &str) -> anyhow::R
     } else {
         anyhow::bail!(
             "WSL distribution is not installed, \
-                       so no EdgeDB instances are present."
+                       so no {BRANDING} instances are present."
         );
     }
     Ok(())
@@ -796,7 +797,7 @@ pub fn start(options: &options::Start, name: &str) -> anyhow::Result<()> {
     } else {
         anyhow::bail!(
             "WSL distribution is not installed, \
-                       so no EdgeDB instances are present."
+                       so no {BRANDING} instances are present."
         );
     }
     Ok(())
@@ -816,7 +817,7 @@ pub fn stop(options: &options::Stop, name: &str) -> anyhow::Result<()> {
     } else {
         anyhow::bail!(
             "WSL distribution is not installed, \
-                       so no EdgeDB instances are present."
+                       so no {BRANDING} instances are present."
         );
     }
     Ok(())
@@ -832,7 +833,7 @@ pub fn restart(options: &options::Restart) -> anyhow::Result<()> {
     } else {
         anyhow::bail!(
             "WSL distribution is not installed, \
-                       so no EdgeDB instances are present."
+                       so no {BRANDING} instances are present."
         );
     }
     Ok(())
@@ -848,7 +849,7 @@ pub fn logs(options: &options::Logs) -> anyhow::Result<()> {
     } else {
         anyhow::bail!(
             "WSL distribution is not installed, \
-                       so no EdgeDB instances are present."
+                       so no {BRANDING} instances are present."
         );
     }
     Ok(())
@@ -865,7 +866,7 @@ pub fn status(options: &options::Status) -> anyhow::Result<()> {
         } else {
             echo!(
                 "WSL distribution is not installed, \
-                   so no EdgeDB instances are present."
+                   so no {BRANDING} instances are present."
             );
             return Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into());
         }

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -15,7 +15,7 @@ use once_cell::sync::{Lazy, OnceCell};
 use url::Url;
 
 use crate::async_util;
-use crate::branding::{BRANDING, BRANDING_CLI};
+use crate::branding::{BRANDING, BRANDING_CLI, BRANDING_WSL};
 use crate::bug;
 use crate::cli::upgrade::{self, self_version};
 use crate::collect::Collector;
@@ -35,7 +35,7 @@ use crate::portable::ver;
 use crate::print::{self, echo, Highlight};
 use crate::process;
 
-const CURRENT_DISTRO: &str = "{BRANDING}.WSL.1";
+const CURRENT_DISTRO: &str = BRANDING_WSL;
 static DISTRO_URL: Lazy<Url> = Lazy::new(|| {
     "https://aka.ms/wsl-debian-gnulinux"
         .parse()

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -321,6 +321,8 @@ fn wsl_check_cli(_wsl: &wslapi::Library, wsl_info: &WslInfo) -> anyhow::Result<b
 #[context("cannot check linux CLI version")]
 fn wsl_cli_version(distro: &str) -> anyhow::Result<ver::Semver> {
     // Note: cannot capture output using wsl.launch
+
+    use const_format::concatcp;
     let data = process::Native::new("check version", "edgedb", "wsl")
         .arg("--user")
         .arg("edgedb")
@@ -331,7 +333,7 @@ fn wsl_cli_version(distro: &str) -> anyhow::Result<ver::Semver> {
         .get_stdout_text()?;
     let version = data
         .trim()
-        .strip_prefix("{BRANDING} CLI ")
+        .strip_prefix(concatcp!(BRANDING_CLI, " "))
         .with_context(|| format!("bad version info returned by linux CLI: {:?}", data))?
         .parse()?;
     Ok(version)

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -926,7 +926,7 @@ fn list_local(options: &options::List) -> anyhow::Result<Vec<status::JsonStatus>
             .args(&inner_opts)
             .get_stdout_text()?;
         log::info!("WSL list returned {:?}", text);
-        serde_json::from_str(&text).context("cannot decode json from edgedb CLI in WSL")?
+        serde_json::from_str(&text).context("cannot decode json from `instance list` in WSL")?
     } else {
         Vec::new()
     };

--- a/src/print/color.rs
+++ b/src/print/color.rs
@@ -4,7 +4,7 @@ use colorful::core::ColorInterface;
 use colorful::Color;
 
 static THEME: once_cell::sync::Lazy<Theme> = once_cell::sync::Lazy::new(|| {
-    if clicolors_control::colors_enabled() {
+    if concolor::get(concolor::Stream::Stdout).color() {
         Theme {
             fade: Some(Style {
                 color: Color::Grey37,

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -12,7 +12,7 @@ use tokio_stream::{Stream, StreamExt};
 
 use edgedb_errors::display::display_error;
 
-use crate::branding::BRANDING_CLI;
+use crate::branding::BRANDING_CLI_CMD;
 use crate::repl::VectorLimit;
 
 pub use crate::echo;
@@ -392,7 +392,7 @@ pub fn prompt(line: impl fmt::Display) {
 }
 
 pub fn err_marker() -> impl fmt::Display {
-    concatcp!(BRANDING_CLI, " error:").err_marker()
+    concatcp!(BRANDING_CLI_CMD, " error:").err_marker()
 }
 
 pub fn error(line: impl fmt::Display) {

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::io;
 
 use colorful::{Color, Colorful};
+use const_format::concatcp;
 use is_terminal::IsTerminal;
 use snafu::{AsErrorSource, ResultExt, Snafu};
 use terminal_size::{terminal_size, Width};
@@ -11,6 +12,7 @@ use tokio_stream::{Stream, StreamExt};
 
 use edgedb_errors::display::display_error;
 
+use crate::branding::BRANDING_CLI;
 use crate::repl::VectorLimit;
 
 pub use crate::echo;
@@ -390,7 +392,7 @@ pub fn prompt(line: impl fmt::Display) {
 }
 
 pub fn err_marker() -> impl fmt::Display {
-    "edgedb error:".err_marker()
+    concatcp!(BRANDING_CLI, " error:").err_marker()
 }
 
 pub fn error(line: impl fmt::Display) {

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -380,7 +380,7 @@ pub fn json_item_to_string<I: FormatExt>(item: &I, config: &Config) -> Result<St
 }
 
 pub fn use_color() -> bool {
-    clicolors_control::colors_enabled()
+    concolor::get(concolor::Stream::Stdout).color()
 }
 
 pub fn prompt(line: impl fmt::Display) {

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -380,7 +380,7 @@ pub fn json_item_to_string<I: FormatExt>(item: &I, config: &Config) -> Result<St
 }
 
 pub fn use_color() -> bool {
-    concolor::get(concolor::Stream::Stdout).color()
+    concolor::get(concolor::Stream::Stdout).ansi_color()
 }
 
 pub fn prompt(line: impl fmt::Display) {

--- a/src/process.rs
+++ b/src/process.rs
@@ -179,7 +179,7 @@ impl Native {
             program: cmd.as_ref().as_os_str().to_os_string(),
             args: vec![cmd.as_ref().as_os_str().to_os_string()],
             envs: HashMap::new(),
-            proxy: clicolors_control::colors_enabled(),
+            proxy: concolor::get(concolor::Stream::Stdout).color(),
             quiet: false,
             stop_process: None,
             pid_file: None,

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -18,6 +18,7 @@ use edgedb_protocol::value::Value;
 
 use crate::analyze;
 use crate::async_util::timeout;
+use crate::branding::BRANDING;
 use crate::connect::Connection;
 use crate::connect::Connector;
 use crate::echo;
@@ -164,7 +165,7 @@ impl State {
     }
     fn print_banner(&self, version: &ver::Build) -> anyhow::Result<()> {
         echo!(
-            format!("{}\rEdgeDB", ansi_escapes::EraseLine).light_gray(),
+            format!("{}\r{BRANDING}", ansi_escapes::EraseLine).light_gray(),
             version.to_string().light_gray(),
             format_args!("(repl {})", env!("CARGO_PKG_VERSION")).fade(),
         );

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -8,6 +8,7 @@ use fn_error_context::context;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 
+use crate::branding::BRANDING_CLI;
 use crate::cli;
 use crate::platform;
 use crate::portable::repository;
@@ -56,14 +57,14 @@ fn write_cache(dir: &Path, data: &Cache) -> anyhow::Result<()> {
 fn newer_warning(ver: &ver::Semver) {
     if cli::upgrade::can_upgrade() {
         eprintln!(
-            "Newer version of edgedb tool exists {} (current {}). \
-                To upgrade run `edgedb cli upgrade`",
+            "Newer version of {BRANDING_CLI} tool exists {} (current {}). \
+                To upgrade run `{BRANDING_CLI} cli upgrade`",
             ver,
             env!("CARGO_PKG_VERSION")
         );
     } else {
         eprintln!(
-            "Newer version of edgedb tool exists {} (current {})",
+            "Newer version of {BRANDING_CLI} tool exists {} (current {})",
             ver,
             env!("CARGO_PKG_VERSION")
         );

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -8,7 +8,7 @@ use fn_error_context::context;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 
-use crate::branding::BRANDING_CLI;
+use crate::branding::BRANDING_CLI_CMD;
 use crate::cli;
 use crate::platform;
 use crate::portable::repository;
@@ -57,14 +57,14 @@ fn write_cache(dir: &Path, data: &Cache) -> anyhow::Result<()> {
 fn newer_warning(ver: &ver::Semver) {
     if cli::upgrade::can_upgrade() {
         eprintln!(
-            "Newer version of {BRANDING_CLI} tool exists {} (current {}). \
-                To upgrade run `{BRANDING_CLI} cli upgrade`",
+            "Newer version of {BRANDING_CLI_CMD} tool exists {} (current {}). \
+                To upgrade run `{BRANDING_CLI_CMD} cli upgrade`",
             ver,
             env!("CARGO_PKG_VERSION")
         );
     } else {
         eprintln!(
-            "Newer version of {BRANDING_CLI} tool exists {} (current {})",
+            "Newer version of {BRANDING_CLI_CMD} tool exists {} (current {})",
             ver,
             env!("CARGO_PKG_VERSION")
         );

--- a/src/watch/main.rs
+++ b/src/watch/main.rs
@@ -70,10 +70,7 @@ pub fn watch(options: &Options, _watch: &WatchCommand) -> anyhow::Result<()> {
         .ok();
         tx.send(()).unwrap();
     })?;
-    watch.watch(
-        &project_path,
-        RecursiveMode::NonRecursive,
-    )?;
+    watch.watch(&project_path, RecursiveMode::NonRecursive)?;
     watch.watch(&ctx.migration.schema_dir, RecursiveMode::Recursive)?;
 
     runtime.block_on(ctx.do_update())?;

--- a/src/watch/main.rs
+++ b/src/watch/main.rs
@@ -1,5 +1,6 @@
 use std::time::{Duration, Instant};
 
+use const_format::concatcp;
 use edgedb_tokio::{get_project_path, Error};
 use edgeql_parser::helpers::quote_string;
 use indicatif::ProgressBar;
@@ -151,7 +152,7 @@ impl WatchContext {
     async fn do_update(&mut self) -> anyhow::Result<()> {
         let bar = ProgressBar::new_spinner();
         bar.enable_steady_tick(Duration::from_millis(100));
-        // TODO(tailhook) check edgedb version
+        // TODO(tailhook) check gel/edgedb version
         bar.set_message("connecting");
         let mut cli = self.connector.connect().await?;
 
@@ -198,9 +199,13 @@ impl From<anyhow::Error> for ErrorJson {
                     err.initial_message().unwrap_or(""),
                 ),
                 hint: Some(
-                    "see the window running \
-                           `edgedb watch` for more info"
-                        .into(),
+                    concatcp!(
+                        "see the window running \
+                           `",
+                        BRANDING_CLI_CMD,
+                        "watch` for more info"
+                    )
+                    .into(),
                 ),
                 details: None,
                 context: None, // TODO(tailhook)
@@ -214,9 +219,13 @@ impl From<anyhow::Error> for ErrorJson {
                     err
                 ),
                 hint: Some(
-                    "see the window running \
-                           `edgedb watch` for more info"
-                        .into(),
+                    concatcp!(
+                        "see the window running \
+                           `",
+                        BRANDING_CLI_CMD,
+                        " watch` for more info"
+                    )
+                    .into(),
                 ),
                 details: None,
                 context: None,

--- a/src/watch/main.rs
+++ b/src/watch/main.rs
@@ -7,7 +7,7 @@ use notify::{RecursiveMode, Watcher};
 use tokio::sync::watch;
 use tokio::time::timeout;
 
-use crate::branding::{BRANDING, BRANDING_CLI};
+use crate::branding::{BRANDING, BRANDING_CLI_CMD};
 use crate::connect::{Connection, Connector};
 use crate::interrupt::Interrupt;
 use crate::migrations::{self, dev_mode};
@@ -52,8 +52,8 @@ pub fn watch(options: &Options, _watch: &WatchCommand) -> anyhow::Result<()> {
     let project_path = match runtime.block_on(get_project_path(None, true))? {
         Some(proj) => proj,
         None => anyhow::bail!(
-            "The `{BRANDING_CLI} watch` command currently only \
-             works for projects. Run `{BRANDING_CLI} project init` first."
+            "The `{BRANDING_CLI_CMD} watch` command currently only \
+             works for projects. Run `{BRANDING_CLI_CMD} project init` first."
         ),
     };
     let mut ctx = WatchContext {
@@ -77,7 +77,7 @@ pub fn watch(options: &Options, _watch: &WatchCommand) -> anyhow::Result<()> {
     runtime.block_on(ctx.do_update())?;
 
     eprintln!("{BRANDING} Watch initialized.");
-    eprintln!("  Hint: Use `{BRANDING_CLI} migration create` and `{BRANDING_CLI} migrate --dev-mode` to apply changes once done.");
+    eprintln!("  Hint: Use `{BRANDING_CLI_CMD} migration create` and `{BRANDING_CLI_CMD} migrate --dev-mode` to apply changes once done.");
     eprintln!("Monitoring {:?}.", project_dir);
     let res = runtime.block_on(watch_loop(rx, &mut ctx));
     runtime

--- a/src/watch/main.rs
+++ b/src/watch/main.rs
@@ -7,6 +7,7 @@ use notify::{RecursiveMode, Watcher};
 use tokio::sync::watch;
 use tokio::time::timeout;
 
+use crate::branding::{BRANDING, BRANDING_CLI};
 use crate::connect::{Connection, Connector};
 use crate::interrupt::Interrupt;
 use crate::migrations::{self, dev_mode};
@@ -51,8 +52,8 @@ pub fn watch(options: &Options, _watch: &WatchCommand) -> anyhow::Result<()> {
     let project_path = match runtime.block_on(get_project_path(None, true))? {
         Some(proj) => proj,
         None => anyhow::bail!(
-            "The `edgedb watch` command currently only \
-             works for projects. Run `edgedb project init` first."
+            "The `{BRANDING_CLI} watch` command currently only \
+             works for projects. Run `{BRANDING_CLI} project init` first."
         ),
     };
     let mut ctx = WatchContext {
@@ -75,8 +76,8 @@ pub fn watch(options: &Options, _watch: &WatchCommand) -> anyhow::Result<()> {
 
     runtime.block_on(ctx.do_update())?;
 
-    eprintln!("EdgeDB Watch initialized.");
-    eprintln!("  Hint: Use `edgedb migration create` and `edgedb migrate --dev-mode` to apply changes once done.");
+    eprintln!("{BRANDING} Watch initialized.");
+    eprintln!("  Hint: Use `{BRANDING_CLI} migration create` and `{BRANDING_CLI} migrate --dev-mode` to apply changes once done.");
     eprintln!("Monitoring {:?}.", project_dir);
     let res = runtime.block_on(watch_loop(rx, &mut ctx));
     runtime

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -1,4 +1,14 @@
+#![allow(unused)]
+
 use assert_cmd::assert::Assert;
+
+use const_format::concatcp;
+
+#[path = "../../src/branding.rs"]
+mod branding;
+
+pub const EXPECTED_VERSION: &str =
+    concatcp!(branding::BRANDING_CLI, " ", env!("CARGO_PKG_VERSION"));
 
 pub trait OutputExt {
     fn context(self, name: &'static str, description: &'static str) -> Self;

--- a/tests/docker_test_wrapper.rs
+++ b/tests/docker_test_wrapper.rs
@@ -98,7 +98,7 @@ fn dockerfile() -> String {
             ca-certificates sudo gnupg2 apt-transport-https curl \
             software-properties-common dbus-user-session
         RUN adduser --uid 2000 --home /home/user1 \
-            --shell /bin/bash --ingroup users --gecos "EdgeDB Test User" \
+            --shell /bin/bash --ingroup users --gecos "Test User" \
             user1
         RUN mkdir /home/edgedb && chown user1 /home/edgedb
         ADD ./edgedb /usr/bin/edgedb

--- a/tests/func/main.rs
+++ b/tests/func/main.rs
@@ -83,7 +83,7 @@ fn simple_query() {
 fn version() {
     let cmd = SERVER.admin_cmd().arg("--version").assert();
     cmd.success()
-        .stdout(concat!("EdgeDB CLI ", env!("CARGO_PKG_VERSION"), "\n"));
+        .stdout(concat!("{BRANDING} CLI ", env!("CARGO_PKG_VERSION"), "\n"));
 }
 
 impl ServerGuard {

--- a/tests/func/main.rs
+++ b/tests/func/main.rs
@@ -2,7 +2,10 @@
 #[macro_use]
 extern crate pretty_assertions;
 
-use std::env;
+#[path = "../common/util.rs"]
+mod util;
+use util::*;
+
 use std::fs;
 use std::path::Path;
 use std::process;
@@ -30,8 +33,6 @@ mod non_interactive;
 mod interactive;
 
 mod help;
-#[path = "../common/util.rs"]
-mod util;
 
 fn edgedb_cli_cmd() -> assert_cmd::Command {
     let mut cmd = Command::cargo_bin("edgedb").expect("binary found");
@@ -83,7 +84,7 @@ fn simple_query() {
 fn version() {
     let cmd = SERVER.admin_cmd().arg("--version").assert();
     cmd.success()
-        .stdout(concat!("{BRANDING} CLI ", env!("CARGO_PKG_VERSION"), "\n"));
+        .stdout(predicates::str::contains(EXPECTED_VERSION));
 }
 
 impl ServerGuard {

--- a/tests/github-actions/install.rs
+++ b/tests/github-actions/install.rs
@@ -93,7 +93,7 @@ fn github_action_install() -> anyhow::Result<()> {
             .context("curl shebang", "command-line install")
             .success()
             .stdout(predicates::str::contains(
-                "The EdgeDB command-line tool is now installed",
+                "The {BRANDING} command-line tool is now installed",
             ));
     }
 
@@ -114,7 +114,7 @@ fn github_action_install() -> anyhow::Result<()> {
         .context("version", "command-line version option")
         .success()
         .stdout(predicates::str::contains(concat!(
-            "EdgeDB CLI ",
+            "{BRANDING} CLI ",
             env!("CARGO_PKG_VERSION")
         )));
 

--- a/tests/github-actions/install.rs
+++ b/tests/github-actions/install.rs
@@ -97,7 +97,7 @@ fn github_action_install() -> anyhow::Result<()> {
             .context("curl shebang", "command-line install")
             .success()
             .stdout(predicates::str::contains(
-                "The {BRANDING} command-line tool is now installed",
+                "command-line tool is now installed",
             ));
     }
 

--- a/tests/github-actions/install.rs
+++ b/tests/github-actions/install.rs
@@ -6,6 +6,10 @@ use tokio::sync::oneshot;
 use warp::filters::path::path;
 use warp::Filter;
 
+#[path = "../common/util.rs"]
+mod util;
+use util::*;
+
 use crate::certs::Certs;
 
 const UNIX_INST: &str = "curl --proto '=https' --tlsv1.2 -sSf https://localhost:8443 | sh -s -- -y";
@@ -113,10 +117,7 @@ fn github_action_install() -> anyhow::Result<()> {
         .assert()
         .context("version", "command-line version option")
         .success()
-        .stdout(predicates::str::contains(concat!(
-            "{BRANDING} CLI ",
-            env!("CARGO_PKG_VERSION")
-        )));
+        .stdout(predicates::str::contains(EXPECTED_VERSION));
 
     if !cfg!(windows) {
         Command::new(&edgedb)

--- a/tests/github-nightly/common.rs
+++ b/tests/github-nightly/common.rs
@@ -13,7 +13,7 @@ pub fn dock_ubuntu(codename: &str) -> String {
            stable"
         RUN apt-get update && apt-get install -y docker-ce-cli
         RUN adduser --uid 1000 --home /home/user1 \
-            --shell /bin/bash --ingroup users --gecos "EdgeDB Test User" \
+            --shell /bin/bash --ingroup users --gecos "Test User" \
             user1
         ADD ./edgedb /usr/bin/edgedb
         ADD ./sudoers /etc/sudoers
@@ -38,7 +38,7 @@ pub fn dock_ubuntu_jspy(codename: &str) -> String {
            stable"
         RUN apt-get update && apt-get install -y docker-ce-cli
         RUN adduser --uid 1000 --home /home/user1 \
-            --shell /bin/bash --ingroup users --gecos "EdgeDB Test User" \
+            --shell /bin/bash --ingroup users --gecos "Test User" \
             user1
         RUN pip3 install edgedb
         RUN npm install edgedb
@@ -85,7 +85,7 @@ pub fn dock_debian(codename: &str) -> String {
            stable"
         RUN apt-get update && apt-get install -y docker-ce-cli
         RUN adduser --uid 1000 --home /home/user1 \
-            --shell /bin/bash --ingroup users --gecos "EdgeDB Test User" \
+            --shell /bin/bash --ingroup users --gecos "Test User" \
             user1
         ADD ./edgedb /usr/bin/edgedb
         ADD ./sudoers /etc/sudoers

--- a/tests/portable_project.rs
+++ b/tests/portable_project.rs
@@ -15,7 +15,7 @@ fn project_link_and_init() {
         .context("version", "command-line version option")
         .success()
         .stdout(predicates::str::contains(concat!(
-            "EdgeDB CLI ",
+            "{BRANDING} CLI ",
             env!("CARGO_PKG_VERSION")
         )));
 

--- a/tests/portable_project.rs
+++ b/tests/portable_project.rs
@@ -14,10 +14,7 @@ fn project_link_and_init() {
         .assert()
         .context("version", "command-line version option")
         .success()
-        .stdout(predicates::str::contains(concat!(
-            "{BRANDING} CLI ",
-            env!("CARGO_PKG_VERSION")
-        )));
+        .stdout(predicates::str::contains(EXPECTED_VERSION));
 
     Command::new("edgedb")
         .arg("server")

--- a/tests/portable_project_dir.rs
+++ b/tests/portable_project_dir.rs
@@ -15,7 +15,7 @@ fn project_link_and_init_from_non_project_dir() {
         .context("version", "command-line version option")
         .success()
         .stdout(predicates::str::contains(concat!(
-            "EdgeDB CLI ",
+            "{BRANDING} CLI ",
             env!("CARGO_PKG_VERSION")
         )));
 

--- a/tests/portable_project_dir.rs
+++ b/tests/portable_project_dir.rs
@@ -14,10 +14,7 @@ fn project_link_and_init_from_non_project_dir() {
         .assert()
         .context("version", "command-line version option")
         .success()
-        .stdout(predicates::str::contains(concat!(
-            "{BRANDING} CLI ",
-            env!("CARGO_PKG_VERSION")
-        )));
+        .stdout(predicates::str::contains(EXPECTED_VERSION));
 
     Command::new("edgedb")
         .arg("server")

--- a/tests/portable_smoke.rs
+++ b/tests/portable_smoke.rs
@@ -14,10 +14,7 @@ fn install() {
         .assert()
         .context("version", "command-line version option")
         .success()
-        .stdout(predicates::str::contains(concat!(
-            "{BRANDING} CLI ",
-            env!("CARGO_PKG_VERSION")
-        )));
+        .stdout(predicates::str::contains(EXPECTED_VERSION));
 
     Command::new("edgedb")
         .arg("instance")

--- a/tests/portable_smoke.rs
+++ b/tests/portable_smoke.rs
@@ -15,7 +15,7 @@ fn install() {
         .context("version", "command-line version option")
         .success()
         .stdout(predicates::str::contains(concat!(
-            "EdgeDB CLI ",
+            "{BRANDING} CLI ",
             env!("CARGO_PKG_VERSION")
         )));
 

--- a/tests/proj/project1/edgedb.toml
+++ b/tests/proj/project1/edgedb.toml
@@ -1,0 +1,2 @@
+[edgedb]
+server-version = "nightly"

--- a/tests/proj/project1/edgedb.toml
+++ b/tests/proj/project1/edgedb.toml
@@ -1,2 +1,0 @@
-[edgedb]
-server-version = "nightly"

--- a/tests/proj/project2/dbschema/default.esdl
+++ b/tests/proj/project2/dbschema/default.esdl
@@ -1,3 +1,0 @@
-module default {
-
-}

--- a/tests/proj/project2/dbschema/default.esdl
+++ b/tests/proj/project2/dbschema/default.esdl
@@ -1,0 +1,3 @@
+module default {
+
+}

--- a/tests/proj/project2/edgedb.toml
+++ b/tests/proj/project2/edgedb.toml
@@ -1,2 +1,0 @@
-[edgedb]
-server-version = "5.6"

--- a/tests/proj/project2/edgedb.toml
+++ b/tests/proj/project2/edgedb.toml
@@ -1,0 +1,2 @@
+[edgedb]
+server-version = "5.6"

--- a/tests/shared-client-tests/build.rs
+++ b/tests/shared-client-tests/build.rs
@@ -65,7 +65,7 @@ fn main() {
         ),
         (
             "no_options_or_toml",
-            "no `edgedb.toml` found and no connection options are specified",
+            "no .*toml.* found and no connection options are specified",
         ),
         (
             "multiple_compound_opts",

--- a/tests/shared-client-tests/tests/shared_client_tests.rs
+++ b/tests/shared-client-tests/tests/shared_client_tests.rs
@@ -148,7 +148,7 @@ fn mock_project(
 
 fn ensure_dir(path: &Path) {
     if !path.exists() {
-        fs::create_dir_all(path).unwrap_or_else(|_| panic!("mkdir -p {:?}", path));
+        fs::create_dir_all(path).unwrap_or_else(|err| panic!("mkdir -p {:?}: {:?}", path, err));
     }
 }
 


### PR DESCRIPTION
Paves the way for a rename patch where we can rename EdgeDB to Gel in one swoop. Each use of EdgeDB is parameterized.

`EdgeDB cloud` strings have become `BRANDING_CLOUD`.

This patch doesn't perform the rename yet. We also don't perform any directory or configuration file migrations yet. We do, however, set the default config file to `gel.toml`.

Review notes:

 - `format`/`println`/`cformat`/`log` support `{}`
 - `print::` and `echo!` must use `concatcp!`
 