### PR TITLE
edgedb-cli 6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "edgedb-cli"
-version = "5.6.0-dev"
+version = "6.0.0"
 dependencies = [
  "anes",
  "ansi-escapes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [package]
 name = "edgedb-cli"
 license = "MIT/Apache-2.0"
-version = "5.6.0-dev"
+version = "6.0.0"
 authors = ["EdgeDB Inc. <hello@edgedb.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Changes
=======

* Add extension commands (#1385 #1389)
  (by @mmastrac in 290579bc 7de43a2d)

* Add support for SQL as input query language (#1400)
  (by @elprans in ac7b368f)

* Change bootstrapped user to "admin" (#1413)
  (by @fantix in c9104a5c)

Binary Protocol Changes:

* Bump edgedb-protocol for protocol v2 support (#1388)
  (by @elprans in 4e7988a1)

* Send query tag "gel/cli" or "gel/repl" (protocol v3, #1408)
  (by @fantix in 1e04b64f)

Config Changes:

* Support scoping config params (#1382)
  (by @mmastrac in 6c93799d)

* Add current_email_provider_name config. (#1409)
  (by @dnwpark in a8cd9bd9)

* Add config track_query_stats (#1411)
  (by @fantix in 45187bfe)

Branding
========

* Prepare to rename EdgeDB -> Gel (#1390)
  (by @mmastrac in 7e58bd24)

* Rename: all other env vars in the CLI (#1396)
  (by @mmastrac in ef333435)

* Install new executable name (and link old executable) (#1398)
  (by @mmastrac in dbc93332)

* Mopping up rest of the edgedb CLI command references  (#1402)
  (by @mmastrac in 01a912ae)

* New branding on install and Repl (#1397)
  (by @mmastrac in 6a5f1c49)

* Add support for .gel files. (#1406)
  (by @dnwpark in e80a37d6)

Fixes
=====

* Warnings (#1378)
  (by @aljazerzen in 4c9e89fe)

* Use rustls for reqwest (#1381)
  (by @mmastrac in 8d05aa70)

* Update Cargo.lock (#1384 #1410)
  (by @aljazerzen in 75a7dfe8 04279871)

* cargo clippy --fix -- -Dclippy::uninlined_format_args (#1392)
  (by @mmastrac in 14930370)

* Remove one style of printing from CLI (#1393)
  (by @mmastrac in 5c93ab75)

* Replace print::warn and print::error with macros (#1395)
  (by @mmastrac in 8367287f)

* workflows: Use correct version for builds on macOS and Windows
  (by @elprans in ba1ccfd5)

* Make sure bzip2 always gets linked statically
  (by @elprans in a1797637)

* Bump Ubuntu _down_ to Jammy (#1405)
  (by @mmastrac in 5f22cb78)

* Fix default server user (#1412)
  (by @fantix in adc523c1)