### PR TITLE
Install new executable name (and link old executable)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ github_action_install = []
 github_nightly = []
 portable_tests = []
 docker_test_wrapper = []
+gel = []
 
 [workspace.dependencies]
 clap = "4.4.6"

--- a/src/branding.rs
+++ b/src/branding.rs
@@ -1,8 +1,40 @@
 #![allow(unused)]
 
-pub const BRANDING: &str = "EdgeDB";
-pub const BRANDING_CLI: &str = "EdgeDB CLI";
-pub const BRANDING_CLOUD: &str = "EdgeDB Cloud";
-pub const BRANDING_CLI_CMD: &str = "edgedb";
+/// The product name.
+pub const BRANDING: &str = if cfg!(feature = "gel") {
+    "Gel"
+} else {
+    "EdgeDB"
+};
+/// The CLI name.
+pub const BRANDING_CLI: &str = const_format::concatcp!(BRANDING, " CLI");
+/// The cloud name.
+pub const BRANDING_CLOUD: &str = const_format::concatcp!(BRANDING, " Cloud");
+/// The CLI command name.
+pub const BRANDING_CLI_CMD: &str = if cfg!(feature = "gel") {
+    "gel"
+} else {
+    "edgedb"
+};
+/// The CLI command name for the alternative executable.
+pub const BRANDING_CLI_CMD_ALT: &str = if cfg!(feature = "gel") {
+    "edgedb"
+} else {
+    "gel"
+};
+/// The executable file name for the CLI.
+pub const BRANDING_CLI_CMD_FILE: &str = if cfg!(windows) {
+    const_format::concatcp!(BRANDING_CLI_CMD, ".exe")
+} else {
+    BRANDING_CLI_CMD
+};
+/// The executable file name for the CLI alternative.
+pub const BRANDING_CLI_CMD_ALT_FILE: &str = if cfg!(windows) {
+    const_format::concatcp!(BRANDING_CLI_CMD_ALT, ".exe")
+} else {
+    BRANDING_CLI_CMD_ALT
+};
+/// The WSL distribution name.
 pub const BRANDING_WSL: &str = "EdgeDB.WSL.1";
+/// The display name for the configuration file.
 pub const CONFIG_FILE_DISPLAY_NAME: &str = "`gel.toml` (or `edgedb.toml`)";

--- a/src/branding.rs
+++ b/src/branding.rs
@@ -1,4 +1,5 @@
 #![allow(unused)]
+use const_format::concatcp;
 
 /// The product name.
 pub const BRANDING: &str = if cfg!(feature = "gel") {
@@ -7,9 +8,10 @@ pub const BRANDING: &str = if cfg!(feature = "gel") {
     "EdgeDB"
 };
 /// The CLI name.
-pub const BRANDING_CLI: &str = const_format::concatcp!(BRANDING, " CLI");
+pub const BRANDING_CLI: &str = concatcp!(BRANDING, " CLI");
 /// The cloud name.
-pub const BRANDING_CLOUD: &str = const_format::concatcp!(BRANDING, " Cloud");
+pub const BRANDING_CLOUD: &str = concatcp!(BRANDING, " Cloud");
+
 /// The CLI command name.
 pub const BRANDING_CLI_CMD: &str = if cfg!(feature = "gel") {
     "gel"
@@ -24,17 +26,19 @@ pub const BRANDING_CLI_CMD_ALT: &str = if cfg!(feature = "gel") {
 };
 /// The executable file name for the CLI.
 pub const BRANDING_CLI_CMD_FILE: &str = if cfg!(windows) {
-    const_format::concatcp!(BRANDING_CLI_CMD, ".exe")
+    concatcp!(BRANDING_CLI_CMD, ".exe")
 } else {
     BRANDING_CLI_CMD
 };
 /// The executable file name for the CLI alternative.
 pub const BRANDING_CLI_CMD_ALT_FILE: &str = if cfg!(windows) {
-    const_format::concatcp!(BRANDING_CLI_CMD_ALT, ".exe")
+    concatcp!(BRANDING_CLI_CMD_ALT, ".exe")
 } else {
     BRANDING_CLI_CMD_ALT
 };
+
 /// The WSL distribution name.
 pub const BRANDING_WSL: &str = "EdgeDB.WSL.1";
+
 /// The display name for the configuration file.
 pub const CONFIG_FILE_DISPLAY_NAME: &str = "`gel.toml` (or `edgedb.toml`)";

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -662,8 +662,8 @@ pub fn check_executables() {
             Please update your scripts (and muscle memory) to use the new executable at {new_executable:?}.");
         } else {
             log::warn!(
-                "{exe_path:?} is the old name for the {BRANDING_CLI_CMD_FILE} executable. \
-            {BRANDING_CLI_CMD_FILE} does not exist. You may need to reinstall {BRANDING}."
+                "{exe_path:?} is the old name for the {BRANDING_CLI_CMD_FILE} executable, but \
+            {BRANDING_CLI_CMD_FILE} does not exist. You may need to reinstall {BRANDING} to fix this."
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ fn _main() -> anyhow::Result<()> {
     });
 
     // Check the executable name and warn on older names, but not for self-install.
-    if !is_cli_self_install(&opt.subcommand) {
+    if !is_cli_self_install(&opt.subcommand) && cfg!(feature = "gel") {
         cli::install::check_executables();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,11 @@ fn is_cli_upgrade(cmd: &Option<options::Command>) -> bool {
     )
 }
 
+fn is_cli_self_install(cmd: &Option<options::Command>) -> bool {
+    use options::Command::_SelfInstall;
+    matches!(cmd, Some(_SelfInstall(..)))
+}
+
 fn _main() -> anyhow::Result<()> {
     // If a crash happens we want the backtrace to be printed by default
     // to ease bug reporting and troubleshooting.
@@ -141,12 +146,15 @@ fn _main() -> anyhow::Result<()> {
     log_levels::init(&mut builder, &opt);
     builder.init();
 
-    cli::install::check_executables();
-
     let cfg = cfg.unwrap_or_else(|e| {
         log::warn!("Config error: {:#}", e);
         Default::default()
     });
+
+    // Check the executable name and warn on older names, but not for self-install.
+    if !is_cli_self_install(&opt.subcommand) {
+        cli::install::check_executables();
+    }
 
     if !is_cli_upgrade(&opt.subcommand) {
         version_check::check(opt.no_cli_update_check)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,8 @@ fn _main() -> anyhow::Result<()> {
     log_levels::init(&mut builder, &opt);
     builder.init();
 
+    cli::install::check_executables();
+
     let cfg = cfg.unwrap_or_else(|e| {
         log::warn!("Config error: {:#}", e);
         Default::default()


### PR DESCRIPTION
This installs (when `--features gel` is passed) to both edgedb and gel executables. The alternative executable is hard linked, symlinked or copied (in that order of preference).

Note that the `gel` executable is installed even w/o `--features gel` right now, but it is installed as the "alternate" executable.

We also check the name of the executable that is invoked and warn if the alternative is there. If the two executables are out of sync (determined by checking executable length), we warn as well.