### PR TITLE
Remove one style of printing from CLI

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -23,7 +23,7 @@ use crate::platform::{binary_path, config_dir, home_dir};
 use crate::portable::platform;
 use crate::portable::project::project_dir;
 use crate::portable::project::{self, Init};
-use crate::print::{self, msg};
+use crate::print::{self};
 use crate::print_markdown;
 use crate::process;
 use crate::question::{self, read_choice};
@@ -452,16 +452,12 @@ fn _main(options: &CliInstall) -> anyhow::Result<()> {
     if !options.no_confirm {
         match home_dir_from_passwd().zip(env::var_os("HOME")) {
             Some((passwd, env)) if passwd != env => {
-                msg!(
-                    "$HOME differs from euid-obtained home directory: \
-                       you may be using sudo"
-                );
+                msg!("$HOME differs from euid-obtained home directory: \
+                       you may be using sudo");
                 msg!("$HOME directory: {}", Path::new(&env).display());
                 msg!("euid-obtained home directory: {}", passwd.display());
-                msg!(
-                    "if this is what you want, \
-                       restart the installation with `-y'"
-                );
+                msg!("if this is what you want, \
+                       restart the installation with `-y'");
                 return Err(ExitCode::new(1).into());
             }
             _ => {}
@@ -499,10 +495,7 @@ fn _main(options: &CliInstall) -> anyhow::Result<()> {
     }
 
     if cfg!(all(target_os = "macos", target_arch = "x86_64")) && platform::is_arm64_hardware() {
-        msg!(
-            "{} now supports native M1 build. Downloading binary...",
-            BRANDING
-        );
+        msg!("{BRANDING} now supports native M1 build. Downloading binary...");
         return upgrade::upgrade_to_arm64();
     }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -23,7 +23,7 @@ use crate::platform::{binary_path, config_dir, home_dir};
 use crate::portable::platform;
 use crate::portable::project::project_dir;
 use crate::portable::project::{self, Init};
-use crate::print::{self, echo};
+use crate::print::{self, msg};
 use crate::print_markdown;
 use crate::process;
 use crate::question::{self, read_choice};
@@ -452,13 +452,13 @@ fn _main(options: &CliInstall) -> anyhow::Result<()> {
     if !options.no_confirm {
         match home_dir_from_passwd().zip(env::var_os("HOME")) {
             Some((passwd, env)) if passwd != env => {
-                echo!(
+                msg!(
                     "$HOME differs from euid-obtained home directory: \
                        you may be using sudo"
                 );
-                echo!("$HOME directory:", Path::new(&env).display());
-                echo!("euid-obtained home directory:", passwd.display());
-                echo!(
+                msg!("$HOME directory: {}", Path::new(&env).display());
+                msg!("euid-obtained home directory: {}", passwd.display());
+                msg!(
                     "if this is what you want, \
                        restart the installation with `-y'"
                 );
@@ -499,9 +499,9 @@ fn _main(options: &CliInstall) -> anyhow::Result<()> {
     }
 
     if cfg!(all(target_os = "macos", target_arch = "x86_64")) && platform::is_arm64_hardware() {
-        echo!(
-            BRANDING,
-            "now supports native M1 build. Downloading binary..."
+        msg!(
+            "{} now supports native M1 build. Downloading binary...",
+            BRANDING
         );
         return upgrade::upgrade_to_arm64();
     }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -23,7 +23,7 @@ use crate::platform::{binary_path, config_dir, home_dir};
 use crate::portable::platform;
 use crate::portable::project::project_dir;
 use crate::portable::project::{self, Init};
-use crate::print::{self};
+use crate::print::{self, msg};
 use crate::print_markdown;
 use crate::process;
 use crate::question::{self, read_choice};
@@ -452,12 +452,16 @@ fn _main(options: &CliInstall) -> anyhow::Result<()> {
     if !options.no_confirm {
         match home_dir_from_passwd().zip(env::var_os("HOME")) {
             Some((passwd, env)) if passwd != env => {
-                msg!("$HOME differs from euid-obtained home directory: \
-                       you may be using sudo");
+                msg!(
+                    "$HOME differs from euid-obtained home directory: \
+                       you may be using sudo"
+                );
                 msg!("$HOME directory: {}", Path::new(&env).display());
                 msg!("euid-obtained home directory: {}", passwd.display());
-                msg!("if this is what you want, \
-                       restart the installation with `-y'");
+                msg!(
+                    "if this is what you want, \
+                       restart the installation with `-y'"
+                );
                 return Err(ExitCode::new(1).into());
             }
             _ => {}

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -12,7 +12,7 @@ use crate::platform::{binary_path, current_exe, home_dir, tmp_file_path};
 use crate::portable::platform;
 use crate::portable::repository::{self, download, Channel};
 use crate::portable::ver;
-use crate::print::{self, msg, Highlight};
+use crate::print::{self, Highlight};
 use crate::process;
 
 const INDEX_TIMEOUT: Duration = Duration::new(60, 0);

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -12,7 +12,7 @@ use crate::platform::{binary_path, current_exe, home_dir, tmp_file_path};
 use crate::portable::platform;
 use crate::portable::repository::{self, download, Channel};
 use crate::portable::ver;
-use crate::print::{self, echo, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::process;
 
 const INDEX_TIMEOUT: Duration = Duration::new(60, 0);
@@ -226,7 +226,7 @@ fn _main(options: &CliUpgrade, path: PathBuf) -> anyhow::Result<()> {
         .run()?;
     fs::remove_file(&tmp_path).ok();
     if !options.quiet {
-        echo!("Upgraded to version", pkg.version.emphasize());
+        msg!("Upgraded to version {}", pkg.version.emphasize());
     }
     Ok(())
 }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -12,7 +12,7 @@ use crate::platform::{binary_path, current_exe, home_dir, tmp_file_path};
 use crate::portable::platform;
 use crate::portable::repository::{self, download, Channel};
 use crate::portable::ver;
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::process;
 
 const INDEX_TIMEOUT: Duration = Duration::new(60, 0);

--- a/src/cloud/secret_keys.rs
+++ b/src/cloud/secret_keys.rs
@@ -12,7 +12,6 @@ use crate::portable::exit_codes;
 
 use crate::table::{self, Cell, Row, Table};
 
-use crate::msg;
 use crate::print::{self, Highlight};
 use crate::question;
 
@@ -142,14 +141,12 @@ pub async fn _do_create(c: &options::CreateSecretKey, client: &CloudClient) -> a
         if c.non_interactive {
             print!("{sk}");
         } else {
-            msg!(
-                "\nYour new {} {}",
+            msg!("\nYour new {} {}",
                 BRANDING_CLOUD,
                 " secret key is printed below. \
                  Be sure to copy and store it securely, as you will \
                  not be able to see it again.\n"
-                    .green()
-            );
+                    .green());
             msg!("{}", sk.emphasize());
         }
     }

--- a/src/cloud/secret_keys.rs
+++ b/src/cloud/secret_keys.rs
@@ -12,7 +12,7 @@ use crate::portable::exit_codes;
 
 use crate::table::{self, Cell, Row, Table};
 
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::question;
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -141,12 +141,14 @@ pub async fn _do_create(c: &options::CreateSecretKey, client: &CloudClient) -> a
         if c.non_interactive {
             print!("{sk}");
         } else {
-            msg!("\nYour new {} {}",
+            msg!(
+                "\nYour new {} {}",
                 BRANDING_CLOUD,
                 " secret key is printed below. \
                  Be sure to copy and store it securely, as you will \
                  not be able to see it again.\n"
-                    .green());
+                    .green()
+            );
             msg!("{}", sk.emphasize());
         }
     }

--- a/src/cloud/secret_keys.rs
+++ b/src/cloud/secret_keys.rs
@@ -12,7 +12,7 @@ use crate::portable::exit_codes;
 
 use crate::table::{self, Cell, Row, Table};
 
-use crate::echo;
+use crate::msg;
 use crate::print::{self, Highlight};
 use crate::question;
 
@@ -142,15 +142,15 @@ pub async fn _do_create(c: &options::CreateSecretKey, client: &CloudClient) -> a
         if c.non_interactive {
             print!("{sk}");
         } else {
-            echo!(
-                "\nYour new ",
+            msg!(
+                "\nYour new {} {}",
                 BRANDING_CLOUD,
                 " secret key is printed below. \
                  Be sure to copy and store it securely, as you will \
                  not be able to see it again.\n"
                     .green()
             );
-            echo!(sk.emphasize());
+            msg!("{}", sk.emphasize());
         }
     }
 

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -9,7 +9,7 @@ use crate::commands::ExitCode;
 use crate::options::{Options, UI};
 use crate::portable::local;
 use crate::portable::repository::USER_AGENT;
-use crate::print::{self};
+use crate::print::{self, msg};
 
 pub fn show_ui(cmd: &UI, opts: &Options) -> anyhow::Result<()> {
     let connector = opts.block_on_create_connector()?;
@@ -118,8 +118,10 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
                         BRANDING,
                         " server."
                     ));
-                    msg!("  Try running the \
-                        server with `--admin-ui=enabled`.");
+                    msg!(
+                        "  Try running the \
+                        server with `--admin-ui=enabled`."
+                    );
                     return Err(ExitCode::new(2).into());
                 }
                 Ok(status) => {

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -9,7 +9,7 @@ use crate::commands::ExitCode;
 use crate::options::{Options, UI};
 use crate::portable::local;
 use crate::portable::repository::USER_AGENT;
-use crate::print;
+use crate::print::{self, msg};
 
 pub fn show_ui(cmd: &UI, opts: &Options) -> anyhow::Result<()> {
     let connector = opts.block_on_create_connector()?;
@@ -102,14 +102,10 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
                     use_https = true;
                 }
                 Ok(status) => {
-                    msg!(
-                        "{} returned status code {}, retry HTTP. {} {}",
-                        https_url,
-                        status
-                    );
+                    msg!("{} returned status code {}, retry HTTP.", https_url, status);
                 }
                 Err(e) => {
-                    msg!("Failed to probe {}: {:#}, retry HTTP. {} {}", https_url, e);
+                    msg!("Failed to probe {}: {:#}, retry HTTP.", https_url, e);
                 }
             }
         }

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -102,10 +102,14 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
                     use_https = true;
                 }
                 Ok(status) => {
-                    print::echo!("{} returned status code {}, retry HTTP.", https_url, status);
+                    msg!(
+                        "{} returned status code {}, retry HTTP. {} {}",
+                        https_url,
+                        status
+                    );
                 }
                 Err(e) => {
-                    print::echo!("Failed to probe {}: {:#}, retry HTTP.", https_url, e);
+                    msg!("Failed to probe {}: {:#}, retry HTTP. {} {}", https_url, e);
                 }
             }
         }
@@ -118,7 +122,7 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
                         BRANDING,
                         " server."
                     ));
-                    print::echo!(
+                    msg!(
                         "  Try running the \
                         server with `--admin-ui=enabled`."
                     );

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -9,7 +9,7 @@ use crate::commands::ExitCode;
 use crate::options::{Options, UI};
 use crate::portable::local;
 use crate::portable::repository::USER_AGENT;
-use crate::print::{self, msg};
+use crate::print::{self};
 
 pub fn show_ui(cmd: &UI, opts: &Options) -> anyhow::Result<()> {
     let connector = opts.block_on_create_connector()?;
@@ -102,10 +102,10 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
                     use_https = true;
                 }
                 Ok(status) => {
-                    msg!("{} returned status code {}, retry HTTP.", https_url, status);
+                    msg!("{https_url} returned status code {status}, retry HTTP.");
                 }
                 Err(e) => {
-                    msg!("Failed to probe {}: {:#}, retry HTTP.", https_url, e);
+                    msg!("Failed to probe {https_url}: {e:#}, retry HTTP.");
                 }
             }
         }
@@ -118,10 +118,8 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
                         BRANDING,
                         " server."
                     ));
-                    msg!(
-                        "  Try running the \
-                        server with `--admin-ui=enabled`."
-                    );
+                    msg!("  Try running the \
+                        server with `--admin-ui=enabled`.");
                     return Err(ExitCode::new(2).into());
                 }
                 Ok(status) => {

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -12,7 +12,7 @@ use termcolor::{ColorChoice, StandardStream};
 use edgedb_errors::{Error, InternalServerError};
 
 use crate::branding::BRANDING_CLI_CMD;
-use crate::print::{self};
+use crate::print::{self, msg};
 
 pub fn print_query_error(
     err: &Error,

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -12,7 +12,7 @@ use termcolor::{ColorChoice, StandardStream};
 use edgedb_errors::{Error, InternalServerError};
 
 use crate::branding::BRANDING_CLI_CMD;
-use crate::print::{self, msg};
+use crate::print::{self};
 
 pub fn print_query_error(
     err: &Error,
@@ -119,5 +119,5 @@ fn print_query_warning_plain(warning: &Warning) {
         CString::new(marker)
     };
 
-    msg!("{} {}", marker, warning);
+    msg!("{marker} {warning}");
 }

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -119,5 +119,5 @@ fn print_query_warning_plain(warning: &Warning) {
         CString::new(marker)
     };
 
-    print::echo!(marker, warning);
+    msg!("{} {}", marker, warning);
 }

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -12,7 +12,7 @@ use termcolor::{ColorChoice, StandardStream};
 use edgedb_errors::{Error, InternalServerError};
 
 use crate::branding::BRANDING_CLI_CMD;
-use crate::print;
+use crate::print::{self, msg};
 
 pub fn print_query_error(
     err: &Error,

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -30,7 +30,7 @@ use crate::interrupt::{Interrupt, InterruptError};
 use crate::options::Options;
 use crate::outputs::tab_separated;
 use crate::print::Highlight;
-use crate::print::{self, PrintError};
+use crate::print::{self, msg, PrintError};
 use crate::prompt;
 use crate::repl::{self, VectorLimit};
 use crate::variables::input_variables;
@@ -151,8 +151,10 @@ pub fn main(options: Options, cfg: Config) -> Result<(), anyhow::Error> {
 pub async fn _main(options: Options, mut state: repl::State, cfg: Config) -> anyhow::Result<()> {
     state.connect().await?;
     if let Some(config_path) = &cfg.file_name {
-        msg!("{}",
-            format_args!("Applied {} configuration file", config_path.display(),).fade());
+        msg!(
+            "{}",
+            format_args!("Applied {} configuration file", config_path.display(),).fade()
+        );
     }
     msg!("{}", r#"Type \help for help, \quit to quit."#.light_gray());
     state.set_history_limit(state.history_limit).await?;
@@ -586,12 +588,14 @@ async fn _interactive_main(
                             continue 'retry;
                         }
                         print::error("State could not be updated automatically");
-                        msg!("  Hint: This means that migrations or DDL \
+                        msg!(
+                            "  Hint: This means that migrations or DDL \
                                statements were run in a concurrent \
                                connection during the interactive \
                                session. Try restarting the CLI to resolve. \
                                (Note: globals and aliases must be \
-                               set again in this case)");
+                               set again in this case)"
+                        );
                         return Err(ExitCode::new(10))?;
                     } else if let Some(e) = err.downcast_ref::<edgedb_errors::Error>() {
                         print::edgedb_error(e, state.verbose_errors);

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -27,7 +27,6 @@ use crate::config::Config;
 use crate::credentials;
 use crate::error_display::print_query_error;
 use crate::interrupt::{Interrupt, InterruptError};
-use crate::msg;
 use crate::options::Options;
 use crate::outputs::tab_separated;
 use crate::print::Highlight;
@@ -152,10 +151,8 @@ pub fn main(options: Options, cfg: Config) -> Result<(), anyhow::Error> {
 pub async fn _main(options: Options, mut state: repl::State, cfg: Config) -> anyhow::Result<()> {
     state.connect().await?;
     if let Some(config_path) = &cfg.file_name {
-        msg!(
-            "{}",
-            format_args!("Applied {} configuration file", config_path.display(),).fade()
-        );
+        msg!("{}",
+            format_args!("Applied {} configuration file", config_path.display(),).fade());
     }
     msg!("{}", r#"Type \help for help, \quit to quit."#.light_gray());
     state.set_history_limit(state.history_limit).await?;
@@ -589,14 +586,12 @@ async fn _interactive_main(
                             continue 'retry;
                         }
                         print::error("State could not be updated automatically");
-                        msg!(
-                            "  Hint: This means that migrations or DDL \
+                        msg!("  Hint: This means that migrations or DDL \
                                statements were run in a concurrent \
                                connection during the interactive \
                                session. Try restarting the CLI to resolve. \
                                (Note: globals and aliases must be \
-                               set again in this case)"
-                        );
+                               set again in this case)");
                         return Err(ExitCode::new(10))?;
                     } else if let Some(e) = err.downcast_ref::<edgedb_errors::Error>() {
                         print::edgedb_error(e, state.verbose_errors);

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -25,9 +25,9 @@ use crate::classify;
 use crate::commands::{backslash, ExitCode};
 use crate::config::Config;
 use crate::credentials;
-use crate::echo;
 use crate::error_display::print_query_error;
 use crate::interrupt::{Interrupt, InterruptError};
+use crate::msg;
 use crate::options::Options;
 use crate::outputs::tab_separated;
 use crate::print::Highlight;
@@ -152,9 +152,12 @@ pub fn main(options: Options, cfg: Config) -> Result<(), anyhow::Error> {
 pub async fn _main(options: Options, mut state: repl::State, cfg: Config) -> anyhow::Result<()> {
     state.connect().await?;
     if let Some(config_path) = &cfg.file_name {
-        echo!(format_args!("Applied {} configuration file", config_path.display(),).fade());
+        msg!(
+            "{}",
+            format_args!("Applied {} configuration file", config_path.display(),).fade()
+        );
     }
-    echo!(r#"Type \help for help, \quit to quit."#.light_gray());
+    msg!("{}", r#"Type \help for help, \quit to quit."#.light_gray());
     state.set_history_limit(state.history_limit).await?;
     match _interactive_main(&options, &mut state).await {
         Ok(()) => Ok(()),
@@ -586,7 +589,7 @@ async fn _interactive_main(
                             continue 'retry;
                         }
                         print::error("State could not be updated automatically");
-                        echo!(
+                        msg!(
                             "  Hint: This means that migrations or DDL \
                                statements were run in a concurrent \
                                connection during the interactive \

--- a/src/migrations/edit.rs
+++ b/src/migrations/edit.rs
@@ -12,7 +12,7 @@ use crate::migrations::grammar::parse_migration;
 use crate::migrations::migration::{file_num, read_names};
 use crate::migrations::options::MigrationEdit;
 use crate::platform::{spawn_editor, tmp_file_path};
-use crate::print::{echo, err_marker, Highlight};
+use crate::print::{err_marker, msg, Highlight};
 use crate::question::Choice;
 
 #[derive(Copy, Clone)]
@@ -102,9 +102,9 @@ pub async fn edit_no_check(
         }
         fs::write(&tmp_file, migration.replace_id(&text, &new_id)).await?;
         fs::rename(&tmp_file, &path).await?;
-        echo!("Updated migration id to", new_id.emphasize());
+        msg!("Updated migration id to {}", new_id.emphasize());
     } else {
-        echo!("Id", migration.id.emphasize(), "is already correct.");
+        msg!("Id {} is already correct.", migration.id.emphasize());
     }
     Ok(())
 }
@@ -175,9 +175,9 @@ async fn _edit(
                 anyhow::Ok(())
             })
             .await?;
-            echo!("Updated migration id to", new_id.emphasize());
+            msg!("Updated migration id to {}", new_id.emphasize());
         } else {
-            echo!("Id", migration.id.emphasize(), "is already correct.");
+            msg!("Id {} is already correct.", migration.id.emphasize());
         }
     } else {
         let temp_path = path.parent().unwrap().join(format!(".editing.{n}.edgeql"));
@@ -226,7 +226,7 @@ async fn _edit(
             let migration = match parse_migration(&new_data) {
                 Ok(migr) => migr,
                 Err(e) => {
-                    echo!(err_marker(), "error parsing file:", e);
+                    msg!("{} error parsing file: {}", err_marker(), e);
                     loop {
                         let mut q = Choice::new("Edit again?");
                         q.option(
@@ -276,14 +276,14 @@ async fn _edit(
             if migration.id != new_id {
                 new_data = migration.replace_id(&new_data, &new_id);
                 fs::write(&temp_path, &new_data).await?;
-                echo!("Updated migration id to", new_id.emphasize());
+                msg!("Updated migration id to {}", new_id.emphasize());
             } else {
-                echo!("Id", migration.id.emphasize(), "is already correct.");
+                msg!("Id {} is already correct.", migration.id.emphasize());
             }
             match check_migration(cli, &new_data, &path).await {
                 Ok(()) => {}
                 Err(e) => {
-                    echo!(err_marker(), "error checking migration:", e);
+                    msg!("{} error checking migration: {}", err_marker(), e);
                     loop {
                         let mut q = Choice::new("Edit again?");
                         q.option(FailAction::Edit, &["y", "yes"][..], "edit the file again");

--- a/src/migrations/edit.rs
+++ b/src/migrations/edit.rs
@@ -12,7 +12,7 @@ use crate::migrations::grammar::parse_migration;
 use crate::migrations::migration::{file_num, read_names};
 use crate::migrations::options::MigrationEdit;
 use crate::platform::{spawn_editor, tmp_file_path};
-use crate::print::{err_marker, Highlight};
+use crate::print::{err_marker, msg, Highlight};
 use crate::question::Choice;
 
 #[derive(Copy, Clone)]

--- a/src/migrations/edit.rs
+++ b/src/migrations/edit.rs
@@ -12,7 +12,7 @@ use crate::migrations::grammar::parse_migration;
 use crate::migrations::migration::{file_num, read_names};
 use crate::migrations::options::MigrationEdit;
 use crate::platform::{spawn_editor, tmp_file_path};
-use crate::print::{err_marker, msg, Highlight};
+use crate::print::{err_marker, Highlight};
 use crate::question::Choice;
 
 #[derive(Copy, Clone)]

--- a/src/migrations/squash.rs
+++ b/src/migrations/squash.rs
@@ -20,7 +20,7 @@ use crate::migrations::migration;
 use crate::migrations::options::CreateMigration;
 use crate::migrations::status::migrations_applied;
 use crate::migrations::timeout;
-use crate::print::{Highlight};
+use crate::print::{msg, Highlight};
 use crate::question::Confirm;
 
 struct TwoStageRemove<'a> {
@@ -123,19 +123,27 @@ async fn create_revision(
 
 async fn confirm_squashing(db_rev: &str) -> anyhow::Result<()> {
     msg!("Current database revision: {}", db_rev.emphasize());
-    msg!("While squashing migrations is non-destructive, it may lead to manual work \
-           if done incorrectly.");
+    msg!(
+        "While squashing migrations is non-destructive, it may lead to manual work \
+           if done incorrectly."
+    );
     msg!();
     msg!("Items to check before using --squash:");
     msg!("  1. Ensure that the `./dbschema` dir is committed to version control");
-    msg!("  2. Ensure that other users of the database either have all .edgeql files\n     \
+    msg!(
+        "  2. Ensure that other users of the database either have all .edgeql files\n     \
                 up to the revision above or can create the database from scratch.\n \
-                Hint: To see the current revision for a specific instance, run:");
-    msg!("       {} {}",
+                Hint: To see the current revision for a specific instance, run:"
+    );
+    msg!(
+        "       {} {}",
         BRANDING_CLI_CMD,
-        " -I <name> migration log --from-db --newest-first --limit 1".command_hint());
-    msg!("  3. Merge version control branches that contain schema changes \
-                if possible.");
+        " -I <name> migration log --from-db --newest-first --limit 1".command_hint()
+    );
+    msg!(
+        "  3. Merge version control branches that contain schema changes \
+                if possible."
+    );
     msg!();
     if !Confirm::new("Proceed?").async_ask().await? {
         return Err(ExitCode::new(0))?;
@@ -144,13 +152,17 @@ async fn confirm_squashing(db_rev: &str) -> anyhow::Result<()> {
 }
 
 async fn want_fixup() -> anyhow::Result<bool> {
-    msg!("Your schema differs from the last revision. \
+    msg!(
+        "Your schema differs from the last revision. \
            A fixup file can be created to automate \
            upgrading other instances to a squashed revision. \
-           This starts the usual migration creation process.");
+           This starts the usual migration creation process."
+    );
     msg!();
-    msg!("Feel free to skip this step if you don't have \
-           other instances to migrate");
+    msg!(
+        "Feel free to skip this step if you don't have \
+           other instances to migrate"
+    );
     msg!();
     Confirm::new("Create a fixup file?").async_ask().await
 }
@@ -159,8 +171,10 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
     if fixup_created {
         msg!("Squash is complete.");
         msg!();
-        msg!("Remember to commit the `dbschema` directory including deleted \
-               files and `fixups` subdirectory. Recommended command:");
+        msg!(
+            "Remember to commit the `dbschema` directory including deleted \
+               files and `fixups` subdirectory. Recommended command:"
+        );
         msg!("{}", "    git add dbschema".command_hint());
         msg!();
         msg!("The normal migration process will update your migration history:");
@@ -168,14 +182,18 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
     } else {
         msg!("Squash is complete.");
         msg!();
-        msg!("Remember to commit the `dbschema` directory including deleted \
-               files. Recommended command:");
+        msg!(
+            "Remember to commit the `dbschema` directory including deleted \
+               files. Recommended command:"
+        );
         msg!("{}", "    git add dbschema".command_hint());
         msg!();
         msg!("You can now wipe your instances and apply the new schema:");
-        msg!("    {} {}",
+        msg!(
+            "    {} {}",
             BRANDING_CLI_CMD,
-            "database wipe".command_hint());
+            "database wipe".command_hint()
+        );
         msg!("    {} {}", BRANDING_CLI_CMD, "migrate".command_hint());
     }
     Ok(())

--- a/src/migrations/squash.rs
+++ b/src/migrations/squash.rs
@@ -20,7 +20,7 @@ use crate::migrations::migration;
 use crate::migrations::options::CreateMigration;
 use crate::migrations::status::migrations_applied;
 use crate::migrations::timeout;
-use crate::print::{msg, Highlight};
+use crate::print::{Highlight};
 use crate::question::Confirm;
 
 struct TwoStageRemove<'a> {
@@ -123,27 +123,19 @@ async fn create_revision(
 
 async fn confirm_squashing(db_rev: &str) -> anyhow::Result<()> {
     msg!("Current database revision: {}", db_rev.emphasize());
-    msg!(
-        "While squashing migrations is non-destructive, it may lead to manual work \
-           if done incorrectly."
-    );
+    msg!("While squashing migrations is non-destructive, it may lead to manual work \
+           if done incorrectly.");
     msg!();
     msg!("Items to check before using --squash:");
     msg!("  1. Ensure that the `./dbschema` dir is committed to version control");
-    msg!(
-        "  2. Ensure that other users of the database either have all .edgeql files\n     \
+    msg!("  2. Ensure that other users of the database either have all .edgeql files\n     \
                 up to the revision above or can create the database from scratch.\n \
-                Hint: To see the current revision for a specific instance, run:"
-    );
-    msg!(
-        "       {} {}",
+                Hint: To see the current revision for a specific instance, run:");
+    msg!("       {} {}",
         BRANDING_CLI_CMD,
-        " -I <name> migration log --from-db --newest-first --limit 1".command_hint()
-    );
-    msg!(
-        "  3. Merge version control branches that contain schema changes \
-                if possible."
-    );
+        " -I <name> migration log --from-db --newest-first --limit 1".command_hint());
+    msg!("  3. Merge version control branches that contain schema changes \
+                if possible.");
     msg!();
     if !Confirm::new("Proceed?").async_ask().await? {
         return Err(ExitCode::new(0))?;
@@ -152,17 +144,13 @@ async fn confirm_squashing(db_rev: &str) -> anyhow::Result<()> {
 }
 
 async fn want_fixup() -> anyhow::Result<bool> {
-    msg!(
-        "Your schema differs from the last revision. \
+    msg!("Your schema differs from the last revision. \
            A fixup file can be created to automate \
            upgrading other instances to a squashed revision. \
-           This starts the usual migration creation process."
-    );
+           This starts the usual migration creation process.");
     msg!();
-    msg!(
-        "Feel free to skip this step if you don't have \
-           other instances to migrate"
-    );
+    msg!("Feel free to skip this step if you don't have \
+           other instances to migrate");
     msg!();
     Confirm::new("Create a fixup file?").async_ask().await
 }
@@ -171,10 +159,8 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
     if fixup_created {
         msg!("Squash is complete.");
         msg!();
-        msg!(
-            "Remember to commit the `dbschema` directory including deleted \
-               files and `fixups` subdirectory. Recommended command:"
-        );
+        msg!("Remember to commit the `dbschema` directory including deleted \
+               files and `fixups` subdirectory. Recommended command:");
         msg!("{}", "    git add dbschema".command_hint());
         msg!();
         msg!("The normal migration process will update your migration history:");
@@ -182,18 +168,14 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
     } else {
         msg!("Squash is complete.");
         msg!();
-        msg!(
-            "Remember to commit the `dbschema` directory including deleted \
-               files. Recommended command:"
-        );
+        msg!("Remember to commit the `dbschema` directory including deleted \
+               files. Recommended command:");
         msg!("{}", "    git add dbschema".command_hint());
         msg!();
         msg!("You can now wipe your instances and apply the new schema:");
-        msg!(
-            "    {} {}",
+        msg!("    {} {}",
             BRANDING_CLI_CMD,
-            "database wipe".command_hint()
-        );
+            "database wipe".command_hint());
         msg!("    {} {}", BRANDING_CLI_CMD, "migrate".command_hint());
     }
     Ok(())

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -23,7 +23,7 @@ use crate::portable::config::Config;
 use crate::portable::install;
 use crate::portable::local::InstallInfo;
 use crate::portable::repository::{self, PackageInfo, Query};
-use crate::print::{success, warn, Highlight};
+use crate::print::{msg, success, warn, Highlight};
 use crate::process;
 use crate::watch::wait_changes;
 
@@ -215,9 +215,11 @@ async fn do_check(ctx: &Context, status_file: &Path, watch: bool) -> anyhow::Res
             Okay => {}
             SchemaIssue => {
                 msg!("For faster feedback loop use:");
-                msg!("    {} {}",
+                msg!(
+                    "    {} {}",
                     BRANDING_CLI_CMD,
-                    " migration upgrade-check --watch".command_hint());
+                    " migration upgrade-check --watch".command_hint()
+                );
                 return Err(ExitCode::new(3))?;
             }
             MigrationsIssue => {
@@ -293,9 +295,11 @@ fn print_apply_migration_error() {
          but some of the migrations are outdated.",
     );
     msg!("Please squash all migrations to fix the issue:");
-    msg!("    {} {}",
+    msg!(
+        "    {} {}",
         BRANDING_CLI_CMD,
-        " migration create --squash".command_hint());
+        " migration create --squash".command_hint()
+    );
 }
 
 pub async fn watch_loop(

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -23,7 +23,7 @@ use crate::portable::config::Config;
 use crate::portable::install;
 use crate::portable::local::InstallInfo;
 use crate::portable::repository::{self, PackageInfo, Query};
-use crate::print::{echo, success, warn, Highlight};
+use crate::print::{msg, success, warn, Highlight};
 use crate::process;
 use crate::watch::wait_changes;
 
@@ -214,9 +214,9 @@ async fn do_check(ctx: &Context, status_file: &Path, watch: bool) -> anyhow::Res
         match single_check(ctx, cli).await? {
             Okay => {}
             SchemaIssue => {
-                echo!("For faster feedback loop use:");
-                echo!(
-                    "    ",
+                msg!("For faster feedback loop use:");
+                msg!(
+                    "    {} {}",
                     BRANDING_CLI_CMD,
                     " migration upgrade-check --watch".command_hint()
                 );
@@ -228,7 +228,7 @@ async fn do_check(ctx: &Context, status_file: &Path, watch: bool) -> anyhow::Res
             }
         }
         if !ctx.quiet {
-            echo!("The schema is forward compatible. Ready for upgrade.");
+            msg!("The schema is forward compatible. Ready for upgrade.");
         }
         Ok(())
     }
@@ -294,9 +294,9 @@ fn print_apply_migration_error() {
         "The current schema is compatible, \
          but some of the migrations are outdated.",
     );
-    echo!("Please squash all migrations to fix the issue:");
-    echo!(
-        "    ",
+    msg!("Please squash all migrations to fix the issue:");
+    msg!(
+        "    {} {}",
         BRANDING_CLI_CMD,
         " migration create --squash".command_hint()
     );

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -23,7 +23,7 @@ use crate::portable::config::Config;
 use crate::portable::install;
 use crate::portable::local::InstallInfo;
 use crate::portable::repository::{self, PackageInfo, Query};
-use crate::print::{msg, success, warn, Highlight};
+use crate::print::{success, warn, Highlight};
 use crate::process;
 use crate::watch::wait_changes;
 
@@ -215,11 +215,9 @@ async fn do_check(ctx: &Context, status_file: &Path, watch: bool) -> anyhow::Res
             Okay => {}
             SchemaIssue => {
                 msg!("For faster feedback loop use:");
-                msg!(
-                    "    {} {}",
+                msg!("    {} {}",
                     BRANDING_CLI_CMD,
-                    " migration upgrade-check --watch".command_hint()
-                );
+                    " migration upgrade-check --watch".command_hint());
                 return Err(ExitCode::new(3))?;
             }
             MigrationsIssue => {
@@ -295,11 +293,9 @@ fn print_apply_migration_error() {
          but some of the migrations are outdated.",
     );
     msg!("Please squash all migrations to fix the issue:");
-    msg!(
-        "    {} {}",
+    msg!("    {} {}",
         BRANDING_CLI_CMD,
-        " migration create --squash".command_hint()
-    );
+        " migration create --squash".command_hint());
 }
 
 pub async fn watch_loop(

--- a/src/portable/backup.rs
+++ b/src/portable/backup.rs
@@ -3,7 +3,6 @@ use color_print::cformat;
 use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::cloud;
 use crate::portable::options::{Backup, InstanceName, ListBackups, Restore};
-use crate::print::msg;
 use crate::question;
 
 pub fn list(cmd: &ListBackups, opts: &crate::options::Options) -> anyhow::Result<()> {
@@ -75,11 +74,7 @@ fn backup_cloud_cmd(
     };
     cloud::backups::backup_cloud_instance(&client, &request)?;
 
-    msg!(
-        "Successfully created a backup for {} instance {}",
-        BRANDING_CLOUD,
-        inst_name
-    );
+    msg!("Successfully created a backup for {BRANDING_CLOUD} instance {inst_name}");
     Ok(())
 }
 
@@ -143,12 +138,8 @@ fn restore_cloud_cmd(
     };
     cloud::backups::restore_cloud_instance(&client, &request)?;
 
-    msg!(
-        "{} instance {} has been restored successfully.",
-        BRANDING_CLOUD,
-        inst_name
-    );
+    msg!("{BRANDING_CLOUD} instance {inst_name} has been restored successfully.");
     msg!("To connect to the instance run:");
-    msg!("  {} -I {}", BRANDING_CLI_CMD, inst_name);
+    msg!("  {BRANDING_CLI_CMD} -I {inst_name}");
     Ok(())
 }

--- a/src/portable/backup.rs
+++ b/src/portable/backup.rs
@@ -3,7 +3,7 @@ use color_print::cformat;
 use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::cloud;
 use crate::portable::options::{Backup, InstanceName, ListBackups, Restore};
-use crate::print::echo;
+use crate::print::msg;
 use crate::question;
 
 pub fn list(cmd: &ListBackups, opts: &crate::options::Options) -> anyhow::Result<()> {
@@ -75,11 +75,10 @@ fn backup_cloud_cmd(
     };
     cloud::backups::backup_cloud_instance(&client, &request)?;
 
-    echo!(
-        "Successfully created a backup for ",
+    msg!(
+        "Successfully created a backup for {} instance {}",
         BRANDING_CLOUD,
-        " instance",
-        inst_name,
+        inst_name
     );
     Ok(())
 }
@@ -144,13 +143,12 @@ fn restore_cloud_cmd(
     };
     cloud::backups::restore_cloud_instance(&client, &request)?;
 
-    echo!(
+    msg!(
+        "{} instance {} has been restored successfully.",
         BRANDING_CLOUD,
-        " instance",
-        inst_name,
-        "has been restored successfully."
+        inst_name
     );
-    echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI_CMD, "-I", inst_name);
+    msg!("To connect to the instance run:");
+    msg!("  {} -I {}", BRANDING_CLI_CMD, inst_name);
     Ok(())
 }

--- a/src/portable/backup.rs
+++ b/src/portable/backup.rs
@@ -3,6 +3,7 @@ use color_print::cformat;
 use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::cloud;
 use crate::portable::options::{Backup, InstanceName, ListBackups, Restore};
+use crate::print::msg;
 use crate::question;
 
 pub fn list(cmd: &ListBackups, opts: &crate::options::Options) -> anyhow::Result<()> {

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -11,7 +11,7 @@ use crate::commands::ExitCode;
 use crate::platform::tmp_file_path;
 use crate::portable::exit_codes;
 use crate::portable::repository::{Channel, Query};
-use crate::print::{self, echo, Highlight};
+use crate::print::{self, msg, Highlight};
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -175,10 +175,9 @@ where
 
 #[context("cannot modify `{}`", config.display())]
 pub fn modify_server_ver(config: &Path, ver: &Query) -> anyhow::Result<bool> {
-    echo!(
-        "Setting `server-version = ",
+    msg!(
+        "Setting `server-version = {}` in `{}`{}",
         format_args!("{:?}", ver.as_config_value()).emphasize(),
-        "` in `{}`",
         config.file_name().unwrap_or_default().to_string_lossy()
     );
     read_modify_write(

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -176,7 +176,7 @@ where
 #[context("cannot modify `{}`", config.display())]
 pub fn modify_server_ver(config: &Path, ver: &Query) -> anyhow::Result<bool> {
     msg!(
-        "Setting `server-version = {}` in `{}`{}",
+        "Setting `server-version = {}` in `{}`",
         format_args!("{:?}", ver.as_config_value()).emphasize(),
         config.file_name().unwrap_or_default().to_string_lossy()
     );

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -11,7 +11,7 @@ use crate::commands::ExitCode;
 use crate::platform::tmp_file_path;
 use crate::portable::exit_codes;
 use crate::portable::repository::{Channel, Query};
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -175,9 +175,11 @@ where
 
 #[context("cannot modify `{}`", config.display())]
 pub fn modify_server_ver(config: &Path, ver: &Query) -> anyhow::Result<bool> {
-    msg!("Setting `server-version = {}` in `{}`",
+    msg!(
+        "Setting `server-version = {}` in `{}`",
         format_args!("{:?}", ver.as_config_value()).emphasize(),
-        config.file_name().unwrap_or_default().to_string_lossy());
+        config.file_name().unwrap_or_default().to_string_lossy()
+    );
     read_modify_write(
         config,
         |v: &SrcConfig| &v.edgedb.server_version,

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -11,7 +11,7 @@ use crate::commands::ExitCode;
 use crate::platform::tmp_file_path;
 use crate::portable::exit_codes;
 use crate::portable::repository::{Channel, Query};
-use crate::print::{self, msg, Highlight};
+use crate::print::{self, Highlight};
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -175,11 +175,9 @@ where
 
 #[context("cannot modify `{}`", config.display())]
 pub fn modify_server_ver(config: &Path, ver: &Query) -> anyhow::Result<bool> {
-    msg!(
-        "Setting `server-version = {}` in `{}`",
+    msg!("Setting `server-version = {}` in `{}`",
         format_args!("{:?}", ver.as_config_value()).emphasize(),
-        config.file_name().unwrap_or_default().to_string_lossy()
-    );
+        config.file_name().unwrap_or_default().to_string_lossy());
     read_modify_write(
         config,
         |v: &SrcConfig| &v.edgedb.server_version,

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -23,7 +23,7 @@ use crate::portable::platform::optional_docker_check;
 use crate::portable::repository::{Query, QueryOptions};
 use crate::portable::reset_password::{generate_password, password_hash};
 use crate::portable::{linux, macos, windows};
-use crate::print::{self, err_marker, msg, Highlight};
+use crate::print::{self, err_marker, Highlight};
 use crate::process;
 use crate::question;
 
@@ -54,11 +54,9 @@ fn ask_name(cloud_client: &mut cloud::client::CloudClient) -> anyhow::Result<Ins
             }
         };
         if exists {
-            msg!(
-                "{} Instance {} already exists.",
+            msg!("{} Instance {} already exists.",
                 err_marker(),
-                name.emphasize()
-            );
+                name.emphasize());
         } else {
             return Ok(inst_name);
         }
@@ -86,11 +84,9 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
     let inst_name = if let Some(name) = &cmd.name {
         name.to_owned()
     } else if cmd.non_interactive {
-        msg!(
-            "{} Instance name is required \
+        msg!("{} Instance name is required \
                              in non-interactive mode",
-            err_marker()
-        );
+            err_marker());
         return Err(ExitCode::new(2).into());
     } else {
         ask_name(&mut client)?
@@ -205,7 +201,7 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
 
     msg!("Instance {} is up and running.", name.emphasize());
     msg!("To connect to the instance run:");
-    msg!("  {} -I {}", BRANDING_CLI_CMD, name);
+    msg!("  {BRANDING_CLI_CMD} -I {name}");
     Ok(())
 }
 
@@ -389,13 +385,9 @@ fn create_cloud(
         source_backup_id: cmd.cloud_backup_source.from_backup_id.clone(),
     };
     cloud::ops::create_cloud_instance(client, &request)?;
-    msg!(
-        "{} instance {} is up and running.",
-        BRANDING_CLOUD,
-        inst_name
-    );
+    msg!("{BRANDING_CLOUD} instance {inst_name} is up and running.");
     msg!("To connect to the instance run:");
-    msg!("  {} -I {}", BRANDING_CLI_CMD, inst_name);
+    msg!("  {BRANDING_CLI_CMD} -I {inst_name}");
     Ok(())
 }
 
@@ -449,7 +441,7 @@ pub fn bootstrap(
     let password = generate_password();
     let script = bootstrap_script(user, &password);
 
-    msg!("Initializing {} instance...", BRANDING);
+    msg!("Initializing {BRANDING} instance...");
     let mut cmd = process::Native::new("bootstrap", "edgedb", server_path);
     cmd.arg("--bootstrap-only");
     cmd.env_default("EDGEDB_SERVER_LOG_LEVEL", "warn");

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -23,7 +23,7 @@ use crate::portable::platform::optional_docker_check;
 use crate::portable::repository::{Query, QueryOptions};
 use crate::portable::reset_password::{generate_password, password_hash};
 use crate::portable::{linux, macos, windows};
-use crate::print::{self, err_marker, Highlight};
+use crate::print::{self, err_marker, msg, Highlight};
 use crate::process;
 use crate::question;
 
@@ -54,9 +54,11 @@ fn ask_name(cloud_client: &mut cloud::client::CloudClient) -> anyhow::Result<Ins
             }
         };
         if exists {
-            msg!("{} Instance {} already exists.",
+            msg!(
+                "{} Instance {} already exists.",
                 err_marker(),
-                name.emphasize());
+                name.emphasize()
+            );
         } else {
             return Ok(inst_name);
         }
@@ -84,9 +86,11 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
     let inst_name = if let Some(name) = &cmd.name {
         name.to_owned()
     } else if cmd.non_interactive {
-        msg!("{} Instance name is required \
+        msg!(
+            "{} Instance name is required \
                              in non-interactive mode",
-            err_marker());
+            err_marker()
+        );
         return Err(ExitCode::new(2).into());
     } else {
         ask_name(&mut client)?

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -23,7 +23,7 @@ use crate::portable::platform::optional_docker_check;
 use crate::portable::repository::{Query, QueryOptions};
 use crate::portable::reset_password::{generate_password, password_hash};
 use crate::portable::{linux, macos, windows};
-use crate::print::{self, echo, err_marker, Highlight};
+use crate::print::{self, err_marker, msg, Highlight};
 use crate::process;
 use crate::question;
 
@@ -54,11 +54,10 @@ fn ask_name(cloud_client: &mut cloud::client::CloudClient) -> anyhow::Result<Ins
             }
         };
         if exists {
-            echo!(
+            msg!(
+                "{} Instance {} already exists.",
                 err_marker(),
-                "Instance",
-                name.emphasize(),
-                "already exists."
+                name.emphasize()
             );
         } else {
             return Ok(inst_name);
@@ -87,10 +86,10 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
     let inst_name = if let Some(name) = &cmd.name {
         name.to_owned()
     } else if cmd.non_interactive {
-        echo!(
-            err_marker(),
-            "Instance name is required \
-                             in non-interactive mode"
+        msg!(
+            "{} Instance name is required \
+                             in non-interactive mode",
+            err_marker()
         );
         return Err(ExitCode::new(2).into());
     } else {
@@ -204,9 +203,9 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
         }
     }
 
-    echo!("Instance", name.emphasize(), "is up and running.");
-    echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI_CMD, "-I", name);
+    msg!("Instance {} is up and running.", name.emphasize());
+    msg!("To connect to the instance run:");
+    msg!("  {} -I {}", BRANDING_CLI_CMD, name);
     Ok(())
 }
 
@@ -390,9 +389,13 @@ fn create_cloud(
         source_backup_id: cmd.cloud_backup_source.from_backup_id.clone(),
     };
     cloud::ops::create_cloud_instance(client, &request)?;
-    echo!(BRANDING_CLOUD, "instance", inst_name, "is up and running.");
-    echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI_CMD, "-I", inst_name);
+    msg!(
+        "{} instance {} is up and running.",
+        BRANDING_CLOUD,
+        inst_name
+    );
+    msg!("To connect to the instance run:");
+    msg!("  {} -I {}", BRANDING_CLI_CMD, inst_name);
     Ok(())
 }
 
@@ -446,7 +449,7 @@ pub fn bootstrap(
     let password = generate_password();
     let script = bootstrap_script(user, &password);
 
-    echo!("Initializing", BRANDING, "instance...");
+    msg!("Initializing {} instance...", BRANDING);
     let mut cmd = process::Native::new("bootstrap", "edgedb", server_path);
     cmd.arg("--bootstrap-only");
     cmd.env_default("EDGEDB_SERVER_LOG_LEVEL", "warn");

--- a/src/portable/destroy.rs
+++ b/src/portable/destroy.rs
@@ -11,7 +11,7 @@ use crate::portable::local;
 use crate::portable::options::{instance_arg, Destroy, InstanceName};
 use crate::portable::project;
 use crate::portable::windows;
-use crate::print::{self, echo, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::question;
 
 #[derive(Debug, thiserror::Error)]
@@ -69,7 +69,7 @@ pub fn destroy(options: &Destroy, opts: &Options) -> anyhow::Result<()> {
         }
     })?;
     if !options.quiet {
-        echo!("Instance", name_str.emphasize(), "is successfully deleted.");
+        msg!("Instance {} is successfully deleted.", name_str.emphasize());
     }
     Ok(())
 }

--- a/src/portable/destroy.rs
+++ b/src/portable/destroy.rs
@@ -11,7 +11,7 @@ use crate::portable::local;
 use crate::portable::options::{instance_arg, Destroy, InstanceName};
 use crate::portable::project;
 use crate::portable::windows;
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::question;
 
 #[derive(Debug, thiserror::Error)]

--- a/src/portable/destroy.rs
+++ b/src/portable/destroy.rs
@@ -11,7 +11,7 @@ use crate::portable::local;
 use crate::portable::options::{instance_arg, Destroy, InstanceName};
 use crate::portable::project;
 use crate::portable::windows;
-use crate::print::{self, msg, Highlight};
+use crate::print::{self, Highlight};
 use crate::question;
 
 #[derive(Debug, thiserror::Error)]

--- a/src/portable/install.rs
+++ b/src/portable/install.rs
@@ -20,7 +20,7 @@ use crate::portable::repository::QueryOptions;
 use crate::portable::repository::{download, PackageHash, PackageInfo, Query};
 use crate::portable::repository::{get_server_package, get_specific_package};
 use crate::portable::ver::{self, Build};
-use crate::print::{self, msg, Highlight};
+use crate::print::{self, Highlight};
 
 static INSTALLED_VERSIONS: Lazy<Mutex<BTreeSet<Build>>> = Lazy::new(|| Mutex::new(BTreeSet::new()));
 

--- a/src/portable/install.rs
+++ b/src/portable/install.rs
@@ -20,7 +20,7 @@ use crate::portable::repository::QueryOptions;
 use crate::portable::repository::{download, PackageHash, PackageInfo, Query};
 use crate::portable::repository::{get_server_package, get_specific_package};
 use crate::portable::ver::{self, Build};
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 
 static INSTALLED_VERSIONS: Lazy<Mutex<BTreeSet<Build>>> = Lazy::new(|| Mutex::new(BTreeSet::new()));
 

--- a/src/portable/install.rs
+++ b/src/portable/install.rs
@@ -20,7 +20,7 @@ use crate::portable::repository::QueryOptions;
 use crate::portable::repository::{download, PackageHash, PackageInfo, Query};
 use crate::portable::repository::{get_server_package, get_specific_package};
 use crate::portable::ver::{self, Build};
-use crate::print::{self, echo, Highlight};
+use crate::print::{self, msg, Highlight};
 
 static INSTALLED_VERSIONS: Lazy<Mutex<BTreeSet<Build>>> = Lazy::new(|| Mutex::new(BTreeSet::new()));
 
@@ -195,12 +195,12 @@ pub fn package(pkg_info: &PackageInfo) -> anyhow::Result<InstallInfo> {
             .unwrap()
             .insert(meta.version.clone())
         {
-            echo!("Version", meta.version.emphasize(), "is already downloaded");
+            msg!("Version {} is already downloaded", meta.version.emphasize());
         }
         return Ok(meta);
     }
 
-    echo!("Downloading package...");
+    msg!("Downloading package...");
     let cache_path = download_package(pkg_info)?;
     let tmp_target = platform::tmp_file_path(&target_dir);
     unpack_package(&cache_path, &tmp_target)?;
@@ -215,7 +215,7 @@ pub fn package(pkg_info: &PackageInfo) -> anyhow::Result<InstallInfo> {
     fs::rename(&tmp_target, &target_dir)
         .with_context(|| format!("cannot rename {tmp_target:?} -> {target_dir:?}"))?;
     unlink_cache(&cache_path);
-    echo!("Successfully installed", pkg_info.version.emphasize());
+    msg!("Successfully installed {}", pkg_info.version.emphasize());
     INSTALLED_VERSIONS
         .lock()
         .unwrap()

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -13,7 +13,7 @@ use crate::platform::{data_dir, get_current_uid, home_dir};
 use crate::portable::local::{log_file, runstate_dir, InstanceInfo};
 use crate::portable::options::{instance_arg, InstanceName, Logs};
 use crate::portable::status::Service;
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::process;
 
 enum Status {
@@ -383,16 +383,20 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
             Failed {
                 exit_code: Some(code),
             } => {
-                msg!("{} {} with exit code {}",
+                msg!(
+                    "{} {} with exit code {}",
                     print::err_marker(),
                     "{BRANDING} failed".emphasize(),
-                    code);
+                    code
+                );
             }
             Failed { exit_code: None } => {
-                msg!("{} {} {}",
+                msg!(
+                    "{} {} {}",
                     print::err_marker(),
                     BRANDING,
-                    "failed".emphasize());
+                    "failed".emphasize()
+                );
             }
         }
     }

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -13,7 +13,7 @@ use crate::platform::{data_dir, get_current_uid, home_dir};
 use crate::portable::local::{log_file, runstate_dir, InstanceInfo};
 use crate::portable::options::{instance_arg, InstanceName, Logs};
 use crate::portable::status::Service;
-use crate::print::{self, echo, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::process;
 
 enum Status {
@@ -383,15 +383,20 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
             Failed {
                 exit_code: Some(code),
             } => {
-                echo!(
+                msg!(
+                    "{} {} with exit code {}",
                     print::err_marker(),
                     "{BRANDING} failed".emphasize(),
-                    "with exit code",
                     code
                 );
             }
             Failed { exit_code: None } => {
-                echo!(print::err_marker(), BRANDING, "failed".emphasize());
+                msg!(
+                    "{} {} {}",
+                    print::err_marker(),
+                    BRANDING,
+                    "failed".emphasize()
+                );
             }
         }
     }

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -13,7 +13,7 @@ use crate::platform::{data_dir, get_current_uid, home_dir};
 use crate::portable::local::{log_file, runstate_dir, InstanceInfo};
 use crate::portable::options::{instance_arg, InstanceName, Logs};
 use crate::portable::status::Service;
-use crate::print::{self, msg, Highlight};
+use crate::print::{self, Highlight};
 use crate::process;
 
 enum Status {
@@ -383,20 +383,16 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
             Failed {
                 exit_code: Some(code),
             } => {
-                msg!(
-                    "{} {} with exit code {}",
+                msg!("{} {} with exit code {}",
                     print::err_marker(),
                     "{BRANDING} failed".emphasize(),
-                    code
-                );
+                    code);
             }
             Failed { exit_code: None } => {
-                msg!(
-                    "{} {} {}",
+                msg!("{} {} {}",
                     print::err_marker(),
                     BRANDING,
-                    "failed".emphasize()
-                );
+                    "failed".emphasize());
             }
         }
     }

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -16,7 +16,7 @@ use crate::portable::local::{
 };
 use crate::portable::repository::Channel;
 use crate::portable::ver;
-use crate::print::{err_marker, warn};
+use crate::print::{err_marker, msg, warn};
 use crate::process::{self, IntoArg};
 
 const DOMAIN_LABEL_MAX_LENGTH: usize = 63;
@@ -933,10 +933,12 @@ pub fn instance_arg<'x>(
 ) -> anyhow::Result<&'x InstanceName> {
     if let Some(name) = positional {
         if named.is_some() {
-            msg!("{} Instance name is specified twice \
+            msg!(
+                "{} Instance name is specified twice \
                 as positional argument and via `-I`. \
                 The latter is preferred.",
-                err_marker());
+                err_marker()
+            );
             return Err(ExitCode::new(2).into());
         }
         warn(format_args!(
@@ -948,7 +950,9 @@ pub fn instance_arg<'x>(
     if let Some(name) = named {
         return Ok(name);
     }
-    msg!("{} Instance name argument is required, use '-I name'",
-        err_marker());
+    msg!(
+        "{} Instance name argument is required, use '-I name'",
+        err_marker()
+    );
     Err(ExitCode::new(2).into())
 }

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -16,7 +16,7 @@ use crate::portable::local::{
 };
 use crate::portable::repository::Channel;
 use crate::portable::ver;
-use crate::print::{err_marker, msg, warn};
+use crate::print::{err_marker, warn};
 use crate::process::{self, IntoArg};
 
 const DOMAIN_LABEL_MAX_LENGTH: usize = 63;
@@ -933,12 +933,10 @@ pub fn instance_arg<'x>(
 ) -> anyhow::Result<&'x InstanceName> {
     if let Some(name) = positional {
         if named.is_some() {
-            msg!(
-                "{} Instance name is specified twice \
+            msg!("{} Instance name is specified twice \
                 as positional argument and via `-I`. \
                 The latter is preferred.",
-                err_marker()
-            );
+                err_marker());
             return Err(ExitCode::new(2).into());
         }
         warn(format_args!(
@@ -950,9 +948,7 @@ pub fn instance_arg<'x>(
     if let Some(name) = named {
         return Ok(name);
     }
-    msg!(
-        "{} Instance name argument is required, use '-I name'",
-        err_marker()
-    );
+    msg!("{} Instance name argument is required, use '-I name'",
+        err_marker());
     Err(ExitCode::new(2).into())
 }

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -16,7 +16,7 @@ use crate::portable::local::{
 };
 use crate::portable::repository::Channel;
 use crate::portable::ver;
-use crate::print::{echo, err_marker, warn};
+use crate::print::{err_marker, msg, warn};
 use crate::process::{self, IntoArg};
 
 const DOMAIN_LABEL_MAX_LENGTH: usize = 63;
@@ -933,11 +933,11 @@ pub fn instance_arg<'x>(
 ) -> anyhow::Result<&'x InstanceName> {
     if let Some(name) = positional {
         if named.is_some() {
-            echo!(
-                err_marker(),
-                "Instance name is specified twice \
+            msg!(
+                "{} Instance name is specified twice \
                 as positional argument and via `-I`. \
-                The latter is preferred."
+                The latter is preferred.",
+                err_marker()
             );
             return Err(ExitCode::new(2).into());
         }
@@ -950,9 +950,9 @@ pub fn instance_arg<'x>(
     if let Some(name) = named {
         return Ok(name);
     }
-    echo!(
-        err_marker(),
-        "Instance name argument is required, use '-I name'"
+    msg!(
+        "{} Instance name argument is required, use '-I name'",
+        err_marker()
     );
     Err(ExitCode::new(2).into())
 }

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -422,7 +422,7 @@ fn link(
     cloud_options: &crate::options::CloudOptions,
 ) -> anyhow::Result<ProjectInfo> {
     msg!(
-        "Found `{}` in {} {}",
+        "Found `{}` in {}",
         config_path
             .file_name()
             .unwrap_or_default()
@@ -608,7 +608,7 @@ pub fn init_existing(
     cloud_options: &crate::options::CloudOptions,
 ) -> anyhow::Result<ProjectInfo> {
     msg!(
-        "Found `{}` in {} {}",
+        "Found `{}` in {}",
         config_path
             .file_name()
             .unwrap_or_default()
@@ -2031,7 +2031,7 @@ pub fn upgrade_instance(options: &Upgrade, opts: &crate::options::Options) -> an
         upgrade::UpgradeAction::None => {
             msg!(
                 "{BRANDING} instance is up to date with \
-                the specification in `{}`. {}",
+                the specification in `{}`.",
                 config_path
                     .file_name()
                     .unwrap_or_default()
@@ -2041,7 +2041,7 @@ pub fn upgrade_instance(options: &Upgrade, opts: &crate::options::Options) -> an
                 msg!("New major version is available: {}", available.emphasize());
                 msg!(
                     "To update `{}` and upgrade to this version, \
-                        run:\n    {} project upgrade --to-latest {}",
+                        run:\n    {} project upgrade --to-latest",
                     BRANDING_CLI_CMD,
                     config_path
                         .file_name()

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -44,7 +44,7 @@ use crate::portable::upgrade;
 use crate::portable::ver;
 use crate::portable::ver::Specific;
 use crate::portable::windows;
-use crate::print::{self, msg, Highlight};
+use crate::print::{self, Highlight};
 
 use crate::question;
 use crate::table;
@@ -421,14 +421,12 @@ fn link(
     config_path: PathBuf,
     cloud_options: &crate::options::CloudOptions,
 ) -> anyhow::Result<ProjectInfo> {
-    msg!(
-        "Found `{}` in {}",
+    msg!("Found `{}` in {}",
         config_path
             .file_name()
             .unwrap_or_default()
             .to_string_lossy(),
-        project_dir.display()
-    );
+        project_dir.display());
     msg!("Linking project...");
 
     let stash_dir = get_stash_path(project_dir)?;
@@ -607,14 +605,12 @@ pub fn init_existing(
     config_path: PathBuf,
     cloud_options: &crate::options::CloudOptions,
 ) -> anyhow::Result<ProjectInfo> {
-    msg!(
-        "Found `{}` in {}",
+    msg!("Found `{}` in {}",
         config_path
             .file_name()
             .unwrap_or_default()
             .to_string_lossy(),
-        project_dir.display()
-    );
+        project_dir.display());
     msg!("Initializing project...");
 
     let stash_dir = get_stash_path(project_dir)?;
@@ -667,7 +663,7 @@ pub fn init_existing(
 
     match &name {
         InstanceName::Cloud { org_slug, name } => {
-            msg!("Checking {} versions...", BRANDING_CLOUD);
+            msg!("Checking {BRANDING_CLOUD} versions...");
 
             let ver = cloud::versions::get_version(&ver_query, &client)
                 .with_context(|| "could not initialize project")?;
@@ -716,7 +712,7 @@ pub fn init_existing(
             )
         }
         InstanceName::Local(name) => {
-            msg!("Checking {} versions...", BRANDING);
+            msg!("Checking {BRANDING} versions...");
 
             let pkg = repository::get_server_package(&ver_query)?.with_context(|| {
                 format!(
@@ -998,7 +994,7 @@ pub fn init_new(
 
     match &inst_name {
         InstanceName::Cloud { org_slug, name } => {
-            msg!("Checking {} versions...", BRANDING_CLOUD);
+            msg!("Checking {BRANDING_CLOUD} versions...");
             client.ensure_authenticated()?;
 
             let (ver_query, version) = ask_cloud_version(options, &client)?;
@@ -1047,7 +1043,7 @@ pub fn init_new(
             )
         }
         InstanceName::Local(name) => {
-            msg!("Checking {} versions...", BRANDING);
+            msg!("Checking {BRANDING} versions...");
             let (ver_query, pkg) = ask_local_version(options)?;
             let specific_version = &pkg.version.specific();
             ver::print_version_hint(specific_version, &ver_query);
@@ -1231,11 +1227,8 @@ async fn migrate_async(inst: &Handle<'_>, ask_for_running: bool) -> anyhow::Resu
                     Retry => continue,
                     Skip => {
                         print::warn("Skipping migrations.");
-                        msg!(
-                            "You can use `{} migrate` to apply migrations \
-                               once the service is up and running.",
-                            BRANDING_CLI_CMD
-                        );
+                        msg!("You can use `{BRANDING_CLI_CMD} migrate` to apply migrations \
+                               once the service is up and running.");
                         return Ok(());
                     }
                 }
@@ -1422,18 +1415,14 @@ fn find_schema_files(path: &Path) -> anyhow::Result<bool> {
 fn print_initialized(name: &str, dir_option: &Option<PathBuf>) {
     print::success("Project initialized.");
     if let Some(dir) = dir_option {
-        msg!(
-            "To connect to {}, navigate to {} and run `{}`",
+        msg!("To connect to {}, navigate to {} and run `{}`",
             name.emphasize(),
             dir.display(),
-            BRANDING_CLI_CMD
-        );
+            BRANDING_CLI_CMD);
     } else {
-        msg!(
-            "To connect to {}, run `{}`",
+        msg!("To connect to {}, run `{}`",
             name.emphasize(),
-            BRANDING_CLI_CMD
-        );
+            BRANDING_CLI_CMD);
     }
 }
 
@@ -1734,11 +1723,9 @@ pub fn info(options: &Info) -> anyhow::Result<()> {
     };
     let stash_dir = get_stash_path(&root)?;
     if !stash_dir.exists() {
-        msg!(
-            "{} {} Run `edgedb project init`.",
+        msg!("{} {} Run `edgedb project init`.",
             print::err_marker(),
-            "Project is not initialized.".emphasize()
-        );
+            "Project is not initialized.".emphasize());
         return Err(ExitCode::new(1).into());
     }
     let instance_name = fs::read_to_string(stash_dir.join("instance-name"))?;
@@ -1910,11 +1897,9 @@ pub fn update_toml(
         } else {
             print::success("Config is up to date.");
         }
-        msg!(
-            "Run {} {} to initialize an instance.",
+        msg!("Run {} {} to initialize an instance.",
             BRANDING_CLI_CMD,
-            " project init".command_hint()
-        );
+            " project init".command_hint());
     } else {
         let name = instance_name(&stash_dir)?;
         let database = database_name(&stash_dir)?;
@@ -2029,25 +2014,21 @@ pub fn upgrade_instance(options: &Upgrade, opts: &crate::options::Options) -> an
             msg!("Canceled.");
         }
         upgrade::UpgradeAction::None => {
-            msg!(
-                "{BRANDING} instance is up to date with \
+            msg!("{BRANDING} instance is up to date with \
                 the specification in `{}`.",
                 config_path
                     .file_name()
                     .unwrap_or_default()
-                    .to_string_lossy()
-            );
+                    .to_string_lossy());
             if let Some(available) = result.available_upgrade {
                 msg!("New major version is available: {}", available.emphasize());
-                msg!(
-                    "To update `{}` and upgrade to this version, \
+                msg!("To update `{}` and upgrade to this version, \
                         run:\n    {} project upgrade --to-latest",
                     BRANDING_CLI_CMD,
                     config_path
                         .file_name()
                         .unwrap_or_default()
-                        .to_string_lossy()
-                );
+                        .to_string_lossy());
             }
         }
     }
@@ -2159,11 +2140,9 @@ fn upgrade_cloud(
 
     if let upgrade::UpgradeAction::Upgraded = result.action {
         let inst_name = format!("{org}/{name}");
-        msg!(
-            "Instance {} has been successfully upgraded to {}",
+        msg!("Instance {} has been successfully upgraded to {}",
             inst_name.emphasize(),
-            result.requested_version.emphasize().to_string() + "."
-        );
+            result.requested_version.emphasize().to_string() + ".");
     }
 
     Ok(result)

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -44,7 +44,7 @@ use crate::portable::upgrade;
 use crate::portable::ver;
 use crate::portable::ver::Specific;
 use crate::portable::windows;
-use crate::print::{self, echo, Highlight};
+use crate::print::{self, msg, Highlight};
 
 use crate::question;
 use crate::table;
@@ -421,15 +421,15 @@ fn link(
     config_path: PathBuf,
     cloud_options: &crate::options::CloudOptions,
 ) -> anyhow::Result<ProjectInfo> {
-    echo!(
-        "Found `{}` in",
+    msg!(
+        "Found `{}` in {} {}",
         config_path
             .file_name()
             .unwrap_or_default()
             .to_string_lossy(),
         project_dir.display()
     );
-    echo!("Linking project...");
+    msg!("Linking project...");
 
     let stash_dir = get_stash_path(project_dir)?;
     if stash_dir.exists() {
@@ -607,15 +607,15 @@ pub fn init_existing(
     config_path: PathBuf,
     cloud_options: &crate::options::CloudOptions,
 ) -> anyhow::Result<ProjectInfo> {
-    echo!(
-        "Found `{}` in",
+    msg!(
+        "Found `{}` in {} {}",
         config_path
             .file_name()
             .unwrap_or_default()
             .to_string_lossy(),
         project_dir.display()
     );
-    echo!("Initializing project...");
+    msg!("Initializing project...");
 
     let stash_dir = get_stash_path(project_dir)?;
     if stash_dir.exists() {
@@ -667,7 +667,7 @@ pub fn init_existing(
 
     match &name {
         InstanceName::Cloud { org_slug, name } => {
-            echo!("Checking", BRANDING_CLOUD, "versions...");
+            msg!("Checking {} versions...", BRANDING_CLOUD);
 
             let ver = cloud::versions::get_version(&ver_query, &client)
                 .with_context(|| "could not initialize project")?;
@@ -716,7 +716,7 @@ pub fn init_existing(
             )
         }
         InstanceName::Local(name) => {
-            echo!("Checking", BRANDING, "versions...");
+            msg!("Checking {} versions...", BRANDING);
 
             let pkg = repository::get_server_package(&ver_query)?.with_context(|| {
                 format!(
@@ -998,7 +998,7 @@ pub fn init_new(
 
     match &inst_name {
         InstanceName::Cloud { org_slug, name } => {
-            echo!("Checking", BRANDING_CLOUD, "versions...");
+            msg!("Checking {} versions...", BRANDING_CLOUD);
             client.ensure_authenticated()?;
 
             let (ver_query, version) = ask_cloud_version(options, &client)?;
@@ -1047,7 +1047,7 @@ pub fn init_new(
             )
         }
         InstanceName::Local(name) => {
-            echo!("Checking", BRANDING, "versions...");
+            msg!("Checking {} versions...", BRANDING);
             let (ver_query, pkg) = ask_local_version(options)?;
             let specific_version = &pkg.version.specific();
             ver::print_version_hint(specific_version, &ver_query);
@@ -1197,7 +1197,7 @@ async fn migrate_async(inst: &Handle<'_>, ask_for_running: bool) -> anyhow::Resu
         Skip,
     }
 
-    echo!("Applying migrations...");
+    msg!("Applying migrations...");
 
     let mut conn = loop {
         match inst.get_default_connection().await {
@@ -1231,11 +1231,10 @@ async fn migrate_async(inst: &Handle<'_>, ask_for_running: bool) -> anyhow::Resu
                     Retry => continue,
                     Skip => {
                         print::warn("Skipping migrations.");
-                        echo!(
-                            "You can use `",
-                            BRANDING_CLI_CMD,
-                            " migrate` to apply migrations \
-                               once the service is up and running."
+                        msg!(
+                            "You can use `{} migrate` to apply migrations \
+                               once the service is up and running.",
+                            BRANDING_CLI_CMD
                         );
                         return Ok(());
                     }
@@ -1423,10 +1422,18 @@ fn find_schema_files(path: &Path) -> anyhow::Result<bool> {
 fn print_initialized(name: &str, dir_option: &Option<PathBuf>) {
     print::success("Project initialized.");
     if let Some(dir) = dir_option {
-        echo!("To connect to", name.emphasize();
-              ", navigate to", dir.display(), "and run `", BRANDING_CLI_CMD, "`");
+        msg!(
+            "To connect to {}, navigate to {} and run `{}`",
+            name.emphasize(),
+            dir.display(),
+            BRANDING_CLI_CMD
+        );
     } else {
-        echo!("To connect to", name.emphasize(); ", run `", BRANDING_CLI_CMD, "`");
+        msg!(
+            "To connect to {}, run `{}`",
+            name.emphasize(),
+            BRANDING_CLI_CMD
+        );
     }
 }
 
@@ -1691,7 +1698,7 @@ pub fn unlink(options: &Unlink, opts: &crate::options::Options) -> anyhow::Resul
         } else {
             match fs::read_to_string(stash_path.join("instance-name")) {
                 Ok(name) => {
-                    echo!("Unlinking instance", name.emphasize());
+                    msg!("Unlinking instance {}", name.emphasize());
                 }
                 Err(e) => {
                     print::error(format!("Cannot read instance name: {e}"));
@@ -1727,10 +1734,10 @@ pub fn info(options: &Info) -> anyhow::Result<()> {
     };
     let stash_dir = get_stash_path(&root)?;
     if !stash_dir.exists() {
-        echo!(
+        msg!(
+            "{} {} Run `edgedb project init`.",
             print::err_marker(),
-            "Project is not initialized.".emphasize(),
-            "Run `edgedb project init`."
+            "Project is not initialized.".emphasize()
         );
         return Err(ExitCode::new(1).into());
     }
@@ -1903,11 +1910,10 @@ pub fn update_toml(
         } else {
             print::success("Config is up to date.");
         }
-        echo!(
-            "Run",
+        msg!(
+            "Run {} {} to initialize an instance.",
             BRANDING_CLI_CMD,
-            " project init".command_hint(),
-            "to initialize an instance."
+            " project init".command_hint()
         );
     } else {
         let name = instance_name(&stash_dir)?;
@@ -1936,21 +1942,16 @@ pub fn update_toml(
                 };
 
                 if config::modify_server_ver(&config_path, &config_version)? {
-                    echo!("Remember to commit it to version control.");
+                    msg!("Remember to commit it to version control.");
                 }
                 let name_str = name.to_string();
                 print_other_project_warning(&name_str, &root, &query)?;
             }
             upgrade::UpgradeAction::Cancelled => {
-                echo!("Canceled.");
+                msg!("Canceled.");
             }
             upgrade::UpgradeAction::None => {
-                echo!(
-                    "Already up to date.\nRequested upgrade version is",
-                    result.requested_version.emphasize().to_string() + ",",
-                    "current instance version is",
-                    result.prior_version.emphasize().to_string() + ".",
-                );
+                msg!("Already up to date.\nRequested upgrade version is {} current instance version is {}", result.requested_version.emphasize().to_string() + ",", result.prior_version.emphasize().to_string() + ".");
             }
         }
     };
@@ -2025,24 +2026,23 @@ pub fn upgrade_instance(options: &Upgrade, opts: &crate::options::Options) -> an
             // would have already printed a message.
         }
         upgrade::UpgradeAction::Cancelled => {
-            echo!("Canceled.");
+            msg!("Canceled.");
         }
         upgrade::UpgradeAction::None => {
-            echo!(
+            msg!(
                 "{BRANDING} instance is up to date with \
-                the specification in `{}`.",
+                the specification in `{}`. {}",
                 config_path
                     .file_name()
                     .unwrap_or_default()
                     .to_string_lossy()
             );
             if let Some(available) = result.available_upgrade {
-                echo!("New major version is available:", available.emphasize());
-                echo!(
+                msg!("New major version is available: {}", available.emphasize());
+                msg!(
                     "To update `{}` and upgrade to this version, \
-                        run:\n    ",
+                        run:\n    {} project upgrade --to-latest {}",
                     BRANDING_CLI_CMD,
-                    " project upgrade --to-latest",
                     config_path
                         .file_name()
                         .unwrap_or_default()
@@ -2159,10 +2159,9 @@ fn upgrade_cloud(
 
     if let upgrade::UpgradeAction::Upgraded = result.action {
         let inst_name = format!("{org}/{name}");
-        echo!(
-            "Instance",
+        msg!(
+            "Instance {} has been successfully upgraded to {}",
             inst_name.emphasize(),
-            "has been successfully upgraded to",
             result.requested_version.emphasize().to_string() + "."
         );
     }

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -44,7 +44,7 @@ use crate::portable::upgrade;
 use crate::portable::ver;
 use crate::portable::ver::Specific;
 use crate::portable::windows;
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 
 use crate::question;
 use crate::table;
@@ -421,12 +421,14 @@ fn link(
     config_path: PathBuf,
     cloud_options: &crate::options::CloudOptions,
 ) -> anyhow::Result<ProjectInfo> {
-    msg!("Found `{}` in {}",
+    msg!(
+        "Found `{}` in {}",
         config_path
             .file_name()
             .unwrap_or_default()
             .to_string_lossy(),
-        project_dir.display());
+        project_dir.display()
+    );
     msg!("Linking project...");
 
     let stash_dir = get_stash_path(project_dir)?;
@@ -605,12 +607,14 @@ pub fn init_existing(
     config_path: PathBuf,
     cloud_options: &crate::options::CloudOptions,
 ) -> anyhow::Result<ProjectInfo> {
-    msg!("Found `{}` in {}",
+    msg!(
+        "Found `{}` in {}",
         config_path
             .file_name()
             .unwrap_or_default()
             .to_string_lossy(),
-        project_dir.display());
+        project_dir.display()
+    );
     msg!("Initializing project...");
 
     let stash_dir = get_stash_path(project_dir)?;
@@ -1227,8 +1231,10 @@ async fn migrate_async(inst: &Handle<'_>, ask_for_running: bool) -> anyhow::Resu
                     Retry => continue,
                     Skip => {
                         print::warn("Skipping migrations.");
-                        msg!("You can use `{BRANDING_CLI_CMD} migrate` to apply migrations \
-                               once the service is up and running.");
+                        msg!(
+                            "You can use `{BRANDING_CLI_CMD} migrate` to apply migrations \
+                               once the service is up and running."
+                        );
                         return Ok(());
                     }
                 }
@@ -1415,14 +1421,18 @@ fn find_schema_files(path: &Path) -> anyhow::Result<bool> {
 fn print_initialized(name: &str, dir_option: &Option<PathBuf>) {
     print::success("Project initialized.");
     if let Some(dir) = dir_option {
-        msg!("To connect to {}, navigate to {} and run `{}`",
+        msg!(
+            "To connect to {}, navigate to {} and run `{}`",
             name.emphasize(),
             dir.display(),
-            BRANDING_CLI_CMD);
+            BRANDING_CLI_CMD
+        );
     } else {
-        msg!("To connect to {}, run `{}`",
+        msg!(
+            "To connect to {}, run `{}`",
             name.emphasize(),
-            BRANDING_CLI_CMD);
+            BRANDING_CLI_CMD
+        );
     }
 }
 
@@ -1723,9 +1733,11 @@ pub fn info(options: &Info) -> anyhow::Result<()> {
     };
     let stash_dir = get_stash_path(&root)?;
     if !stash_dir.exists() {
-        msg!("{} {} Run `edgedb project init`.",
+        msg!(
+            "{} {} Run `edgedb project init`.",
             print::err_marker(),
-            "Project is not initialized.".emphasize());
+            "Project is not initialized.".emphasize()
+        );
         return Err(ExitCode::new(1).into());
     }
     let instance_name = fs::read_to_string(stash_dir.join("instance-name"))?;
@@ -1897,9 +1909,11 @@ pub fn update_toml(
         } else {
             print::success("Config is up to date.");
         }
-        msg!("Run {} {} to initialize an instance.",
+        msg!(
+            "Run {} {} to initialize an instance.",
             BRANDING_CLI_CMD,
-            " project init".command_hint());
+            " project init".command_hint()
+        );
     } else {
         let name = instance_name(&stash_dir)?;
         let database = database_name(&stash_dir)?;
@@ -2014,21 +2028,25 @@ pub fn upgrade_instance(options: &Upgrade, opts: &crate::options::Options) -> an
             msg!("Canceled.");
         }
         upgrade::UpgradeAction::None => {
-            msg!("{BRANDING} instance is up to date with \
+            msg!(
+                "{BRANDING} instance is up to date with \
                 the specification in `{}`.",
                 config_path
                     .file_name()
                     .unwrap_or_default()
-                    .to_string_lossy());
+                    .to_string_lossy()
+            );
             if let Some(available) = result.available_upgrade {
                 msg!("New major version is available: {}", available.emphasize());
-                msg!("To update `{}` and upgrade to this version, \
+                msg!(
+                    "To update `{}` and upgrade to this version, \
                         run:\n    {} project upgrade --to-latest",
                     BRANDING_CLI_CMD,
                     config_path
                         .file_name()
                         .unwrap_or_default()
-                        .to_string_lossy());
+                        .to_string_lossy()
+                );
             }
         }
     }
@@ -2140,9 +2158,11 @@ fn upgrade_cloud(
 
     if let upgrade::UpgradeAction::Upgraded = result.action {
         let inst_name = format!("{org}/{name}");
-        msg!("Instance {} has been successfully upgraded to {}",
+        msg!(
+            "Instance {} has been successfully upgraded to {}",
             inst_name.emphasize(),
-            result.requested_version.emphasize().to_string() + ".");
+            result.requested_version.emphasize().to_string() + "."
+        );
     }
 
     Ok(result)

--- a/src/portable/resize.rs
+++ b/src/portable/resize.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::cloud;
 use crate::portable::options::{InstanceName, Resize};
-use crate::print::echo;
+use crate::print::msg;
 use crate::question;
 
 pub fn resize(cmd: &Resize, opts: &crate::options::Options) -> anyhow::Result<()> {
@@ -178,13 +178,12 @@ fn resize_cloud_cmd(
         };
         cloud::ops::resize_cloud_instance(&client, &request)?;
     }
-    echo!(
+    msg!(
+        "{} instance {} has been resized successfuly.",
         BRANDING_CLOUD,
-        " instance",
-        inst_name,
-        "has been resized successfuly."
+        inst_name
     );
-    echo!("To connect to the instance run:");
-    echo!("  ", BRANDING_CLI_CMD, "-I", inst_name);
+    msg!("To connect to the instance run:");
+    msg!("  {} -I {}", BRANDING_CLI_CMD, inst_name);
     Ok(())
 }

--- a/src/portable/resize.rs
+++ b/src/portable/resize.rs
@@ -5,6 +5,7 @@ use anyhow::Context;
 use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::cloud;
 use crate::portable::options::{InstanceName, Resize};
+use crate::print::msg;
 use crate::question;
 
 pub fn resize(cmd: &Resize, opts: &crate::options::Options) -> anyhow::Result<()> {

--- a/src/portable/resize.rs
+++ b/src/portable/resize.rs
@@ -5,7 +5,6 @@ use anyhow::Context;
 use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::cloud;
 use crate::portable::options::{InstanceName, Resize};
-use crate::print::msg;
 use crate::question;
 
 pub fn resize(cmd: &Resize, opts: &crate::options::Options) -> anyhow::Result<()> {
@@ -178,12 +177,8 @@ fn resize_cloud_cmd(
         };
         cloud::ops::resize_cloud_instance(&client, &request)?;
     }
-    msg!(
-        "{} instance {} has been resized successfuly.",
-        BRANDING_CLOUD,
-        inst_name
-    );
+    msg!("{BRANDING_CLOUD} instance {inst_name} has been resized successfuly.");
     msg!("To connect to the instance run:");
-    msg!("  {} -I {}", BRANDING_CLI_CMD, inst_name);
+    msg!("  {BRANDING_CLI_CMD} -I {inst_name}");
     Ok(())
 }

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -14,7 +14,7 @@ use crate::portable::install;
 use crate::portable::local::Paths;
 use crate::portable::options::{instance_arg, InstanceName, Revert};
 use crate::portable::status::{instance_status, BackupStatus, DataDirectory};
-use crate::print::{self, msg, Highlight};
+use crate::print::{self, Highlight};
 use crate::process;
 use crate::question;
 
@@ -54,19 +54,15 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
         } => (b, d),
     };
     msg!("{} version: {:?}", BRANDING, old_inst.get_version());
-    msg!(
-        "Backup timestamp: {} {}",
+    msg!("Backup timestamp: {} {}",
         humantime::format_rfc3339(backup_info.timestamp),
-        format!("({})", format::done_before(backup_info.timestamp))
-    );
+        format!("({})", format::done_before(backup_info.timestamp)));
     if !options.ignore_pid_check {
         match status.data_status {
             DataDirectory::Upgrading(Ok(up)) if process::exists(up.pid) => {
-                msg!(
-                    "Upgrade appears to still be in progress \
+                msg!("Upgrade appears to still be in progress \
                     with pid {}",
-                    up.pid.emphasize()
-                );
+                    up.pid.emphasize());
                 msg!("Run with `--ignore-pid-check` to override");
                 Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
             }
@@ -78,10 +74,8 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
     }
     if !options.no_confirm {
         eprintln!();
-        msg!(
-            "Currently stored data {} and overwritten by the backup.",
-            "will be lost".emphasize()
-        );
+        msg!("Currently stored data {} and overwritten by the backup.",
+            "will be lost".emphasize());
         let q = question::Confirm::new_dangerous("Do you really want to revert?");
         if !q.ask()? {
             print::error("Canceled.");
@@ -109,7 +103,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
     fs::rename(&paths.backup_dir, &paths.data_dir)?;
 
     let inst = old_inst;
-    msg!("Starting {} {}...", BRANDING, inst.get_version()?);
+    msg!("Starting {} {:?}...", BRANDING, inst.get_version());
 
     create::create_service(&inst)
         .map_err(|e| {
@@ -118,11 +112,9 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
         .ok();
 
     control::do_restart(&inst)?;
-    msg!(
-        "Instance {} is successfully reverted to {}",
+    msg!("Instance {} is successfully reverted to {}",
         inst.name.emphasize(),
-        inst.get_version()?.emphasize()
-    );
+        inst.get_version()?.emphasize());
 
     fs::remove_file(paths.data_dir.join("backup.json"))?;
     fs::remove_dir_all(&tmp_path)?;

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -53,7 +53,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
             data_meta: Ok(d),
         } => (b, d),
     };
-    msg!("{} version: {}", BRANDING, old_inst.get_version());
+    msg!("{} version: {:?}", BRANDING, old_inst.get_version());
     msg!(
         "Backup timestamp: {} {}",
         humantime::format_rfc3339(backup_info.timestamp),

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -14,7 +14,7 @@ use crate::portable::install;
 use crate::portable::local::Paths;
 use crate::portable::options::{instance_arg, InstanceName, Revert};
 use crate::portable::status::{instance_status, BackupStatus, DataDirectory};
-use crate::print::{self, echo, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::process;
 use crate::question;
 
@@ -53,35 +53,34 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
             data_meta: Ok(d),
         } => (b, d),
     };
-    echo!(BRANDING, "version:", old_inst.get_version()?);
-    echo!(
-        "Backup timestamp:",
+    msg!("{} version: {}", BRANDING, old_inst.get_version());
+    msg!(
+        "Backup timestamp: {} {}",
         humantime::format_rfc3339(backup_info.timestamp),
         format!("({})", format::done_before(backup_info.timestamp))
     );
     if !options.ignore_pid_check {
         match status.data_status {
             DataDirectory::Upgrading(Ok(up)) if process::exists(up.pid) => {
-                echo!(
+                msg!(
                     "Upgrade appears to still be in progress \
-                    with pid",
-                    up.pid.emphasize(),
+                    with pid {}",
+                    up.pid.emphasize()
                 );
-                echo!("Run with `--ignore-pid-check` to override");
+                msg!("Run with `--ignore-pid-check` to override");
                 Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
             }
             DataDirectory::Upgrading(_) => {
-                echo!("Note: backup appears to be from a broken upgrade");
+                msg!("Note: backup appears to be from a broken upgrade");
             }
             _ => {}
         }
     }
     if !options.no_confirm {
         eprintln!();
-        echo!(
-            "Currently stored data",
-            "will be lost".emphasize(),
-            "and overwritten by the backup."
+        msg!(
+            "Currently stored data {} and overwritten by the backup.",
+            "will be lost".emphasize()
         );
         let q = question::Confirm::new_dangerous("Do you really want to revert?");
         if !q.ask()? {
@@ -110,7 +109,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
     fs::rename(&paths.backup_dir, &paths.data_dir)?;
 
     let inst = old_inst;
-    echo!("Starting", BRANDING, inst.get_version()?; "...");
+    msg!("Starting {} {}...", BRANDING, inst.get_version()?);
 
     create::create_service(&inst)
         .map_err(|e| {
@@ -119,10 +118,9 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
         .ok();
 
     control::do_restart(&inst)?;
-    echo!(
-        "Instance",
+    msg!(
+        "Instance {} is successfully reverted to {}",
         inst.name.emphasize(),
-        "is successfully reverted to",
         inst.get_version()?.emphasize()
     );
 

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -14,7 +14,7 @@ use crate::portable::install;
 use crate::portable::local::Paths;
 use crate::portable::options::{instance_arg, InstanceName, Revert};
 use crate::portable::status::{instance_status, BackupStatus, DataDirectory};
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::process;
 use crate::question;
 
@@ -54,15 +54,19 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
         } => (b, d),
     };
     msg!("{} version: {:?}", BRANDING, old_inst.get_version());
-    msg!("Backup timestamp: {} {}",
+    msg!(
+        "Backup timestamp: {} {}",
         humantime::format_rfc3339(backup_info.timestamp),
-        format!("({})", format::done_before(backup_info.timestamp)));
+        format!("({})", format::done_before(backup_info.timestamp))
+    );
     if !options.ignore_pid_check {
         match status.data_status {
             DataDirectory::Upgrading(Ok(up)) if process::exists(up.pid) => {
-                msg!("Upgrade appears to still be in progress \
+                msg!(
+                    "Upgrade appears to still be in progress \
                     with pid {}",
-                    up.pid.emphasize());
+                    up.pid.emphasize()
+                );
                 msg!("Run with `--ignore-pid-check` to override");
                 Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
             }
@@ -74,8 +78,10 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
     }
     if !options.no_confirm {
         eprintln!();
-        msg!("Currently stored data {} and overwritten by the backup.",
-            "will be lost".emphasize());
+        msg!(
+            "Currently stored data {} and overwritten by the backup.",
+            "will be lost".emphasize()
+        );
         let q = question::Confirm::new_dangerous("Do you really want to revert?");
         if !q.ask()? {
             print::error("Canceled.");
@@ -112,9 +118,11 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
         .ok();
 
     control::do_restart(&inst)?;
-    msg!("Instance {} is successfully reverted to {}",
+    msg!(
+        "Instance {} is successfully reverted to {}",
         inst.name.emphasize(),
-        inst.get_version()?.emphasize());
+        inst.get_version()?.emphasize()
+    );
 
     fs::remove_file(paths.data_dir.join("backup.json"))?;
     fs::remove_dir_all(&tmp_path)?;

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -33,7 +33,7 @@ use crate::portable::local::{InstanceInfo, Paths};
 use crate::portable::options::{instance_arg, InstanceName, List, Status};
 use crate::portable::upgrade::{BackupMeta, UpgradeMeta};
 use crate::portable::{linux, macos, windows};
-use crate::print::{self, msg, Highlight};
+use crate::print::{self, Highlight};
 use crate::process;
 use crate::table::{self, Cell, Row, Table};
 
@@ -312,11 +312,9 @@ async fn _remote_status(name: &str, quiet: bool) -> anyhow::Result<RemoteStatus>
     let cred_path = credentials::path(name)?;
     if !cred_path.exists() {
         if !quiet {
-            msg!(
-                "{} No instance {} found",
+            msg!("{} No instance {} found",
                 print::err_marker(),
-                name.emphasize()
-            );
+                name.emphasize());
         }
         return Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into());
     }

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -33,7 +33,7 @@ use crate::portable::local::{InstanceInfo, Paths};
 use crate::portable::options::{instance_arg, InstanceName, List, Status};
 use crate::portable::upgrade::{BackupMeta, UpgradeMeta};
 use crate::portable::{linux, macos, windows};
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::process;
 use crate::table::{self, Cell, Row, Table};
 
@@ -312,9 +312,11 @@ async fn _remote_status(name: &str, quiet: bool) -> anyhow::Result<RemoteStatus>
     let cred_path = credentials::path(name)?;
     if !cred_path.exists() {
         if !quiet {
-            msg!("{} No instance {} found",
+            msg!(
+                "{} No instance {} found",
                 print::err_marker(),
-                name.emphasize());
+                name.emphasize()
+            );
         }
         return Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into());
     }

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -33,7 +33,7 @@ use crate::portable::local::{InstanceInfo, Paths};
 use crate::portable::options::{instance_arg, InstanceName, List, Status};
 use crate::portable::upgrade::{BackupMeta, UpgradeMeta};
 use crate::portable::{linux, macos, windows};
-use crate::print::{self, echo, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::process;
 use crate::table::{self, Cell, Row, Table};
 
@@ -312,11 +312,10 @@ async fn _remote_status(name: &str, quiet: bool) -> anyhow::Result<RemoteStatus>
     let cred_path = credentials::path(name)?;
     if !cred_path.exists() {
         if !quiet {
-            echo!(
+            msg!(
+                "{} No instance {} found",
                 print::err_marker(),
-                "No instance",
-                name.emphasize(),
-                "found"
+                name.emphasize()
             );
         }
         return Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into());

--- a/src/portable/uninstall.rs
+++ b/src/portable/uninstall.rs
@@ -10,7 +10,7 @@ use crate::portable::options::Uninstall;
 use crate::portable::repository::Query;
 use crate::portable::status;
 use crate::portable::ver;
-use crate::print::{self, msg, Highlight};
+use crate::print::{self, Highlight};
 
 pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
     let mut candidates = local::get_installed()?;
@@ -72,10 +72,8 @@ pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
         print::error("some instances are in use. See messages above.");
         Err(ExitCode::new(exit_codes::PARTIAL_SUCCESS))?;
     } else if uninstalled > 0 {
-        msg!(
-            "Successfully uninstalled {} versions.",
-            uninstalled.emphasize()
-        );
+        msg!("Successfully uninstalled {} versions.",
+            uninstalled.emphasize());
     } else {
         print::success("Nothing to uninstall.")
     }

--- a/src/portable/uninstall.rs
+++ b/src/portable/uninstall.rs
@@ -10,7 +10,7 @@ use crate::portable::options::Uninstall;
 use crate::portable::repository::Query;
 use crate::portable::status;
 use crate::portable::ver;
-use crate::print::{self, echo, Highlight};
+use crate::print::{self, msg, Highlight};
 
 pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
     let mut candidates = local::get_installed()?;
@@ -68,14 +68,13 @@ pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
     }
 
     if !all && !options.unused {
-        echo!("Uninstalled", uninstalled.emphasize(), "versions.");
+        msg!("Uninstalled {} versions.", uninstalled.emphasize());
         print::error("some instances are in use. See messages above.");
         Err(ExitCode::new(exit_codes::PARTIAL_SUCCESS))?;
     } else if uninstalled > 0 {
-        echo!(
-            "Successfully uninstalled",
-            uninstalled.emphasize(),
-            "versions."
+        msg!(
+            "Successfully uninstalled {} versions.",
+            uninstalled.emphasize()
         );
     } else {
         print::success("Nothing to uninstall.")

--- a/src/portable/uninstall.rs
+++ b/src/portable/uninstall.rs
@@ -10,7 +10,7 @@ use crate::portable::options::Uninstall;
 use crate::portable::repository::Query;
 use crate::portable::status;
 use crate::portable::ver;
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 
 pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
     let mut candidates = local::get_installed()?;
@@ -72,8 +72,10 @@ pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
         print::error("some instances are in use. See messages above.");
         Err(ExitCode::new(exit_codes::PARTIAL_SUCCESS))?;
     } else if uninstalled > 0 {
-        msg!("Successfully uninstalled {} versions.",
-            uninstalled.emphasize());
+        msg!(
+            "Successfully uninstalled {} versions.",
+            uninstalled.emphasize()
+        );
     } else {
         print::success("Nothing to uninstall.")
     }

--- a/src/portable/upgrade.rs
+++ b/src/portable/upgrade.rs
@@ -21,7 +21,7 @@ use crate::portable::project;
 use crate::portable::repository::{self, Channel, PackageInfo, Query, QueryOptions};
 use crate::portable::ver;
 use crate::portable::windows;
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::question;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
@@ -139,9 +139,11 @@ fn upgrade_local_cmd(cmd: &Upgrade, name: &str) -> anyhow::Result<()> {
     let pkg_ver = pkg.version.specific();
 
     if pkg_ver <= inst_ver && !cmd.force {
-        msg!("Latest version found {} current instance version is {} Already up to date.",
+        msg!(
+            "Latest version found {} current instance version is {} Already up to date.",
             pkg.version.to_string() + ",",
-            inst.get_version()?.emphasize().to_string() + ".");
+            inst.get_version()?.emphasize().to_string() + "."
+        );
         return Ok(());
     }
     ver::print_version_hint(&pkg_ver, &ver_query);
@@ -199,8 +201,10 @@ fn upgrade_cloud_cmd(
 
     match result.action {
         UpgradeAction::Upgraded => {
-            msg!("{BRANDING_CLOUD} instance {inst_name} has been successfully \
-                upgraded to version {target_ver_str}.");
+            msg!(
+                "{BRANDING_CLOUD} instance {inst_name} has been successfully \
+                upgraded to version {target_ver_str}."
+            );
         }
         UpgradeAction::Cancelled => {
             msg!("Canceled.");
@@ -274,9 +278,11 @@ pub fn upgrade_compatible(mut inst: InstanceInfo, pkg: PackageInfo) -> anyhow::R
         })
         .ok();
     control::do_restart(&inst)?;
-    msg!("Instance {} successfully upgraded to {}",
+    msg!(
+        "Instance {} successfully upgraded to {}",
         inst.name.emphasize(),
-        pkg.version.emphasize());
+        pkg.version.emphasize()
+    );
     Ok(())
 }
 
@@ -350,9 +356,11 @@ pub fn upgrade_incompatible(
         .ok();
     control::do_restart(&inst)?;
 
-    msg!("Instance {} successfully upgraded to {}",
+    msg!(
+        "Instance {} successfully upgraded to {}",
         inst.name.emphasize(),
-        pkg.version.emphasize());
+        pkg.version.emphasize()
+    );
 
     Ok(())
 }

--- a/src/portable/upgrade.rs
+++ b/src/portable/upgrade.rs
@@ -21,7 +21,7 @@ use crate::portable::project;
 use crate::portable::repository::{self, Channel, PackageInfo, Query, QueryOptions};
 use crate::portable::ver;
 use crate::portable::windows;
-use crate::print::{self, msg, Highlight};
+use crate::print::{self, Highlight};
 use crate::question;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
@@ -139,11 +139,9 @@ fn upgrade_local_cmd(cmd: &Upgrade, name: &str) -> anyhow::Result<()> {
     let pkg_ver = pkg.version.specific();
 
     if pkg_ver <= inst_ver && !cmd.force {
-        msg!(
-            "Latest version found {} current instance version is {} Already up to date.",
+        msg!("Latest version found {} current instance version is {} Already up to date.",
             pkg.version.to_string() + ",",
-            inst.get_version()?.emphasize().to_string() + "."
-        );
+            inst.get_version()?.emphasize().to_string() + ".");
         return Ok(());
     }
     ver::print_version_hint(&pkg_ver, &ver_query);
@@ -201,10 +199,8 @@ fn upgrade_cloud_cmd(
 
     match result.action {
         UpgradeAction::Upgraded => {
-            msg!(
-                "{BRANDING_CLOUD} instance {inst_name} has been successfully \
-                upgraded to version {target_ver_str}."
-            );
+            msg!("{BRANDING_CLOUD} instance {inst_name} has been successfully \
+                upgraded to version {target_ver_str}.");
         }
         UpgradeAction::Cancelled => {
             msg!("Canceled.");
@@ -278,11 +274,9 @@ pub fn upgrade_compatible(mut inst: InstanceInfo, pkg: PackageInfo) -> anyhow::R
         })
         .ok();
     control::do_restart(&inst)?;
-    msg!(
-        "Instance {} successfully upgraded to {}",
+    msg!("Instance {} successfully upgraded to {}",
         inst.name.emphasize(),
-        pkg.version.emphasize()
-    );
+        pkg.version.emphasize());
     Ok(())
 }
 
@@ -356,11 +350,9 @@ pub fn upgrade_incompatible(
         .ok();
     control::do_restart(&inst)?;
 
-    msg!(
-        "Instance {} successfully upgraded to {}",
+    msg!("Instance {} successfully upgraded to {}",
         inst.name.emphasize(),
-        pkg.version.emphasize()
-    );
+        pkg.version.emphasize());
 
     Ok(())
 }

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -10,7 +10,7 @@ use regex::Regex;
 use crate::branding::BRANDING_CLI_CMD;
 use crate::connect::Connection;
 use crate::portable::repository::Query;
-use crate::print::{msg, Highlight};
+use crate::print::{Highlight};
 use crate::process::{self, IntoArg};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -396,12 +396,10 @@ pub async fn check_client(cli: &mut Connection, minimum_version: &Build) -> anyh
 pub fn print_version_hint(version: &Specific, ver_query: &Query) {
     if let Some(filter) = &ver_query.version {
         if !filter.matches_exact(version) {
-            msg!(
-                "Using {} (matches `{}`), use `{}` for exact version",
+            msg!("Using {} (matches `{}`), use `{}` for exact version",
                 version.emphasize(),
                 filter,
-                filter.clone().with_exact()
-            );
+                filter.clone().with_exact());
         }
     }
 }

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -10,7 +10,7 @@ use regex::Regex;
 use crate::branding::BRANDING_CLI_CMD;
 use crate::connect::Connection;
 use crate::portable::repository::Query;
-use crate::print::{echo, Highlight};
+use crate::print::{msg, Highlight};
 use crate::process::{self, IntoArg};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -396,9 +396,12 @@ pub async fn check_client(cli: &mut Connection, minimum_version: &Build) -> anyh
 pub fn print_version_hint(version: &Specific, ver_query: &Query) {
     if let Some(filter) = &ver_query.version {
         if !filter.matches_exact(version) {
-            echo!("Using", version.emphasize(),
-                "(matches `"; filter; "`), use `"; filter.clone().with_exact();
-                "` for exact version");
+            msg!(
+                "Using {} (matches `{}`), use `{}` for exact version",
+                version.emphasize(),
+                filter,
+                filter.clone().with_exact()
+            );
         }
     }
 }

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -10,7 +10,7 @@ use regex::Regex;
 use crate::branding::BRANDING_CLI_CMD;
 use crate::connect::Connection;
 use crate::portable::repository::Query;
-use crate::print::{Highlight};
+use crate::print::{msg, Highlight};
 use crate::process::{self, IntoArg};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -396,10 +396,12 @@ pub async fn check_client(cli: &mut Connection, minimum_version: &Build) -> anyh
 pub fn print_version_hint(version: &Specific, ver_query: &Query) {
     if let Some(filter) = &ver_query.version {
         if !filter.matches_exact(version) {
-            msg!("Using {} (matches `{}`), use `{}` for exact version",
+            msg!(
+                "Using {} (matches `{}`), use `{}` for exact version",
                 version.emphasize(),
                 filter,
-                filter.clone().with_exact());
+                filter.clone().with_exact()
+            );
         }
     }
 }

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -866,10 +866,8 @@ pub fn status(options: &options::Status) -> anyhow::Result<()> {
                 .args(options)
                 .run()?;
         } else {
-            msg!(
-                "WSL distribution is not installed, \
-                   so no {BRANDING} instances are present."
-            );
+            msg!("WSL distribution is not installed, \
+                   so no {BRANDING} instances are present.");
             return Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into());
         }
     } else {

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -32,7 +32,7 @@ use crate::portable::project;
 use crate::portable::repository::{self, download, PackageHash, PackageInfo};
 use crate::portable::status::{self, Service};
 use crate::portable::ver;
-use crate::print::{self, echo, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::process;
 
 const CURRENT_DISTRO: &str = BRANDING_WSL;
@@ -264,7 +264,7 @@ pub fn destroy(options: &options::Destroy, name: &str) -> anyhow::Result<()> {
         }
     }
     if !found {
-        echo!("No instance named", name.emphasize(), "found");
+        msg!("No instance named {} found", name.emphasize());
         return Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into());
     }
     Ok(())
@@ -456,7 +456,7 @@ fn get_wsl_distro(install: bool) -> anyhow::Result<Wsl> {
 
             let download_path = download_dir.join("debian.zip");
             download(&download_path, &*DISTRO_URL, false)?;
-            echo!("Unpacking WSL distribution...");
+            msg!("Unpacking WSL distribution...");
             let appx_path = download_dir.join("debian.appx");
             unpack_appx(&download_path, &appx_path)?;
             let root_path = download_dir.join("install.tar");
@@ -464,7 +464,7 @@ fn get_wsl_distro(install: bool) -> anyhow::Result<Wsl> {
 
             let distro_path = wsl_dir()?.join(CURRENT_DISTRO);
             fs::create_dir_all(&distro_path)?;
-            echo!("Initializing WSL distribution...");
+            msg!("Initializing WSL distribution...");
 
             let result = process::Native::new("wsl check", "wsl", "wsl")
                 .arg("--help")
@@ -509,7 +509,7 @@ fn get_wsl_distro(install: bool) -> anyhow::Result<Wsl> {
     }
 
     if update_cli {
-        echo!("Updating container CLI version...");
+        msg!("Updating container CLI version...");
         if let Some(bin_path) = env::var_os("_EDGEDB_WSL_LINUX_BINARY") {
             let bin_path = fs::canonicalize(bin_path)?;
             wsl_simple_cmd(
@@ -537,7 +537,7 @@ fn get_wsl_distro(install: bool) -> anyhow::Result<Wsl> {
     let certs_timestamp = if let Some(ts) = certs_timestamp {
         ts
     } else {
-        echo!("Checking certificate updates...");
+        msg!("Checking certificate updates...");
         process::Native::new("update certificates", "apt", "wsl")
             .arg("--distribution")
             .arg(&distro)
@@ -866,7 +866,7 @@ pub fn status(options: &options::Status) -> anyhow::Result<()> {
                 .args(options)
                 .run()?;
         } else {
-            echo!(
+            msg!(
                 "WSL distribution is not installed, \
                    so no {BRANDING} instances are present."
             );

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -866,8 +866,10 @@ pub fn status(options: &options::Status) -> anyhow::Result<()> {
                 .args(options)
                 .run()?;
         } else {
-            msg!("WSL distribution is not installed, \
-                   so no {BRANDING} instances are present.");
+            msg!(
+                "WSL distribution is not installed, \
+                   so no {BRANDING} instances are present."
+            );
             return Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into());
         }
     } else {

--- a/src/print/color.rs
+++ b/src/print/color.rs
@@ -147,40 +147,6 @@ impl<T: fmt::Display> fmt::Display for Colored<&T> {
     }
 }
 
-#[deprecated(note = "use msg! instead")]
-#[macro_export]
-macro_rules! echo {
-    ($word1:expr $(; $semi_word1:expr)*
-     $(,$word:expr $(; $semi_word:expr )*)* $(,)?) => {
-        // Buffer the whole output so mutliple processes do not interfere
-        // each other
-        {
-            use ::std::fmt::Write;
-            let mut buf = ::std::string::String::with_capacity(4096);
-            write!(&mut buf, "{}", $word1)
-                .expect("buffering of echo succeeds");
-            $(
-                write!(&mut buf, "{}", $semi_word1)
-                    .expect("buffering of echo succeeds");
-            )*
-            $(
-                buf.push(' ');
-                write!(&mut buf, "{}", $word)
-                    .expect("buffering of echo succeeds");
-                $(
-                    write!(&mut buf, "{}", $semi_word)
-                        .expect("buffering of echo succeeds");
-                )*
-            )*
-            if cfg!(windows) {
-                buf.push('\r');
-            }
-            buf.push('\n');
-            eprint!("{}", buf);
-        };
-    }
-}
-
 #[macro_export]
 macro_rules! msg {
     ($($tt:tt)*) => {

--- a/src/print/color.rs
+++ b/src/print/color.rs
@@ -147,6 +147,7 @@ impl<T: fmt::Display> fmt::Display for Colored<&T> {
     }
 }
 
+#[deprecated(note = "use msg! instead")]
 #[macro_export]
 macro_rules! echo {
     ($word1:expr $(; $semi_word1:expr)*
@@ -177,5 +178,12 @@ macro_rules! echo {
             buf.push('\n');
             eprint!("{}", buf);
         };
+    }
+}
+
+#[macro_export]
+macro_rules! msg {
+    ($($tt:tt)*) => {
+        eprintln!($($tt)*);
     }
 }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -420,9 +420,11 @@ pub fn success(line: impl fmt::Display) {
 
 pub fn success_msg(title: impl fmt::Display, msg: impl fmt::Display) {
     if use_color() {
-        msg!("{}: {}",
+        msg!(
+            "{}: {}",
             title.to_string().bold().light_green(),
-            msg.to_string().bold().white());
+            msg.to_string().bold().white()
+        );
     } else {
         msg!("{title}: {msg}");
     }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -15,7 +15,7 @@ use edgedb_errors::display::display_error;
 use crate::branding::BRANDING_CLI_CMD;
 use crate::repl::VectorLimit;
 
-pub use crate::{echo, msg};
+pub use crate::msg;
 
 mod buffer;
 mod color;

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -414,19 +414,17 @@ pub fn success(line: impl fmt::Display) {
     if use_color() {
         msg!("{}", line.to_string().bold().light_green());
     } else {
-        msg!("{}", line);
+        msg!("{line}");
     }
 }
 
 pub fn success_msg(title: impl fmt::Display, msg: impl fmt::Display) {
     if use_color() {
-        msg!(
-            "{}: {}",
+        msg!("{}: {}",
             title.to_string().bold().light_green(),
-            msg.to_string().bold().white()
-        );
+            msg.to_string().bold().white());
     } else {
-        msg!("{}: {}", title, msg);
+        msg!("{title}: {msg}");
     }
 }
 
@@ -434,6 +432,6 @@ pub fn warn(line: impl fmt::Display) {
     if use_color() {
         msg!("{}", line.to_string().bold().yellow());
     } else {
-        msg!("{}", line);
+        msg!("{line}");
     }
 }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -15,7 +15,7 @@ use edgedb_errors::display::display_error;
 use crate::branding::BRANDING_CLI_CMD;
 use crate::repl::VectorLimit;
 
-pub use crate::echo;
+pub use crate::{echo, msg};
 
 mod buffer;
 mod color;

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -398,41 +398,42 @@ pub fn err_marker() -> impl fmt::Display {
 pub fn error(line: impl fmt::Display) {
     let text = format!("{line:#}");
     if text.len() > 60 {
-        echo!(err_marker(), text);
+        msg!("{} {}", err_marker(), text);
     } else {
         // Emphasise only short lines. Long lines with bold look ugly.
-        echo!(err_marker(), text.emphasize());
+        msg!("{} {}", err_marker(), text.emphasize());
     }
 }
 
 pub fn edgedb_error(err: &edgedb_errors::Error, verbose: bool) {
     // Note: not using `error()` as display_error has markup inside
-    echo!(err_marker(), display_error(err, verbose));
+    msg!("{} {}", err_marker(), display_error(err, verbose));
 }
 
 pub fn success(line: impl fmt::Display) {
     if use_color() {
-        echo!(line.to_string().bold().light_green());
+        msg!("{}", line.to_string().bold().light_green());
     } else {
-        echo!(line);
+        msg!("{}", line);
     }
 }
 
 pub fn success_msg(title: impl fmt::Display, msg: impl fmt::Display) {
     if use_color() {
-        echo!(
-            title.to_string().bold().light_green(); ":",
-            msg.to_string().bold().white(),
+        msg!(
+            "{}: {}",
+            title.to_string().bold().light_green(),
+            msg.to_string().bold().white()
         );
     } else {
-        echo!(title; ":", msg);
+        msg!("{}: {}", title, msg);
     }
 }
 
 pub fn warn(line: impl fmt::Display) {
     if use_color() {
-        echo!(line.to_string().bold().yellow());
+        msg!("{}", line.to_string().bold().yellow());
     } else {
-        echo!(line);
+        msg!("{}", line);
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -21,7 +21,7 @@ use crate::async_util::timeout;
 use crate::branding::BRANDING;
 use crate::connect::Connection;
 use crate::connect::Connector;
-use crate::echo;
+use crate::msg;
 use crate::portable::ver;
 use crate::print::{self, Highlight};
 use crate::prompt::variable::VariableInput;
@@ -164,10 +164,11 @@ impl State {
         Ok(())
     }
     fn print_banner(&self, version: &ver::Build) -> anyhow::Result<()> {
-        echo!(
+        msg!(
+            "{} {} {}",
             format!("{}\r{BRANDING}", ansi_escapes::EraseLine).light_gray(),
             version.to_string().light_gray(),
-            format_args!("(repl {})", env!("CARGO_PKG_VERSION")).fade(),
+            format_args!("(repl {})", env!("CARGO_PKG_VERSION")).fade()
         );
         Ok(())
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -22,7 +22,7 @@ use crate::branding::BRANDING;
 use crate::connect::Connection;
 use crate::connect::Connector;
 use crate::portable::ver;
-use crate::print::{self, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::prompt::variable::VariableInput;
 use crate::prompt::{self, Control};
 
@@ -163,10 +163,12 @@ impl State {
         Ok(())
     }
     fn print_banner(&self, version: &ver::Build) -> anyhow::Result<()> {
-        msg!("{} {} {}",
+        msg!(
+            "{} {} {}",
             format!("{}\r{BRANDING}", ansi_escapes::EraseLine).light_gray(),
             version.to_string().light_gray(),
-            format_args!("(repl {})", env!("CARGO_PKG_VERSION")).fade());
+            format_args!("(repl {})", env!("CARGO_PKG_VERSION")).fade()
+        );
         Ok(())
     }
     pub async fn try_connect(&mut self, branch: &str) -> anyhow::Result<()> {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -21,7 +21,6 @@ use crate::async_util::timeout;
 use crate::branding::BRANDING;
 use crate::connect::Connection;
 use crate::connect::Connector;
-use crate::msg;
 use crate::portable::ver;
 use crate::print::{self, Highlight};
 use crate::prompt::variable::VariableInput;
@@ -164,12 +163,10 @@ impl State {
         Ok(())
     }
     fn print_banner(&self, version: &ver::Build) -> anyhow::Result<()> {
-        msg!(
-            "{} {} {}",
+        msg!("{} {} {}",
             format!("{}\r{BRANDING}", ansi_escapes::EraseLine).light_gray(),
             version.to_string().light_gray(),
-            format_args!("(repl {})", env!("CARGO_PKG_VERSION")).fade()
-        );
+            format_args!("(repl {})", env!("CARGO_PKG_VERSION")).fade());
         Ok(())
     }
     pub async fn try_connect(&mut self, branch: &str) -> anyhow::Result<()> {


### PR DESCRIPTION
`echo!` was a macro that had its own print style which made it difficult to understand. A few uses of `echo!` incorrectly assumed it took `format!`-style args, which was actually incorrect.

Most of this PR was done in a mechanical way via this grit script, and then touched up by hand, and then a pass where `msg!` was replaced by `println!` temporarily was used to give `clippy` a chance to inline format args.

```
engine marzano(0.1)

language rust

function replace_semi($node) js {
    return $node.text.replace(new RegExp(';', 'g'), ',');
}

function add_var($str) js {
    const text = $str.text;
    if (text.length == 0 || text.endsWith(' ') || text.endsWith("`")) {
        return "{}";
    }
    return " {}";
}

function add_string($str1, $str2) js {
    const t1 = $str1.text;
    const t2 = $str2.text;
    if (t1.length == 0 || t1.endsWith('`') || t1.endsWith(':')) {
        return t2;
    }
    if (t2.startsWith(' ') || t2.startsWith("`") || t2.startsWith('.') || t2.startsWith(',') || t2.startsWith(':')) {
        return t2;
    }
    return " " + t2;
}

function rewrite($a0, $a1, $a2, $a3, $a4, $a5, $a6) {
    $string = "",
    $vars = [],
    if ($a0 <: "") {
    } else if ($a0 <: string_literal(content=$t0)) {
        $string += add_string($string, $t0)
    } else {
        $string += add_var($string),
        $vars += $a0
    },
    if ($a1 <: "") {
    } else if ($a1 <: string_literal(content=$t1)) {
        $string += add_string($string, $t1)
    } else {
        $string += add_var($string),
        $vars += $a1
    },
    if ($a2 <: "") {
    } else if ($a2 <: string_literal(content=$t2)) {
        $string += add_string($string, $t2)
    } else {
        $string += add_var($string),
        $vars += $a2
    },
    if ($a3 <: "") {
    } else if ($a3 <: string_literal(content=$t3)) {
        $string += add_string($string, $t3)
    } else {
        $string += add_var($string),
        $vars += $a3
    },
    if ($a4 <: "") {
    } else if ($a4 <: string_literal(content=$t4)) {
        $string += add_string($string, $t4)
    } else {
        $string += add_var($string),
        $vars += $a4
    },
    if ($a5 <: "") {
    } else if ($a5 <: string_literal(content=$t5)) {
        $string += add_string($string, $t5)
    } else {
        $string += add_var($string),
        $vars += $a5
    },
    if ($a6 <: "") {
    } else if ($a6 <: string_literal(content=$t6)) {
        $string += add_string($string, $t6)
    } else {
        $string += add_var($string),
        $vars += $a6
    },
    $string = `"$string"`,
    if ($vars <: []) {
        $ret = `msg!($string)`
    } else {
        $vars = join($vars, ", "),
        $ret = `msg!($string, $vars)`
    },
    return $ret
}

sequential {

    bubble file($body) where $body <: contains bubble or {
        `echo!("")` => `msg!()`,
        bubble `echo!(format!($args))` => `msg!($args)`,
        bubble `print::echo!($args)` as $node where {
            $args = replace_semi($args),
            $node => `echo_former_macro($args)`
        },
        bubble `echo!($args)` as $node where {
            $args = replace_semi($args),
            $node => `echo_former_macro($args)`
        }
    },
    bubble file($body) where $body <: contains bubble or {
        bubble `echo_former_macro($a0, $a1)` => rewrite($a0, $a1, "", "", "", "", ""),
        bubble `echo_former_macro($a0, $a1, $a2)` => rewrite($a0, $a1, $a2, "", "", "", ""),
        bubble `echo_former_macro($a0, $a1, $a2, $a3)` => rewrite($a0, $a1, $a2, $a3, "", "", ""),
        bubble `echo_former_macro($a0, $a1, $a2, $a3, $a4)` => rewrite($a0, $a1, $a2, $a3, $a4, "", ""),
        bubble `echo_former_macro($a0, $a1, $a2, $a3, $a4, $a5)` => rewrite($a0, $a1, $a2, $a3, $a4, $a5, ""),
        bubble `echo_former_macro($a0, $a1, $a2, $a3, $a4, $a5, $a6)` =>  rewrite($a0, $a1, $a2, $a3, $a4, $a5, $a6),
        bubble `echo_former_macro($args)` => rewrite($args, "", "", "", "", "", ""),
    }
}

```