### PR TITLE
Add support for SQL as input query language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "edgedb-cli"
-version = "5.5.0-dev"
+version = "5.6.0-dev"
 dependencies = [
  "ansi-escapes",
  "anyhow",
@@ -1251,7 +1251,7 @@ dependencies = [
 [[package]]
 name = "edgedb-derive"
 version = "0.5.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#4214a078436c54adbf857058f44f0d63aaa13a86"
+source = "git+https://github.com/edgedb/edgedb-rust/#b38fb4af07ae0017329eb3cce30ca37fe12acd29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1262,7 +1262,7 @@ dependencies = [
 [[package]]
 name = "edgedb-errors"
 version = "0.4.2"
-source = "git+https://github.com/edgedb/edgedb-rust/#4214a078436c54adbf857058f44f0d63aaa13a86"
+source = "git+https://github.com/edgedb/edgedb-rust/#b38fb4af07ae0017329eb3cce30ca37fe12acd29"
 dependencies = [
  "bytes",
 ]
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.6.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#4214a078436c54adbf857058f44f0d63aaa13a86"
+source = "git+https://github.com/edgedb/edgedb-rust/#b38fb4af07ae0017329eb3cce30ca37fe12acd29"
 dependencies = [
  "bigdecimal",
  "bitflags 2.6.0",
@@ -1288,7 +1288,7 @@ dependencies = [
 [[package]]
 name = "edgedb-tokio"
 version = "0.5.1"
-source = "git+https://github.com/edgedb/edgedb-rust/#4214a078436c54adbf857058f44f0d63aaa13a86"
+source = "git+https://github.com/edgedb/edgedb-rust/#b38fb4af07ae0017329eb3cce30ca37fe12acd29"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [package]
 name = "edgedb-cli"
 license = "MIT/Apache-2.0"
-version = "5.5.0-dev"
+version = "5.6.0-dev"
 authors = ["EdgeDB Inc. <hello@edgedb.com>"]
 edition = "2018"
 

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -34,7 +34,11 @@ pub async fn interactive(prompt: &mut repl::State, query: &str) -> anyhow::Resul
             };
             let indesc = data_description.input()?;
             let input = match cli
-                .ping_while(input_variables(&indesc, &mut prompt.prompt))
+                .ping_while(input_variables(
+                    &indesc,
+                    &mut prompt.prompt,
+                    prompt.input_language,
+                ))
                 .await
             {
                 Ok(input) => input,

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -539,6 +539,7 @@ pub fn get_setting(s: &Setting, prompt: &repl::State) -> Cow<'static, str> {
                 "0  # no timeout".into()
             }
         }
+        Language(_) => prompt.input_language.as_str().into(),
         HistorySize(_) => prompt.history_limit.to_string().into(),
         OutputFormat(_) => prompt.output_format.as_str().into(),
         DisplayTypenames(_) => bool_str(prompt.display_typenames).into(),
@@ -644,6 +645,9 @@ pub async fn execute(
                 HistorySize(c) => {
                     let limit = c.value.expect("only set here");
                     prompt.set_history_limit(limit).await?;
+                }
+                Language(l) => {
+                    prompt.input_language = l.value.expect("only writes here");
                 }
                 OutputFormat(c) => {
                     prompt.output_format = c.value.expect("only writes here");

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -216,6 +216,8 @@ pub struct SetCommand {
 
 #[derive(clap::Subcommand, Clone, Debug, EdbSettings)]
 pub enum Setting {
+    /// Query language. One of: edgeql, sql.
+    Language(Language),
     /// Set input mode. One of: vi, emacs
     InputMode(InputMode),
     /// Print implicit properties of objects: id, type id
@@ -242,6 +244,12 @@ pub enum Setting {
     /// Set idle transaction timeout in Duration format.
     /// Default is 5 minutes; specify 0 to disable.
     IdleTransactionTimeout(IdleTransactionTimeout),
+}
+
+#[derive(clap::Args, Clone, Debug, Default)]
+pub struct Language {
+    #[arg(value_name = "lang")]
+    pub value: Option<repl::InputLanguage>,
 }
 
 #[derive(clap::Args, Clone, Debug, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,8 @@ pub struct ShellConfig {
     #[serde(default, deserialize_with = "parse_idle_tx_timeout")]
     pub idle_transaction_timeout: Option<Duration>,
     #[serde(with = "serde_str::opt", default)]
+    pub input_language: Option<repl::InputLanguage>,
+    #[serde(with = "serde_str::opt", default)]
     pub output_format: Option<repl::OutputFormat>,
     #[serde(default)]
     pub display_typenames: Option<bool>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,7 @@ fn _main() -> anyhow::Result<()> {
             non_interactive::interpret_stdin(
                 &opt,
                 opt.output_format.unwrap_or(repl::OutputFormat::JsonPretty),
+                opt.input_language.unwrap_or(repl::InputLanguage::EdgeQL),
             )
         }
     }

--- a/src/migrations/migrate.rs
+++ b/src/migrations/migrate.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 
 use anyhow::Context as _;
 use colorful::Colorful;
-use edgedb_protocol::common::{Capabilities, Cardinality, CompilationOptions, IoFormat};
+use edgedb_protocol::common::{
+    Capabilities, Cardinality, CompilationOptions, InputLanguage, IoFormat,
+};
 use indexmap::IndexMap;
 use indicatif::ProgressBar;
 use tokio::fs;
@@ -549,6 +551,7 @@ async fn execute_with_parse_callback(
         implicit_typeids: false,
         explicit_objectids: true,
         allow_capabilities: Capabilities::ALL,
+        input_language: InputLanguage::EdgeQL,
         io_format: IoFormat::Binary,
         expected_cardinality: Cardinality::Many,
     };

--- a/src/options.rs
+++ b/src/options.rs
@@ -31,7 +31,7 @@ use crate::portable::local::{instance_data_dir, runstate_dir};
 use crate::portable::options::InstanceName;
 use crate::portable::project;
 use crate::print;
-use crate::repl::OutputFormat;
+use crate::repl::{InputLanguage, OutputFormat};
 use crate::tty_password;
 use crate::watch::options::WatchCommand;
 
@@ -404,6 +404,11 @@ pub struct Query {
     #[arg(short = 'F', long)]
     pub output_format: Option<OutputFormat>,
 
+    /// Input language: `edgeql`, `sql`.
+    /// Default is `edgeql`.
+    #[arg(short = 'L', long)]
+    pub input_language: Option<InputLanguage>,
+
     /// Filename to execute queries from.
     /// Pass `--file -` to execute queries from stdin.
     #[arg(short = 'f', long)]
@@ -459,6 +464,7 @@ pub struct Options {
     pub debug_print_frames: bool,
     pub debug_print_descriptors: bool,
     pub debug_print_codecs: bool,
+    pub input_language: Option<InputLanguage>,
     pub output_format: Option<OutputFormat>,
     pub no_cli_update_check: bool,
     pub test_output_conn_params: bool,
@@ -815,6 +821,7 @@ impl Options {
             Some(Command::Query(Query {
                 queries: Some(vec![query]),
                 output_format,
+                input_language: Some(InputLanguage::EdgeQL),
                 file: None,
                 conn: args.conn.clone(),
             }))
@@ -847,6 +854,7 @@ impl Options {
             debug_print_frames: args.debug_print_frames,
             debug_print_descriptors: args.debug_print_descriptors,
             debug_print_codecs: args.debug_print_codecs,
+            input_language: Some(InputLanguage::EdgeQL),
             output_format: if args.tab_separated {
                 Some(OutputFormat::TabSeparated)
             } else if args.json {


### PR DESCRIPTION
The new `\set language sql` toggle switches the CLI into SQL mode.  The
`query` subcommand also gained the `--input-language` argument here,
though it only works with `--tab-separated` output mode.
