### PR TITLE
Replace print::warn and print::error with macros

### DIFF
--- a/src/branch/drop.rs
+++ b/src/branch/drop.rs
@@ -25,7 +25,7 @@ pub async fn main(
             options.target_branch
         ));
         if !connection.ping_while(q.async_ask()).await? {
-            print::error("Canceled by user.");
+            print::error!("Canceled by user.");
             return Err(ExitCode::new(exit_codes::NOT_CONFIRMED).into());
         }
     }

--- a/src/branch/rebase.rs
+++ b/src/branch/rebase.rs
@@ -42,7 +42,7 @@ pub async fn main(
     .await
     {
         Err(e) => {
-            print::error(e);
+            print::error!("{e}");
 
             eprintln!("Cleaning up cloned branch...");
             let mut rename_connection =

--- a/src/branch/wipe.rs
+++ b/src/branch/wipe.rs
@@ -26,7 +26,7 @@ pub async fn main(
             options.target_branch
         ));
         if !connection.ping_while(q.async_ask()).await? {
-            print::error("Canceled by user.");
+            print::error!("Canceled by user.");
             return Err(ExitCode::new(exit_codes::NOT_CONFIRMED).into());
         }
     }

--- a/src/cli/directory_check.rs
+++ b/src/cli/directory_check.rs
@@ -34,11 +34,9 @@ fn _check() -> anyhow::Result<Option<PathBuf>> {
 pub fn check_and_error() -> anyhow::Result<()> {
     match _check().context("failed directory check")? {
         Some(dir) => {
-            print::error(format!(
-                "{BRANDING_CLI} no longer uses `{dir}` to store data \
+            print::error!("{BRANDING_CLI} no longer uses `{dir}` to store data \
                 and now uses standard locations of your OS.",
-                dir = dir.display()
-            ));
+                dir = dir.display());
             print_markdown!(
                 "To upgrade the directory layout, run: \n\
                 ```\n\

--- a/src/cli/directory_check.rs
+++ b/src/cli/directory_check.rs
@@ -34,9 +34,11 @@ fn _check() -> anyhow::Result<Option<PathBuf>> {
 pub fn check_and_error() -> anyhow::Result<()> {
     match _check().context("failed directory check")? {
         Some(dir) => {
-            print::error!("{BRANDING_CLI} no longer uses `{dir}` to store data \
+            print::error!(
+                "{BRANDING_CLI} no longer uses `{dir}` to store data \
                 and now uses standard locations of your OS.",
-                dir = dir.display());
+                dir = dir.display()
+            );
             print_markdown!(
                 "To upgrade the directory layout, run: \n\
                 ```\n\

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -377,7 +377,7 @@ fn customize(settings: &mut Settings) -> anyhow::Result<()> {
         let q = question::Confirm::new("Modify PATH variable?");
         settings.modify_path = q.ask()?;
     } else {
-        print::error("No options to customize.");
+        print::error!("No options to customize.");
     }
     Ok(())
 }
@@ -490,7 +490,7 @@ fn _main(options: &CliInstall) -> anyhow::Result<()> {
                         settings.print();
                     }
                     _ => {
-                        print::error("Aborting installation.");
+                        print::error!("Aborting installation.");
                         exit(7);
                     }
                 }

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -3,7 +3,6 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use const_format::concatcp;
 use fn_error_context::context;
 use fs_err as fs;
 
@@ -210,11 +209,7 @@ fn update_path(base: &Path, new_bin_path: &Path) -> anyhow::Result<()> {
             )
         })?;
         if modified && no_dir_in_path(&new_bin_dir) {
-            print::success(concatcp!(
-                "The `",
-                BRANDING_CLI_CMD,
-                "` executable has moved!"
-            ));
+            print::success!("The `{BRANDING_CLI_CMD}` executable has moved!");
             print_markdown!(
                 "\
                 \n\
@@ -247,11 +242,7 @@ fn update_path(base: &Path, new_bin_path: &Path) -> anyhow::Result<()> {
             .with_context(|| format!("failed to write env file {env_file:?}"))?;
 
         if modified && no_dir_in_path(new_bin_dir) {
-            print::success(concatcp!(
-                "The `",
-                BRANDING_CLI_CMD,
-                "` executable has moved!"
-            ));
+            print::success!("The `{BRANDING_CLI_CMD}` executable has moved!");
             print_markdown!(
                 "\
                 \n\
@@ -374,7 +365,7 @@ pub fn migrate(base: &Path, dry_run: bool) -> anyhow::Result<()> {
         }
     }
     remove_dir_all(base, dry_run)?;
-    print::success("Directory layout migration successful!");
+    print::success!("Directory layout migration successful!");
 
     Ok(())
 }

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -279,7 +279,7 @@ pub fn migrate(base: &Path, dry_run: bool) -> anyhow::Result<()> {
         if exe_path.starts_with(base) {
             let new_bin_path = binary_path()?;
             try_move_bin(&exe_path, &new_bin_path).map_err(|e| {
-                print::error("Cannot move executable to new location.");
+                print::error!("Cannot move executable to new location.");
                 eprintln!("  Try `{BRANDING_CLI_CMD} cli upgrade` instead.");
                 e
             })?;
@@ -359,7 +359,7 @@ pub fn migrate(base: &Path, dry_run: bool) -> anyhow::Result<()> {
             "Do you want to remove all files and directories within {base:?}?",
         ));
         if !q.ask()? {
-            print::error("Canceled by user.");
+            print::error!("Canceled by user.");
             print_markdown!(
                 "\
                 Once all files are backed up, run one of:\n\

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -190,7 +190,7 @@ fn _main(options: &CliUpgrade, path: PathBuf) -> anyhow::Result<()> {
     if !force && pkg.version <= self_version()? {
         log::info!("Version is identical; no update needed.");
         if !options.quiet {
-            print::success("Already up to date.");
+            print::success!("Already up to date.");
         }
         return Ok(());
     }

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -52,7 +52,7 @@ pub async fn _do_login(client: &mut CloudClient) -> anyhow::Result<()> {
 
     match user_resp {
         Ok(user) => {
-            print::success(format!("Already logged in as {}.", user.name));
+            print::success!("Already logged in as {}.", user.name);
             return Ok(());
         }
         Err(ref err)
@@ -120,10 +120,10 @@ pub async fn _do_login(client: &mut CloudClient) -> anyhow::Result<()> {
                 client.set_secret_key(None)?;
 
                 let user: User = client.get("user").await?;
-                print::success(format!(
+                print::success!(
                     "Successfully logged in to {BRANDING_CLOUD} as {}.",
                     user.name
-                ));
+                );
                 return Ok(());
             }
             Err(e) => print::warn!("Request failed: {e:?}\nRetrying..."),
@@ -212,9 +212,7 @@ pub fn logout(c: &options::Logout, options: &CloudOptions) -> anyhow::Result<()>
             }
             removed = true;
             fs::remove_file(cloud_creds.join(item.file_name()))?;
-            print::success(format!(
-                "You are now logged out from {BRANDING_CLOUD} profile {profile:?}."
-            ));
+            print::success!("You are now logged out from {BRANDING_CLOUD} profile {profile:?}.");
         }
     } else {
         let client = CloudClient::new(options)?;
@@ -240,10 +238,10 @@ pub fn logout(c: &options::Logout, options: &CloudOptions) -> anyhow::Result<()>
             }
             if removed {
                 fs::remove_file(path).with_context(|| "failed to log out")?;
-                print::success(format!(
+                print::success!(
                     "You are now logged out from {BRANDING_CLOUD} for profile \"{}\".",
                     client.profile.as_deref().unwrap_or("default")
-                ));
+                );
             }
             skipped = !removed;
         } else {

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -126,7 +126,7 @@ pub async fn _do_login(client: &mut CloudClient) -> anyhow::Result<()> {
                 ));
                 return Ok(());
             }
-            Err(e) => print::warn(format!("Request failed: {e:?}\nRetrying...")),
+            Err(e) => print::warn!("Request failed: {e:?}\nRetrying..."),
             _ => {}
         }
         sleep(AUTHENTICATION_POLL_INTERVAL).await;
@@ -247,10 +247,8 @@ pub fn logout(c: &options::Logout, options: &CloudOptions) -> anyhow::Result<()>
             }
             skipped = !removed;
         } else {
-            print::warn(format!(
-                "Already logged out from {BRANDING_CLOUD} for profile \"{}\".",
-                client.profile.as_deref().unwrap_or("default")
-            ));
+            print::warn!("Already logged out from {BRANDING_CLOUD} for profile \"{}\".",
+                client.profile.as_deref().unwrap_or("default"));
         }
     }
     if !warnings.is_empty() {
@@ -260,9 +258,9 @@ pub fn logout(c: &options::Logout, options: &CloudOptions) -> anyhow::Result<()>
             .collect::<Vec<_>>()
             .join("\n");
         if c.force {
-            print::warn(message);
+            print::warn!("{message}");
         } else {
-            print::error(message);
+            print::error!("{message}");
             Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
         }
     }

--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -247,8 +247,10 @@ pub fn logout(c: &options::Logout, options: &CloudOptions) -> anyhow::Result<()>
             }
             skipped = !removed;
         } else {
-            print::warn!("Already logged out from {BRANDING_CLOUD} for profile \"{}\".",
-                client.profile.as_deref().unwrap_or("default"));
+            print::warn!(
+                "Already logged out from {BRANDING_CLOUD} for profile \"{}\".",
+                client.profile.as_deref().unwrap_or("default")
+            );
         }
     }
     if !warnings.is_empty() {

--- a/src/cloud/secret_keys.rs
+++ b/src/cloud/secret_keys.rs
@@ -179,7 +179,7 @@ pub async fn _do_revoke(c: &options::RevokeSecretKey, client: &CloudClient) -> a
             c.secret_key_id
         ));
         if !q.ask()? {
-            print::error("Canceled.");
+            print::error!("Canceled.");
             return Err(ExitCode::new(exit_codes::NOT_CONFIRMED).into());
         }
     }
@@ -214,7 +214,7 @@ fn _ask_ttl() -> anyhow::Result<Option<String>> {
             _ => match humantime::parse_duration(&ttl) {
                 Ok(duration) => Some(humantime::format_duration(duration).to_string()),
                 Err(e) => {
-                    print::error(e);
+                    print::error!("{e}");
                     continue;
                 }
             },

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -662,13 +662,13 @@ pub async fn execute(
         }
         Connect(c) => {
             if prompt.in_transaction() {
-                print::warn("WARNING: Transaction canceled.");
+                print::warn!("WARNING: Transaction canceled.");
             }
             prompt
                 .try_connect(&c.database_name)
                 .await
                 .map_err(|e| {
-                    print::error(format!("Cannot connect: {e:#}"));
+                    print::error!("Cannot connect: {e:#}");
                 })
                 .ok();
             Ok(Skip)

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -43,7 +43,7 @@ pub async fn drop(
             options.database_name
         ));
         if !cli.ping_while(q.async_ask()).await? {
-            print::error("Canceled.");
+            print::error!("Canceled.");
             return Err(ExitCode::new(exit_codes::NOT_CONFIRMED).into());
         }
     }
@@ -80,7 +80,7 @@ pub async fn wipe(
             cli.database()
         ));
         if !cli.ping_while(q.async_ask()).await? {
-            print::error("Canceled.");
+            print::error!("Canceled.");
             return Err(ExitCode::new(exit_codes::NOT_CONFIRMED).into());
         }
     }

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -1,5 +1,4 @@
 use crate::connect::Connection;
-use const_format::concatcp;
 use edgedb_tokio::server_params::{PostgresAddress, PostgresDsn};
 
 use crate::analyze;
@@ -78,11 +77,9 @@ pub async fn common(
                     Some(addr) => {
                         println!("{}", addr.0);
                     }
-                    None => print::error(concatcp!(
-                        "pgaddr requires ",
-                        BRANDING,
-                        " to run in DEV mode"
-                    )),
+                    None => print::error!(
+                        "pgaddr requires {BRANDING} to run in DEV mode"
+                    ),
                 }
             }
         },

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -77,9 +77,7 @@ pub async fn common(
                     Some(addr) => {
                         println!("{}", addr.0);
                     }
-                    None => print::error!(
-                        "pgaddr requires {BRANDING} to run in DEV mode"
-                    ),
+                    None => print::error!("pgaddr requires {BRANDING} to run in DEV mode"),
                 }
             }
         },

--- a/src/commands/list_branches.rs
+++ b/src/commands/list_branches.rs
@@ -12,9 +12,7 @@ pub async fn list_branches(cli: &mut Connection, options: &Options) -> Result<()
     let version = cli.get_version().await?;
 
     if version.specific().major <= 4 {
-        print::warn(format!(
-            "Branches are not supported in {BRANDING} {version}, printing list of databases instead"
-        ));
+        print::warn!("Branches are not supported in {BRANDING} {version}, printing list of databases instead");
         return list_databases(cli, options).await;
     }
 

--- a/src/commands/list_databases.rs
+++ b/src/commands/list_databases.rs
@@ -19,9 +19,7 @@ pub async fn list_databases(cli: &mut Connection, options: &Options) -> Result<(
     let version = cli.get_version().await?;
 
     if version.specific().major >= 5 {
-        print::warn(format!(
-            "Databases are not supported in {BRANDING} {version}, printing list of branches instead"
-        ));
+        print::warn!("Databases are not supported in {BRANDING} {version}, printing list of branches instead");
         return list_branches0(cli, options).await;
     }
 

--- a/src/commands/psql.rs
+++ b/src/commands/psql.rs
@@ -5,7 +5,6 @@ use std::process::Command;
 use crate::branding::BRANDING;
 use crate::connect::Connection;
 use anyhow::Context;
-use const_format::concatcp;
 use edgedb_tokio::server_params::{PostgresAddress, PostgresDsn};
 
 use crate::commands::Options;
@@ -53,7 +52,7 @@ pub async fn psql<'x>(cli: &mut Connection, _options: &Options) -> Result<(), an
                 cmd.arg(&addr.0);
             }
             None => {
-                "print::error!({BRANDING} must be run in DEV mode to use psql.)";
+                print::error!("{BRANDING} must be run in DEV mode to use psql.");
                 return Ok(());
             }
         },

--- a/src/commands/psql.rs
+++ b/src/commands/psql.rs
@@ -53,7 +53,7 @@ pub async fn psql<'x>(cli: &mut Connection, _options: &Options) -> Result<(), an
                 cmd.arg(&addr.0);
             }
             None => {
-                print::error(concatcp!(BRANDING, " must be run in DEV mode to use psql."));
+                "print::error!({BRANDING} must be run in DEV mode to use psql.)";
                 return Ok(());
             }
         },

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -31,7 +31,7 @@ pub fn show_ui(cmd: &UI, opts: &Options) -> anyhow::Result<()> {
     } else {
         match open::that(&url) {
             Ok(_) => {
-                print::success("Opening URL in browser:");
+                print::success!("Opening URL in browser:");
                 println!("{url}");
                 Ok(())
             }

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -1,7 +1,6 @@
 use std::io::{stdout, Write};
 
 use anyhow::Context;
-use const_format::concatcp;
 
 use crate::branding::BRANDING;
 use crate::cloud;
@@ -113,11 +112,9 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
             match open_url(&url).map(|r| r.status()) {
                 Ok(reqwest::StatusCode::OK) => {}
                 Ok(reqwest::StatusCode::NOT_FOUND) => {
-                    print::error(concatcp!(
-                        "Web UI not served correctly by specified ",
-                        BRANDING,
-                        " server."
-                    ));
+                    print::error!(
+                        "Web UI not served correctly by specified {BRANDING} server."
+                    );
                     msg!(
                         "  Try running the \
                         server with `--admin-ui=enabled`."

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -112,9 +112,7 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
             match open_url(&url).map(|r| r.status()) {
                 Ok(reqwest::StatusCode::OK) => {}
                 Ok(reqwest::StatusCode::NOT_FOUND) => {
-                    print::error!(
-                        "Web UI not served correctly by specified {BRANDING} server."
-                    );
+                    print::error!("Web UI not served correctly by specified {BRANDING} server.");
                     msg!(
                         "  Try running the \
                         server with `--admin-ui=enabled`."
@@ -123,8 +121,10 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
                 }
                 Ok(status) => {
                     log::info!("GET {} returned status code {}", url, status);
-                    print::error!("Web UI not served correctly by specified {BRANDING} server. \
-                        Try `edgedb instance logs -I <instance_name>` to see details.");
+                    print::error!(
+                        "Web UI not served correctly by specified {BRANDING} server. \
+                        Try `edgedb instance logs -I <instance_name>` to see details."
+                    );
                     return Err(ExitCode::new(3).into());
                 }
                 Err(e) => {

--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -37,7 +37,7 @@ pub fn show_ui(cmd: &UI, opts: &Options) -> anyhow::Result<()> {
                 Ok(())
             }
             Err(e) => {
-                print::error(format!("Cannot launch browser: {e:#}"));
+                print::error!("Cannot launch browser: {e:#}");
                 print::prompt(
                     "Please paste the URL below into your browser to launch the {BRANDING} UI:",
                 );
@@ -126,14 +126,12 @@ fn _get_local_ui_url(cmd: &UI, cfg: &edgedb_tokio::Config) -> anyhow::Result<Str
                 }
                 Ok(status) => {
                     log::info!("GET {} returned status code {}", url, status);
-                    print::error(
-                        "Web UI not served correctly by specified {BRANDING} server. \
-                        Try `edgedb instance logs -I <instance_name>` to see details.",
-                    );
+                    print::error!("Web UI not served correctly by specified {BRANDING} server. \
+                        Try `edgedb instance logs -I <instance_name>` to see details.");
                     return Err(ExitCode::new(3).into());
                 }
                 Err(e) => {
-                    print::error(format!("cannot connect to {url}: {e:#}",));
+                    print::error!("cannot connect to {url}: {e:#}");
                     return Err(ExitCode::new(4).into());
                 }
             }

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -34,7 +34,7 @@ pub fn print_query_error(
     let files = SimpleFile::new(source_name, query);
     let context_error = err.contexts().rev().collect::<Vec<_>>();
     if !context_error.is_empty() {
-        print::error(context_error.join(": "));
+        print::error!("{}", context_error.join(": "));
     }
     let diag = Diagnostic::error()
         .with_message(format!(

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -587,7 +587,7 @@ async fn _interactive_main(
                         if state.try_update_state()? {
                             continue 'retry;
                         }
-                        print::error("State could not be updated automatically");
+                        print::error!("State could not be updated automatically");
                         msg!(
                             "  Hint: This means that migrations or DDL \
                                statements were run in a concurrent \
@@ -600,7 +600,7 @@ async fn _interactive_main(
                     } else if let Some(e) = err.downcast_ref::<edgedb_errors::Error>() {
                         print::edgedb_error(e, state.verbose_errors);
                     } else if !err.is::<QueryError>() {
-                        print::error(err);
+                        print::error!("{err}");
                     }
                     // Don't continue next statements on error
                     break 'todo;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,9 +72,9 @@ fn main() {
             } else {
                 let mut error_chain = err.chain();
                 if let Some(first) = error_chain.next() {
-                    print::error(first);
+                    print::error!("{first}");
                 } else {
-                    print::error(" <empty error message>");
+                    print::error!(" <empty error message>");
                 }
                 for e in error_chain {
                     eprintln!("  Caused by: {e}");

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -329,7 +329,7 @@ pub async fn first_migration(
                 return Err(bug::error("First migration population is not complete"));
             }
             if descr.confirmed.is_empty() && !options.allow_empty {
-                print::warn("No schema changes detected.");
+                print::warn!("No schema changes detected.");
                 return Err(ExitCode::new(4))?;
             }
             Ok(FutureMigration::new(MigrationKey::Index(1), descr))

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -506,7 +506,7 @@ async fn run_non_interactive(
         non_interactive_populate(ctx, cli).await?
     };
     if descr.confirmed.is_empty() && !options.allow_empty {
-        print::warn("No schema changes detected.");
+        print::warn!("No schema changes detected.");
         //print::echo!("Hint: --allow-empty can be used to create a data-only migration with no schema changes.");
         return Err(ExitCode::new(4))?;
     }
@@ -652,7 +652,7 @@ impl InteractiveMigration<'_> {
                         return Err(SplitMigration.into());
                     }
                     Quit => {
-                        print::error("Migration aborted; no results were saved.");
+                        print::error!("Migration aborted; no results were saved.");
                         return Err(ExitCode::new(0))?;
                     }
                 }
@@ -722,7 +722,7 @@ async fn run_interactive(
     let descr = InteractiveMigration::new(cli).run(options).await?;
 
     if descr.confirmed.is_empty() && !options.allow_empty {
-        print::warn("No schema changes detected.");
+        print::warn!("No schema changes detected.");
         //print::echo!("Hint: --allow-empty can be used to create a data-only migration with no schema changes.");
         return Err(ExitCode::new(4))?;
     }

--- a/src/migrations/extract.rs
+++ b/src/migrations/extract.rs
@@ -88,7 +88,7 @@ pub async fn extract(
                                 migration_file.path.display()
                             ));
                             if !q.ask()? {
-                                print::error("Canceled.");
+                                print::error!("Canceled.");
                                 return Err(ExitCode::new(exit_codes::NOT_CONFIRMED))?;
                             }
                         }
@@ -116,7 +116,7 @@ pub async fn extract(
                         migration_file.path.display()
                     ));
                     if !q.ask()? {
-                        print::error("Canceled.");
+                        print::error!("Canceled.");
                         return Err(ExitCode::new(exit_codes::NOT_CONFIRMED))?;
                     }
                 }
@@ -131,10 +131,8 @@ pub async fn extract(
     let to_migrations_dir = src_ctx.schema_dir.join("migrations");
     if !to_migrations_dir.is_dir() {
         if src_ctx.schema_dir.is_dir() {
-            print::warn(format!(
-                "Creating directory {}",
-                to_migrations_dir.display()
-            ));
+            print::warn!("Creating directory {}",
+                to_migrations_dir.display());
             fs::create_dir(to_migrations_dir)?;
         } else {
             anyhow::bail!(

--- a/src/migrations/extract.rs
+++ b/src/migrations/extract.rs
@@ -131,8 +131,7 @@ pub async fn extract(
     let to_migrations_dir = src_ctx.schema_dir.join("migrations");
     if !to_migrations_dir.is_dir() {
         if src_ctx.schema_dir.is_dir() {
-            print::warn!("Creating directory {}",
-                to_migrations_dir.display());
+            print::warn!("Creating directory {}", to_migrations_dir.display());
             fs::create_dir(to_migrations_dir)?;
         } else {
             anyhow::bail!(

--- a/src/migrations/extract.rs
+++ b/src/migrations/extract.rs
@@ -159,10 +159,10 @@ pub async fn extract(
         updated = true;
     }
     if !updated {
-        print::success(format!(
+        print::success!(
             "Migration history in {:?} and in the database are in sync.",
-            src_ctx.schema_dir.join("migrations"),
-        ));
+            src_ctx.schema_dir.join("migrations")
+        );
     }
     Ok(())
 }

--- a/src/migrations/migration.rs
+++ b/src/migrations/migration.rs
@@ -141,7 +141,7 @@ async fn _read_names(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
     }
 
     if has_old_filename {
-        print::warn("Legacy migration file names detected, consider running 'edgedb migration upgrade-format'")
+        print::warn!("Legacy migration file names detected, consider running 'edgedb migration upgrade-format'")
     }
 
     Ok(result)

--- a/src/migrations/status.rs
+++ b/src/migrations/status.rs
@@ -91,21 +91,25 @@ pub async fn migrations_applied(
                     iter.next(); // skip db_migration itself
                     let first = iter.next().unwrap(); // we know it's not last
                     let count = iter.count() + 1;
-                    print::error!("Database is at migration {db:?} while sources \
+                    print::error!(
+                        "Database is at migration {db:?} while sources \
                         contain {n} migrations ahead, \
                         starting from {first:?}({first_file})",
                         db = db_migration,
                         n = count,
                         first = first,
-                        first_file = migrations[first].path.display());
+                        first_file = migrations[first].path.display()
+                    );
                 } else {
                     print::error!("Database revision {db_migration} not found in the filesystem.");
                     eprintln!("  Consider updating sources.");
                 }
             } else {
-                print::error!("Database is empty, while {} migrations \
+                print::error!(
+                    "Database is empty, while {} migrations \
                     have been found in the filesystem.",
-                    migrations.len());
+                    migrations.len()
+                );
                 eprintln!("  Run `{BRANDING_CLI_CMD} migrate` to apply.");
             }
         }

--- a/src/migrations/status.rs
+++ b/src/migrations/status.rs
@@ -35,7 +35,7 @@ async fn ensure_diff_is_empty(cli: &mut Connection, ctx: &Context) -> Result<(),
             if changes > 3 {
                 eprintln!("... and {} more changes", changes - 3);
             }
-            print::error("Some migrations are missing.");
+            print::error!("Some migrations are missing.");
             eprintln!("  Use `{BRANDING_CLI_CMD} migration create`.");
         }
         return Err(ExitCode::new(2).into());
@@ -91,27 +91,21 @@ pub async fn migrations_applied(
                     iter.next(); // skip db_migration itself
                     let first = iter.next().unwrap(); // we know it's not last
                     let count = iter.count() + 1;
-                    print::error(format!(
-                        "Database is at migration {db:?} while sources \
+                    print::error!("Database is at migration {db:?} while sources \
                         contain {n} migrations ahead, \
                         starting from {first:?}({first_file})",
                         db = db_migration,
                         n = count,
                         first = first,
-                        first_file = migrations[first].path.display()
-                    ));
+                        first_file = migrations[first].path.display());
                 } else {
-                    print::error(format!(
-                        "Database revision {db_migration} not found in the filesystem.",
-                    ));
+                    print::error!("Database revision {db_migration} not found in the filesystem.");
                     eprintln!("  Consider updating sources.");
                 }
             } else {
-                print::error(format!(
-                    "Database is empty, while {} migrations \
+                print::error!("Database is empty, while {} migrations \
                     have been found in the filesystem.",
-                    migrations.len(),
-                ));
+                    migrations.len());
                 eprintln!("  Run `{BRANDING_CLI_CMD} migrate` to apply.");
             }
         }

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -23,7 +23,7 @@ use crate::portable::config::Config;
 use crate::portable::install;
 use crate::portable::local::InstallInfo;
 use crate::portable::repository::{self, PackageInfo, Query};
-use crate::print::{msg, success, self, Highlight};
+use crate::print::{self, msg, success, Highlight};
 use crate::process;
 use crate::watch::wait_changes;
 

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -23,7 +23,7 @@ use crate::portable::config::Config;
 use crate::portable::install;
 use crate::portable::local::InstallInfo;
 use crate::portable::repository::{self, PackageInfo, Query};
-use crate::print::{self, msg, success, Highlight};
+use crate::print::{self, msg, Highlight};
 use crate::process;
 use crate::watch::wait_changes;
 
@@ -205,7 +205,7 @@ async fn do_check(ctx: &Context, status_file: &Path, watch: bool) -> anyhow::Res
 
         let ok = matches!(single_check(ctx, cli).await?, Okay);
         if ok {
-            success("The schema is forward compatible. Ready for upgrade.");
+            print::success!("The schema is forward compatible. Ready for upgrade.");
         }
         eprintln!("Monitoring {:?} for changes.", &ctx.schema_dir);
         watch_loop(rx, ctx, cli, ok).await?;
@@ -318,7 +318,7 @@ pub async fn watch_loop(
         match single_check(ctx, cli).await {
             Ok(CheckResult::Okay) => {
                 if !ok {
-                    success(
+                    print::success!(
                         "The schema is forward compatible. \
                             Ready for upgrade.",
                     );

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -23,7 +23,7 @@ use crate::portable::config::Config;
 use crate::portable::install;
 use crate::portable::local::InstallInfo;
 use crate::portable::repository::{self, PackageInfo, Query};
-use crate::print::{msg, success, warn, Highlight};
+use crate::print::{msg, success, self, Highlight};
 use crate::process;
 use crate::watch::wait_changes;
 
@@ -246,7 +246,7 @@ async fn single_check(ctx: &Context, cli: &mut Connection) -> anyhow::Result<Che
             execute(cli, "ABORT MIGRATION", None).await?;
         }
         Err(e) if e.is::<EsdlError>() => {
-            warn(
+            print::warn!(
                 "Schema incompatibilities found. \
                   Please fix the errors above to proceed.",
             );
@@ -290,7 +290,7 @@ async fn single_check(ctx: &Context, cli: &mut Connection) -> anyhow::Result<Che
 }
 
 fn print_apply_migration_error() {
-    warn(
+    print::warn!(
         "The current schema is compatible, \
          but some of the migrations are outdated.",
     );

--- a/src/migrations/upgrade_format.rs
+++ b/src/migrations/upgrade_format.rs
@@ -34,7 +34,7 @@ async fn _upgrade_format(context: &Context) -> anyhow::Result<()> {
         } else if new_filename.captures(fname).is_some() {
             println!("Migration {fname} OK")
         } else {
-            print::warn(format!("Unknown migration file naming schema: {fname}",))
+            print::warn!("Unknown migration file naming schema: {fname}")
         }
     }
 

--- a/src/non_interactive.rs
+++ b/src/non_interactive.rs
@@ -65,10 +65,8 @@ pub async fn noninteractive_main(q: &Query, options: &Options) -> Result<(), any
             run_query(&mut conn, query, options, fmt).await?;
         }
     } else {
-        print::error(
-            "either a --file option or \
-                     a <queries> positional argument is required.",
-        );
+        print::error!("either a --file option or \
+                     a <queries> positional argument is required.");
     }
 
     Ok(())
@@ -185,10 +183,10 @@ async fn _run_query(
                     PrintError::StreamErr {
                         source: ref error, ..
                     } => {
-                        print::error(error);
+                        print::error!("{error}");
                     }
                     _ => {
-                        print::error(e);
+                        print::error!("{e}");
                     }
                 }
                 return Ok(());

--- a/src/non_interactive.rs
+++ b/src/non_interactive.rs
@@ -65,8 +65,10 @@ pub async fn noninteractive_main(q: &Query, options: &Options) -> Result<(), any
             run_query(&mut conn, query, options, fmt).await?;
         }
     } else {
-        print::error!("either a --file option or \
-                     a <queries> positional argument is required.");
+        print::error!(
+            "either a --file option or \
+                     a <queries> positional argument is required."
+        );
     }
 
     Ok(())

--- a/src/options.rs
+++ b/src/options.rs
@@ -249,7 +249,7 @@ pub struct ConnectionOptions {
 impl ConnectionOptions {
     pub(crate) fn validate(&self) -> anyhow::Result<()> {
         if self.database.is_some() {
-            print::warn("database connection argument is deprecated in favor of 'branch'");
+            print::warn!("database connection argument is deprecated in favor of 'branch'");
         }
         if let Some((d, b)) = self.database.as_ref().zip(self.branch.as_ref()) {
             anyhow::bail!("Arguments --database={d} and --branch={b} are mutually exclusive");

--- a/src/portable/config.rs
+++ b/src/portable/config.rs
@@ -137,9 +137,7 @@ where
         return Ok(Some(out));
     }
 
-    print::error(format!(
-        "Invalid {CONFIG_FILE_DISPLAY_NAME}: missing {field_name}"
-    ));
+    print::error!("Invalid {CONFIG_FILE_DISPLAY_NAME}: missing {field_name}");
     Err(ExitCode::new(exit_codes::INVALID_CONFIG).into())
 }
 

--- a/src/portable/control.rs
+++ b/src/portable/control.rs
@@ -227,9 +227,7 @@ pub fn start(options: &Start) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error!(
-                "Starting {BRANDING_CLOUD} instances is not yet supported."
-            );
+            print::error!("Starting {BRANDING_CLOUD} instances is not yet supported.");
             return Err(ExitCode::new(1))?;
         }
     };
@@ -415,9 +413,7 @@ pub fn stop(options: &Stop) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error!(
-                "Stopping {BRANDING_CLOUD} instances is not yet supported."
-            );
+            print::error!("Stopping {BRANDING_CLOUD} instances is not yet supported.");
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/control.rs
+++ b/src/portable/control.rs
@@ -3,7 +3,6 @@ use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use const_format::concatcp;
 use fn_error_context::context;
 
 use crate::branding::{BRANDING, BRANDING_CLOUD};
@@ -228,11 +227,9 @@ pub fn start(options: &Start) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error(concatcp!(
-                "Starting ",
-                BRANDING_CLOUD,
-                " instances is not yet supported."
-            ));
+            print::error!(
+                "Starting {BRANDING_CLOUD} instances is not yet supported."
+            );
             return Err(ExitCode::new(1))?;
         }
     };
@@ -418,11 +415,9 @@ pub fn stop(options: &Stop) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error(concatcp!(
-                "Stopping ",
-                BRANDING_CLOUD,
-                " instances is not yet supported."
-            ));
+            print::error!(
+                "Stopping {BRANDING_CLOUD} instances is not yet supported."
+            );
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -73,9 +73,11 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
         Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
     }
     if cmd.start_conf.is_some() {
-        print::warn!("The option `--start-conf` is deprecated. \
+        print::warn!(
+            "The option `--start-conf` is deprecated. \
                      Use `edgedb instance start/stop` to control \
-                     the instance.");
+                     the instance."
+        );
     }
 
     let mut client = cloud::client::CloudClient::new(&opts.cloud_options)?;
@@ -185,8 +187,10 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
         Ok(()) => {}
         Err(e) => {
             log::warn!("Error running {BRANDING} as a service: {e:#}");
-            print::warn!("{BRANDING} will not start on next login. \
-                         Trying to start database in the background...");
+            print::warn!(
+                "{BRANDING} will not start on next login. \
+                         Trying to start database in the background..."
+            );
             control::start(&Start {
                 name: None,
                 instance: Some(inst_name),

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -37,7 +37,7 @@ fn ask_name(cloud_client: &mut cloud::client::CloudClient) -> anyhow::Result<Ins
         let inst_name = match InstanceName::from_str(&name) {
             Ok(name) => name,
             Err(e) => {
-                print::error(e);
+                print::error!("{e}");
                 continue;
             }
         };
@@ -46,7 +46,7 @@ fn ask_name(cloud_client: &mut cloud::client::CloudClient) -> anyhow::Result<Ins
             InstanceName::Cloud { org_slug, name } => {
                 if !cloud_client.is_logged_in {
                     if let Err(e) = cloud::ops::prompt_cloud_login(cloud_client) {
-                        print::error(e);
+                        print::error!("{e}");
                         continue;
                     }
                 }
@@ -75,11 +75,9 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
         Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
     }
     if cmd.start_conf.is_some() {
-        print::warn(
-            "The option `--start-conf` is deprecated. \
+        print::warn!("The option `--start-conf` is deprecated. \
                      Use `edgedb instance start/stop` to control \
-                     the instance.",
-        );
+                     the instance.");
     }
 
     let mut client = cloud::client::CloudClient::new(&opts.cloud_options)?;
@@ -189,10 +187,8 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
         Ok(()) => {}
         Err(e) => {
             log::warn!("Error running {BRANDING} as a service: {e:#}");
-            print::warn(
-                "{BRANDING} will not start on next login. \
-                         Trying to start database in the background...",
-            );
+            print::warn!("{BRANDING} will not start on next login. \
+                         Trying to start database in the background...");
             control::start(&Start {
                 name: None,
                 instance: Some(inst_name),

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -67,11 +67,9 @@ fn ask_name(cloud_client: &mut cloud::client::CloudClient) -> anyhow::Result<Ins
 
 pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()> {
     if optional_docker_check()? {
-        print::error(concatcp!(
-            "`",
-            BRANDING_CLI_CMD,
-            " instance create` is not supported in Docker containers."
-        ));
+        print::error!(
+            "`{BRANDING_CLI_CMD} instance create` is not supported in Docker containers."
+        );
         Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
     }
     if cmd.start_conf.is_some() {

--- a/src/portable/destroy.rs
+++ b/src/portable/destroy.rs
@@ -55,14 +55,14 @@ pub fn destroy(options: &Destroy, opts: &Options) -> anyhow::Result<()> {
                 "Do you really want to delete instance {name_str:?}?"
             ));
             if !q.ask()? {
-                print::error("Canceled.");
+                print::error!("Canceled.");
                 return Err(ExitCode::new(exit_codes::NOT_CONFIRMED).into());
             }
         }
         match do_destroy(options, opts, name) {
             Ok(()) => Ok(()),
             Err(e) if e.is::<InstanceNotFound>() => {
-                print::error(e);
+                print::error!("{e}");
                 Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into())
             }
             Err(e) => Err(e),
@@ -153,7 +153,7 @@ fn do_destroy(options: &Destroy, opts: &Options, name: &InstanceName) -> anyhow:
             {
                 let msg = format!("Could not destroy {BRANDING_CLOUD} instance: {e:#}");
                 if options.force {
-                    print::warn(msg);
+                    print::warn!("{msg}");
                 } else {
                     anyhow::bail!(msg);
                 }

--- a/src/portable/install.rs
+++ b/src/portable/install.rs
@@ -152,7 +152,7 @@ fn unlink_cache(cache_file: &Path) {
 
 pub fn install(options: &Install) -> anyhow::Result<()> {
     if optional_docker_check()? {
-        print::error("`edgedb server install` not supported in Docker containers.");
+        print::error!("`edgedb server install` not supported in Docker containers.");
         Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
     }
     let (query, _) = Query::from_options(

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -295,8 +295,10 @@ pub fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
                             .default(&default)
                             .ask()?;
                     if !is_valid_local_instance_name(&name) {
-                        print::error!("Instance name must be a valid identifier, \
-                             (regex: ^[a-zA-Z_0-9]+(-[a-zA-Z_0-9]+)*$)");
+                        print::error!(
+                            "Instance name must be a valid identifier, \
+                             (regex: ^[a-zA-Z_0-9]+(-[a-zA-Z_0-9]+)*$)"
+                        );
                         continue;
                     }
                     break (credentials::path(&name)?, name);

--- a/src/portable/link.rs
+++ b/src/portable/link.rs
@@ -94,9 +94,7 @@ impl ServerCertVerifier for InteractiveCertVerifier {
                 let fingerprint = digest::digest(&digest::SHA1_FOR_LEGACY_USE_ONLY, end_entity);
                 if self.trust_tls_cert {
                     if !self.quiet {
-                        print::warn(format!(
-                            "Trusting unknown server certificate: {fingerprint:?}",
-                        ));
+                        print::warn!("Trusting unknown server certificate: {fingerprint:?}");
                     }
                 } else if self.non_interactive {
                     return Err(e);
@@ -297,10 +295,8 @@ pub fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
                             .default(&default)
                             .ask()?;
                     if !is_valid_local_instance_name(&name) {
-                        print::error(
-                            "Instance name must be a valid identifier, \
-                             (regex: ^[a-zA-Z_0-9]+(-[a-zA-Z_0-9]+)*$)",
-                        );
+                        print::error!("Instance name must be a valid identifier, \
+                             (regex: ^[a-zA-Z_0-9]+(-[a-zA-Z_0-9]+)*$)");
                         continue;
                     }
                     break (credentials::path(&name)?, name);
@@ -311,7 +307,7 @@ pub fn link(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
     if cred_path.exists() {
         if cmd.overwrite {
             if !cmd.quiet {
-                print::warn(format!("Overwriting {}", cred_path.display()));
+                print::warn!("Overwriting {}", cred_path.display());
             }
         } else if cmd.non_interactive {
             anyhow::bail!("File {} exists; aborting.", cred_path.display());

--- a/src/portable/linux.rs
+++ b/src/portable/linux.rs
@@ -3,7 +3,6 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::Context;
-use const_format::concatcp;
 use fn_error_context::context;
 
 use crate::branding::BRANDING_CLOUD;
@@ -425,11 +424,9 @@ pub fn logs(options: &Logs) -> anyhow::Result<()> {
     let name = match instance_arg(&options.name, &options.instance)? {
         InstanceName::Local(name) => name,
         InstanceName::Cloud { .. } => {
-            print::error(concatcp!(
-                "This operation is not yet supported on ",
-                BRANDING_CLOUD,
-                " instances."
-            ));
+            print::error!(
+                "This operation is not yet supported on {BRANDING_CLOUD} instances."
+            );
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/linux.rs
+++ b/src/portable/linux.rs
@@ -424,9 +424,7 @@ pub fn logs(options: &Logs) -> anyhow::Result<()> {
     let name = match instance_arg(&options.name, &options.instance)? {
         InstanceName::Local(name) => name,
         InstanceName::Cloud { .. } => {
-            print::error!(
-                "This operation is not yet supported on {BRANDING_CLOUD} instances."
-            );
+            print::error!("This operation is not yet supported on {BRANDING_CLOUD} instances.");
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use std::thread;
 use std::time;
 
-use const_format::concatcp;
 use fn_error_context::context;
 
 use crate::branding::BRANDING;

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -372,7 +372,7 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
             Inactive { .. } | Ready => {
                 thread::sleep(time::Duration::from_millis(30));
                 if time::SystemTime::now() > cut_off {
-                    print::error(concatcp!(BRANDING, " failed to start for 30 seconds"));
+                    "print::error!({BRANDING} failed to start for 30 seconds)";
                     break;
                 }
                 continue;

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -371,7 +371,7 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
             Inactive { .. } | Ready => {
                 thread::sleep(time::Duration::from_millis(30));
                 if time::SystemTime::now() > cut_off {
-                    "print::error!({BRANDING} failed to start for 30 seconds)";
+                    print::error!("{BRANDING} failed to start for 30 seconds");
                     break;
                 }
                 continue;

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -16,7 +16,7 @@ use crate::portable::local::{
 };
 use crate::portable::repository::Channel;
 use crate::portable::ver;
-use crate::print::{err_marker, msg, self};
+use crate::print::{self, err_marker, msg};
 use crate::process::{self, IntoArg};
 
 const DOMAIN_LABEL_MAX_LENGTH: usize = 63;

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -16,7 +16,7 @@ use crate::portable::local::{
 };
 use crate::portable::repository::Channel;
 use crate::portable::ver;
-use crate::print::{err_marker, msg, warn};
+use crate::print::{err_marker, msg, self};
 use crate::process::{self, IntoArg};
 
 const DOMAIN_LABEL_MAX_LENGTH: usize = 63;
@@ -941,10 +941,10 @@ pub fn instance_arg<'x>(
             );
             return Err(ExitCode::new(2).into());
         }
-        warn(format_args!(
+        print::warn!(
             "Specifying instance name as positional argument is \
             deprecated. Use `-I {name}` instead."
-        ));
+        );
         return Ok(name);
     }
     if let Some(name) = named {

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -282,9 +282,11 @@ pub fn init(options: &Init, opts: &crate::options::Options) -> anyhow::Result<()
     }
 
     if options.server_start_conf.is_some() {
-        print::warn!("The option `--server-start-conf` is deprecated. \
+        print::warn!(
+            "The option `--server-start-conf` is deprecated. \
                      Use `edgedb instance start/stop` to control \
-                     the instance.");
+                     the instance."
+        );
     }
 
     let Some((project_dir, config_path)) = project_dir(options.project_dir.as_deref())? else {
@@ -836,8 +838,10 @@ fn do_init(
             Ok(()) => {}
             Err(e) => {
                 log::warn!("Error running {BRANDING} as a service: {e:#}");
-                print::warn!("{BRANDING} will not start on next login. \
-                             Trying to start database in the background...");
+                print::warn!(
+                    "{BRANDING} will not start on next login. \
+                             Trying to start database in the background..."
+                );
                 control::start(&Start {
                     name: None,
                     instance: Some(inst_name.clone()),
@@ -1373,10 +1377,12 @@ impl Handle<'_> {
         match self.get_version() {
             Ok(inst_ver) if ver_query.matches(&inst_ver) => {}
             Ok(inst_ver) => {
-                print::warn!("WARNING: existing instance has version {}, \
+                print::warn!(
+                    "WARNING: existing instance has version {}, \
                     but {} is required by {CONFIG_FILE_DISPLAY_NAME}",
                     inst_ver,
-                    ver_query.display());
+                    ver_query.display()
+                );
             }
             Err(e) => {
                 log::warn!("Could not check instance's version: {:#}", e);
@@ -1829,9 +1835,11 @@ pub fn find_project_stash_dirs(
 }
 
 pub fn print_instance_in_use_warning(name: &str, project_dirs: &[PathBuf]) {
-    print::warn!("Instance {:?} is used by the following project{}:",
+    print::warn!(
+        "Instance {:?} is used by the following project{}:",
         name,
-        if project_dirs.len() > 1 { "s" } else { "" });
+        if project_dirs.len() > 1 { "s" } else { "" }
+    );
     for dir in project_dirs {
         let dest = match read_project_path(dir) {
             Ok(path) => path,
@@ -1965,8 +1973,10 @@ fn print_other_project_warning(
         }
     }
     if !project_dirs.is_empty() {
-        print::warn!("Warning: the instance {name} is still used by the following \
-            projects:");
+        print::warn!(
+            "Warning: the instance {name} is still used by the following \
+            projects:"
+        );
         for pd in &project_dirs {
             eprintln!("  {}", pd.display());
         }

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -286,11 +286,9 @@ pub fn init(options: &Init, opts: &crate::options::Options) -> anyhow::Result<()
     }
 
     if options.server_start_conf.is_some() {
-        print::warn(
-            "The option `--server-start-conf` is deprecated. \
+        print::warn!("The option `--server-start-conf` is deprecated. \
                      Use `edgedb instance start/stop` to control \
-                     the instance.",
-        );
+                     the instance.");
     }
 
     let Some((project_dir, config_path)) = project_dir(options.project_dir.as_deref())? else {
@@ -332,7 +330,7 @@ fn ask_existing_instance_name(cloud_client: &mut CloudClient) -> anyhow::Result<
         let inst_name = match InstanceName::from_str(&target_name) {
             Ok(name) => name,
             Err(e) => {
-                print::error(e);
+                print::error!("{e}");
                 continue;
             }
         };
@@ -341,7 +339,7 @@ fn ask_existing_instance_name(cloud_client: &mut CloudClient) -> anyhow::Result<
             InstanceName::Cloud { org_slug, name } => {
                 if !cloud_client.is_logged_in {
                     if let Err(e) = crate::cloud::ops::prompt_cloud_login(cloud_client) {
-                        print::error(e);
+                        print::error!("{e}");
                         continue;
                     }
                 }
@@ -352,7 +350,7 @@ fn ask_existing_instance_name(cloud_client: &mut CloudClient) -> anyhow::Result<
         if exists {
             return Ok(inst_name);
         } else {
-            print::error(format!("Instance {target_name:?} does not exist"));
+            print::error!("Instance {target_name:?} does not exist");
         }
     }
 }
@@ -367,7 +365,7 @@ fn ask_database(project_dir: &Path, options: &Init) -> anyhow::Result<String> {
     loop {
         let name = q.ask()?;
         if name.trim().is_empty() {
-            print::error(format!("Non-empty name is required"));
+            print::error!("Non-empty name is required");
         } else {
             return Ok(name.trim().into());
         }
@@ -380,7 +378,7 @@ fn ask_branch() -> anyhow::Result<String> {
     loop {
         let name = q.ask()?;
         if name.trim().is_empty() {
-            print::error(format!("Non-empty name is required"));
+            print::error!("Non-empty name is required");
         } else {
             return Ok(name.trim().into());
         }
@@ -570,7 +568,7 @@ fn ask_name(
         let inst_name = match InstanceName::from_str(&target_name) {
             Ok(name) => name,
             Err(e) => {
-                print::error(e);
+                print::error!("{e}");
                 continue;
             }
         };
@@ -579,7 +577,7 @@ fn ask_name(
             InstanceName::Cloud { org_slug, name } => {
                 if !cloud_client.is_logged_in {
                     if let Err(e) = crate::cloud::ops::prompt_cloud_login(cloud_client) {
-                        print::error(e);
+                        print::error!("{e}");
                         continue;
                     }
                 }
@@ -842,10 +840,8 @@ fn do_init(
             Ok(()) => {}
             Err(e) => {
                 log::warn!("Error running {BRANDING} as a service: {e:#}");
-                print::warn(
-                    "{BRANDING} will not start on next login. \
-                             Trying to start database in the background...",
-                );
+                print::warn!("{BRANDING} will not start on next login. \
+                             Trying to start database in the background...");
                 control::start(&Start {
                     name: None,
                     instance: Some(inst_name.clone()),
@@ -1203,7 +1199,7 @@ async fn migrate_async(inst: &Handle<'_>, ask_for_running: bool) -> anyhow::Resu
         match inst.get_default_connection().await {
             Ok(conn) => break conn,
             Err(e) if ask_for_running && inst.instance.is_local() => {
-                print::error(e);
+                print::error!("{e}");
                 let mut q = question::Numeric::new(format!(
                     "Cannot connect to instance {:?}. Options:",
                     inst.name,
@@ -1220,7 +1216,7 @@ async fn migrate_async(inst: &Handle<'_>, ask_for_running: bool) -> anyhow::Resu
                     Service => match start(inst) {
                         Ok(()) => continue,
                         Err(e) => {
-                            print::error(e);
+                            print::error!("{e}");
                             continue;
                         }
                     },
@@ -1230,7 +1226,7 @@ async fn migrate_async(inst: &Handle<'_>, ask_for_running: bool) -> anyhow::Resu
                     }
                     Retry => continue,
                     Skip => {
-                        print::warn("Skipping migrations.");
+                        print::warn!("Skipping migrations.");
                         msg!(
                             "You can use `{BRANDING_CLI_CMD} migrate` to apply migrations \
                                once the service is up and running."
@@ -1381,12 +1377,10 @@ impl Handle<'_> {
         match self.get_version() {
             Ok(inst_ver) if ver_query.matches(&inst_ver) => {}
             Ok(inst_ver) => {
-                print::warn(format!(
-                    "WARNING: existing instance has version {}, \
+                print::warn!("WARNING: existing instance has version {}, \
                     but {} is required by {CONFIG_FILE_DISPLAY_NAME}",
                     inst_ver,
-                    ver_query.display(),
-                ));
+                    ver_query.display());
             }
             Err(e) => {
                 log::warn!("Could not check instance's version: {:#}", e);
@@ -1506,11 +1500,11 @@ fn ask_local_version(options: &Init) -> anyhow::Result<(Query, PackageInfo)> {
             match repository::get_server_package(&Query::nightly()) {
                 Ok(Some(pkg)) => return Ok((Query::nightly(), pkg)),
                 Ok(None) => {
-                    print::error("No nightly versions found");
+                    print::error!("No nightly versions found");
                     continue;
                 }
                 Err(e) => {
-                    print::error(format!("Cannot find nightly version: {e}"));
+                    print::error!("Cannot find nightly version: {e}");
                     continue;
                 }
             }
@@ -1518,11 +1512,11 @@ fn ask_local_version(options: &Init) -> anyhow::Result<(Query, PackageInfo)> {
             match repository::get_server_package(&Query::testing()) {
                 Ok(Some(pkg)) => return Ok((Query::testing(), pkg)),
                 Ok(None) => {
-                    print::error("No testing versions found");
+                    print::error!("No testing versions found");
                     continue;
                 }
                 Err(e) => {
-                    print::error(format!("Cannot find testing version: {e}"));
+                    print::error!("Cannot find testing version: {e}");
                     continue;
                 }
             }
@@ -1530,12 +1524,12 @@ fn ask_local_version(options: &Init) -> anyhow::Result<(Query, PackageInfo)> {
             match parse_ver_and_find(value) {
                 Ok(Some(pair)) => return Ok(pair),
                 Ok(None) => {
-                    print::error("No matching packages found");
+                    print::error!("No matching packages found");
                     print_versions("Available versions")?;
                     continue;
                 }
                 Err(e) => {
-                    print::error(e);
+                    print::error!("{e}");
                     print_versions("Available versions")?;
                     continue;
                 }
@@ -1596,7 +1590,7 @@ fn ask_cloud_version(
             match cloud::versions::get_version(&Query::nightly(), client) {
                 Ok(v) => return Ok((Query::nightly(), v)),
                 Err(e) => {
-                    print::error(format!("{e}"));
+                    print::error!("{e}");
                     continue;
                 }
             }
@@ -1604,7 +1598,7 @@ fn ask_cloud_version(
             match cloud::versions::get_version(&Query::testing(), client) {
                 Ok(v) => return Ok((Query::testing(), v)),
                 Err(e) => {
-                    print::error(format!("{e}"));
+                    print::error!("{e}");
                     continue;
                 }
             }
@@ -1612,7 +1606,7 @@ fn ask_cloud_version(
             match parse_ver_and_find_cloud(value, client) {
                 Ok(pair) => return Ok(pair),
                 Err(e) => {
-                    print::error(e);
+                    print::error!("{e}");
                     print_cloud_versions("Available versions", client)?;
                     continue;
                 }
@@ -1677,7 +1671,7 @@ pub fn unlink(options: &Unlink, opts: &crate::options::Options) -> anyhow::Resul
                              and delete instance {inst}?"
                 ));
                 if !q.ask()? {
-                    print::error("Canceled.");
+                    print::error!("Canceled.");
                     return Ok(());
                 }
             }
@@ -1700,7 +1694,7 @@ pub fn unlink(options: &Unlink, opts: &crate::options::Options) -> anyhow::Resul
                     msg!("Unlinking instance {}", name.emphasize());
                 }
                 Err(e) => {
-                    print::error(format!("Cannot read instance name: {e}"));
+                    print::error!("Cannot read instance name: {e}");
                     eprintln!("Removing project configuration directory...");
                 }
             };
@@ -1839,16 +1833,14 @@ pub fn find_project_stash_dirs(
 }
 
 pub fn print_instance_in_use_warning(name: &str, project_dirs: &[PathBuf]) {
-    print::warn(format!(
-        "Instance {:?} is used by the following project{}:",
+    print::warn!("Instance {:?} is used by the following project{}:",
         name,
-        if project_dirs.len() > 1 { "s" } else { "" },
-    ));
+        if project_dirs.len() > 1 { "s" } else { "" });
     for dir in project_dirs {
         let dest = match read_project_path(dir) {
             Ok(path) => path,
             Err(e) => {
-                print::error(e);
+                print::error!("{e}");
                 continue;
             }
         };
@@ -1968,7 +1960,7 @@ fn print_other_project_warning(
         let real_pd = match read_project_path(&pd) {
             Ok(path) => path,
             Err(e) => {
-                print::error(e);
+                print::error!("{e}");
                 continue;
             }
         };
@@ -1977,10 +1969,8 @@ fn print_other_project_warning(
         }
     }
     if !project_dirs.is_empty() {
-        print::warn(format!(
-            "Warning: the instance {name} is still used by the following \
-            projects:"
-        ));
+        print::warn!("Warning: the instance {name} is still used by the following \
+            projects:");
         for pd in &project_dirs {
             eprintln!("  {}", pd.display());
         }

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -277,11 +277,7 @@ struct JsonInfo<'a> {
 
 pub fn init(options: &Init, opts: &crate::options::Options) -> anyhow::Result<()> {
     if optional_docker_check()? {
-        print::error(concatcp!(
-            "`",
-            BRANDING_CLI_CMD,
-            " project init` is not supported in Docker containers."
-        ));
+        print::error!("`{BRANDING_CLI_CMD} project init` is not supported in Docker containers.");
         Err(ExitCode::new(exit_codes::DOCKER_CONTAINER))?;
     }
 

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -482,7 +482,7 @@ fn do_link(inst: &Handle, options: &Init, stash_dir: &Path) -> anyhow::Result<Pr
         create_database(inst)?;
     }
 
-    print::success("Project linked");
+    print::success!("Project linked");
     if let Some(dir) = &options.project_dir {
         eprintln!(
             "To connect to {}, navigate to {} and run `{BRANDING_CLI_CMD}`",
@@ -1415,7 +1415,7 @@ fn find_schema_files(path: &Path) -> anyhow::Result<bool> {
 }
 
 fn print_initialized(name: &str, dir_option: &Option<PathBuf>) {
-    print::success("Project initialized.");
+    print::success!("Project initialized.");
     if let Some(dir) = dir_option {
         msg!(
             "To connect to {}, navigate to {} and run `{}`",
@@ -1901,9 +1901,9 @@ pub fn update_toml(
         log::warn!("No associated instance found.");
 
         if config::modify_server_ver(&config_path, &query)? {
-            print::success("Config updated successfully.");
+            print::success!("Config updated successfully.");
         } else {
-            print::success("Config is up to date.");
+            print::success!("Config is up to date.");
         }
         msg!(
             "Run {} {} to initialize an instance.",

--- a/src/portable/reset_password.rs
+++ b/src/portable/reset_password.rs
@@ -3,7 +3,6 @@ use std::num::NonZeroU32;
 use std::path::Path;
 
 use base64::display::Base64Display;
-use const_format::concatcp;
 use fn_error_context::context;
 use rand::{Rng, SeedableRng};
 
@@ -48,11 +47,9 @@ pub fn reset_password(options: &ResetPassword) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error(concatcp!(
-                "This operation is not supported on ",
-                BRANDING_CLOUD,
-                " instances yet."
-            ));
+            print::error!(
+                "This operation is not yet supported on {BRANDING_CLOUD} instances."
+            );
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/reset_password.rs
+++ b/src/portable/reset_password.rs
@@ -47,9 +47,7 @@ pub fn reset_password(options: &ResetPassword) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error!(
-                "This operation is not yet supported on {BRANDING_CLOUD} instances."
-            );
+            print::error!("This operation is not yet supported on {BRANDING_CLOUD} instances.");
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/reset_password.rs
+++ b/src/portable/reset_password.rs
@@ -120,7 +120,7 @@ pub fn reset_password(options: &ResetPassword) -> anyhow::Result<()> {
                 credentials_file.display(),
             );
         } else {
-            print::success("Password was successfully changed.");
+            print::success!("Password was successfully changed.");
         }
     }
     Ok(())

--- a/src/portable/reset_password.rs
+++ b/src/portable/reset_password.rs
@@ -81,7 +81,7 @@ pub fn reset_password(options: &ResetPassword) -> anyhow::Result<()> {
                 user.escape_default()
             ))?;
             if password != confirm {
-                print::error("Passwords do not match");
+                print::error!("Passwords do not match");
             } else {
                 break password;
             }

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -30,9 +30,7 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error!(
-                "This operation is not yet supported on {BRANDING_CLOUD} instances."
-            );
+            print::error!("This operation is not yet supported on {BRANDING_CLOUD} instances.");
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -30,11 +30,9 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
             }
         }
         InstanceName::Cloud { .. } => {
-            print::error(concatcp!(
-                "This operation is not supported on ",
-                BRANDING_CLOUD,
-                " instances yet."
-            ));
+            print::error!(
+                "This operation is not yet supported on {BRANDING_CLOUD} instances."
+            );
             return Err(ExitCode::new(1))?;
         }
     };

--- a/src/portable/revert.rs
+++ b/src/portable/revert.rs
@@ -84,17 +84,17 @@ pub fn revert(options: &Revert) -> anyhow::Result<()> {
         );
         let q = question::Confirm::new_dangerous("Do you really want to revert?");
         if !q.ask()? {
-            print::error("Canceled.");
+            print::error!("Canceled.");
             Err(ExitCode::new(exit_codes::NOT_CONFIRMED))?;
         }
     }
 
     if let Err(e) = control::do_stop(name) {
-        print::error(format!("Error stopping service: {e:#}"));
+        print::error!("Error stopping service: {e:#}");
         if !options.no_confirm {
             let q = question::Confirm::new("Do you want to proceed?");
             if !q.ask()? {
-                print::error("Canceled.");
+                print::error!("Canceled.");
                 Err(ExitCode::new(exit_codes::NOT_CONFIRMED))?;
             }
         }

--- a/src/portable/status.rs
+++ b/src/portable/status.rs
@@ -377,7 +377,7 @@ pub fn remote_status(options: &Status) -> anyhow::Result<()> {
     } else if let Some(inst_status) = &status.instance_status {
         println!("{inst_status}");
     } else if let Some(ConnectionStatus::Error(e)) = &status.connection {
-        print::error(e);
+        print::error!("{e}");
     } else if let Some(conn_status) = &status.connection {
         println!("{}", conn_status.as_str());
     } else {
@@ -569,7 +569,7 @@ pub fn list(options: &List, opts: &crate::options::Options) -> anyhow::Result<()
             if options.json {
                 println!("[]");
             } else if !options.quiet {
-                print::warn("No instances found");
+                print::warn!("No instances found");
             }
             Ok(())
         };
@@ -615,9 +615,9 @@ pub fn list(options: &List, opts: &crate::options::Options) -> anyhow::Result<()
 pub fn print_errors(errs: &[anyhow::Error], is_warning: bool) -> bool {
     for e in errs {
         if is_warning {
-            print::warn(format!("Warning: {e:#}"));
+            print::warn!("Warning: {e:#}");
         } else {
-            print::error(e);
+            print::error!("{e}");
         }
     }
     !errs.is_empty()

--- a/src/portable/uninstall.rs
+++ b/src/portable/uninstall.rs
@@ -77,7 +77,7 @@ pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
             uninstalled.emphasize()
         );
     } else {
-        print::success("Nothing to uninstall.")
+        print::success!("Nothing to uninstall.")
     }
     Ok(())
 }

--- a/src/portable/uninstall.rs
+++ b/src/portable/uninstall.rs
@@ -69,7 +69,7 @@ pub fn uninstall(options: &Uninstall) -> anyhow::Result<()> {
 
     if !all && !options.unused {
         msg!("Uninstalled {} versions.", uninstalled.emphasize());
-        print::error("some instances are in use. See messages above.");
+        print::error!("some instances are in use. See messages above.");
         Err(ExitCode::new(exit_codes::PARTIAL_SUCCESS))?;
     } else if uninstalled > 0 {
         msg!(

--- a/src/portable/upgrade.rs
+++ b/src/portable/upgrade.rs
@@ -316,7 +316,7 @@ pub fn upgrade_incompatible(
         }
 
         if has_main_dump {
-            print::warn("The database 'main' will now become the default database");
+            print::warn!("The database 'main' will now become the default database");
         } else if has_edgedb_dump
             && (non_interactive
                 || question::Confirm::new(
@@ -338,7 +338,7 @@ pub fn upgrade_incompatible(
     }
 
     reinit_and_restore(&inst, &paths).map_err(|e| {
-        print::error(format!("{e:#}"));
+        print::error!("{e:#}");
         eprintln!(
             "To undo run:\n  {BRANDING_CLI_CMD} instance revert -I {:?}",
             inst.name

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -966,7 +966,7 @@ pub fn list(options: &options::List, opts: &crate::Options) -> anyhow::Result<()
             if options.json {
                 println!("[]");
             } else if !options.quiet {
-                print::warn("No instances found");
+                print::warn!("No instances found");
             }
             return Ok(());
         }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -411,7 +411,8 @@ pub fn edgedb_error(err: &edgedb_errors::Error, verbose: bool) {
     msg!("{} {}", err_marker(), display_error(err, verbose));
 }
 
-pub fn success(line: impl fmt::Display) {
+#[doc(hidden)]
+pub fn write_success(line: impl fmt::Display) {
     if use_color() {
         msg!("{}", line.to_string().bold().light_green());
     } else {
@@ -447,8 +448,6 @@ macro_rules! warn {
     }
 }
 
-pub use crate::warn;
-
 #[macro_export]
 macro_rules! error {
     ($($args:tt)*) => {
@@ -456,4 +455,11 @@ macro_rules! error {
     }
 }
 
-pub use crate::error;
+#[macro_export]
+macro_rules! success {
+    ($($args:tt)*) => {
+        $crate::print::write_success(format_args!($($args)*))
+    }
+}
+
+pub use crate::{error, success, warn};

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -395,7 +395,8 @@ pub fn err_marker() -> impl fmt::Display {
     concatcp!(BRANDING_CLI_CMD, " error:").err_marker()
 }
 
-pub fn error(line: impl fmt::Display) {
+#[doc(hidden)]
+pub fn write_error(line: impl fmt::Display) {
     let text = format!("{line:#}");
     if text.len() > 60 {
         msg!("{} {}", err_marker(), text);
@@ -430,10 +431,29 @@ pub fn success_msg(title: impl fmt::Display, msg: impl fmt::Display) {
     }
 }
 
-pub fn warn(line: impl fmt::Display) {
+#[doc(hidden)]
+pub fn write_warn(line: impl fmt::Display) {
     if use_color() {
         msg!("{}", line.to_string().bold().yellow());
     } else {
         msg!("{line}");
     }
 }
+
+#[macro_export]
+macro_rules! warn {
+    ($($args:tt)*) => {
+        $crate::print::write_warn(format_args!($($args)*))
+    }
+}
+
+pub use crate::warn;
+
+#[macro_export]
+macro_rules! error {
+    ($($args:tt)*) => {
+        $crate::print::write_error(format_args!($($args)*))
+    }
+}
+
+pub use crate::error;

--- a/src/question.rs
+++ b/src/question.rs
@@ -72,13 +72,13 @@ impl<'a, T: Clone + 'a> Numeric<'a, T> {
             let choice = match value.parse::<u32>() {
                 Ok(choice) => choice,
                 Err(e) => {
-                    print::error(format!("Error reading choice: {e}"));
+                    print::error!("Error reading choice: {e}");
                     print::prompt("Please enter a number");
                     continue;
                 }
             };
             if choice == 0 || choice as usize > self.options.len() {
-                print::error("Please specify a choice from the list above");
+                print::error!("Please specify a choice from the list above");
                 continue;
             }
             return Ok(self.options[(choice - 1) as usize].1.clone());
@@ -190,7 +190,7 @@ impl<'a> Confirm<'a> {
                     }
                     _ => {
                         initial = val.into();
-                        print::error("Please answer Y or N");
+                        print::error!("Please answer Y or N");
                         continue;
                     }
                 }
@@ -267,9 +267,7 @@ impl<'a, T: Clone + 'a> Choice<'a, T> {
                     }
                 }
             }
-            print::error(format!(
-                "Invalid option {val:?}, please use one of: [{options}]"
-            ));
+            print::error!("Invalid option {val:?}, please use one of: [{options}]");
         }
     }
 }


### PR DESCRIPTION
Rewrite `print::{warn,error}` to `print::{warn!,error!}` macros to remove yet another way of printing.

Most of the work done via this grit script.

```
engine marzano(0.1)

language rust

function concatcp_to_format($args) {
    $string = "",
    $args <: every or {
        string_literal(content=$str) where { $string += $str },
        `"$other"` where { $string += $other },
        identifier() as $node where { 
            $string += "{",
            $string += $node,
            $string += "}",
        }
    },
    return `"$string"`
}

sequential {
    bubble file($body) where $body <: maybe contains bubble any {
        `print::$level(concatcp!("$str", $expr, "$str2"))` => `"print::$level!($str{$expr}$str2)"`,
        `print::$level(concatcp!($expr, "$str"))` => `"print::$level!({$expr}$str)"`,
        `print::$level(concatcp!("$str", $expr))` => `"print::$level!($str{$expr})"`
    },
    bubble file($body) where $body <: maybe contains bubble any {
        `print::$level(concatcp!($args))` => `print::$level(__concat__($args))` where {
            $level <: `warn`,
            $level <: `error`
        }
    },
    bubble file($body) where $body <: maybe contains bubble any {
        `print::$level(__concat__($args))` as $node where {
            $args = concatcp_to_format($args),
            $node => `print::$level($args)`
        },
        `print::warn(format!($args))` => `print::warn!($args)`,
        `print::error(format!($args))` => `print::error!($args)`,
        `print::$level($args)` as $node where {
            or {
                $level <: `warn`,
                $level <: `error`            
            },
            if ($args <: arguments(args=[])) {
                $node => `print::$level!()`
            } else if ($args <: [string_literal(content=$str)]) {
                $node => `print::$level!("$str")`
            } else if ($args <: [identifier()]) {
                $node => `print::$level!("{$args}")`
            }
        }
    }
}
```