### PR TITLE
Change bootstrapped user to "admin"

### DIFF
--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -336,7 +336,7 @@ pub struct Create {
 
     /// Default user name (created during initialization and saved in
     /// credentials file).
-    #[arg(long, default_value = "edgedb")]
+    #[arg(long, default_value = "admin")]
     pub default_user: String,
 
     /// The default branch name. This defaults to 'main' on EdgeDB >=5.x; otherwise

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -836,7 +836,7 @@ fn do_init(
             installation: Some(inst),
             port,
         };
-        create::bootstrap(&paths, &info, "edgedb", database)?;
+        create::bootstrap(&paths, &info, "admin", database)?;
         match create::create_service(&info) {
             Ok(()) => {}
             Err(e) => {


### PR DESCRIPTION
This changes the user bootstrapped by default from `edgedb` to `admin`, regardless of the server version.

See also:
* edgedb/edgedb#8010
* #1412