### PR TITLE
Fix "admin" role issue with different servers

### DIFF
--- a/src/branding.rs
+++ b/src/branding.rs
@@ -58,3 +58,7 @@ pub const CONFIG_FILE_DISPLAY_NAME: &str = if cfg!(feature = "gel") {
 /// The default query tag for server statistics.
 pub const QUERY_TAG: &str = "gel/cli";
 pub const REPL_QUERY_TAG: &str = "gel/repl";
+
+/// The default name of the database user bootstrapped in a new instance.
+pub const BRANDING_DEFAULT_USERNAME: &str = "admin";
+pub const BRANDING_DEFAULT_USERNAME_LEGACY: &str = "edgedb";

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -442,10 +442,14 @@ pub fn bootstrap(
     fs::create_dir_all(&tmp_data).with_context(|| format!("creating {:?}", &tmp_data))?;
 
     let password = generate_password();
+    let version = info.get_version()?;
     let script = bootstrap_script(
         user,
         &password,
-        if info.get_version()? >= &Build::from_str("6.0-dev.9024+4b89273").unwrap() {
+        if &Build::from_str("6.0-alpha.2+8fb3f01").unwrap() <= version
+            && version < &Build::from_str("6.0-dev.8321+d6c575a").unwrap()  // lowest nightly
+            || version >= &Build::from_str("6.0-dev.9024+4b89273").unwrap()  // first "admin"
+        {
             "admin"
         } else {
             "edgedb"

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -28,7 +28,7 @@ use crate::print::{self, err_marker, msg, Highlight};
 use crate::process;
 use crate::question;
 
-use crate::portable::project::get_default_branch_name;
+use crate::portable::project::{get_default_branch_name, get_default_user_name};
 use edgedb_tokio::credentials::Credentials;
 
 fn ask_name(cloud_client: &mut cloud::client::CloudClient) -> anyhow::Result<InstanceName> {
@@ -171,7 +171,9 @@ pub fn create(cmd: &Create, opts: &crate::options::Options) -> anyhow::Result<()
         bootstrap(
             &paths,
             &info,
-            &cmd.default_user,
+            cmd.default_user
+                .as_deref()
+                .unwrap_or_else(|| get_default_user_name(specific_version)),
             &cmd.default_branch
                 .clone()
                 .unwrap_or_else(|| get_default_branch_name(specific_version)),

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -22,7 +22,7 @@ use crate::portable::options::{Create, InstanceName, Start};
 use crate::portable::platform::optional_docker_check;
 use crate::portable::repository::{Query, QueryOptions};
 use crate::portable::reset_password::{generate_password, password_hash};
-use crate::portable::ver::Build;
+use crate::portable::ver::Specific;
 use crate::portable::{linux, macos, windows};
 use crate::print::{self, err_marker, msg, Highlight};
 use crate::process;
@@ -447,7 +447,7 @@ pub fn bootstrap(
     let script = bootstrap_script(
         user,
         &password,
-        if info.get_version()? >= &Build::from_str("6.0-alpha.2+8fb3f01").unwrap() {
+        if info.get_version()?.specific() >= Specific::from_str("6.0-alpha.2").unwrap() {
             "admin"
         } else {
             "edgedb"

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -442,14 +442,10 @@ pub fn bootstrap(
     fs::create_dir_all(&tmp_data).with_context(|| format!("creating {:?}", &tmp_data))?;
 
     let password = generate_password();
-    let version = info.get_version()?;
     let script = bootstrap_script(
         user,
         &password,
-        if &Build::from_str("6.0-alpha.2+8fb3f01").unwrap() <= version
-            && version < &Build::from_str("6.0-dev.8321+d6c575a").unwrap()  // lowest nightly
-            || version >= &Build::from_str("6.0-dev.9024+4b89273").unwrap()  // first "admin"
-        {
+        if info.get_version()? >= &Build::from_str("6.0-alpha.2+8fb3f01").unwrap() {
             "admin"
         } else {
             "edgedb"

--- a/src/portable/create.rs
+++ b/src/portable/create.rs
@@ -7,7 +7,10 @@ use fn_error_context::context;
 
 use color_print::cformat;
 
-use crate::branding::{BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD};
+use crate::branding::{
+    BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD, BRANDING_DEFAULT_USERNAME,
+    BRANDING_DEFAULT_USERNAME_LEGACY,
+};
 use crate::cloud;
 use crate::commands::ExitCode;
 use crate::credentials;
@@ -447,10 +450,11 @@ pub fn bootstrap(
     let script = bootstrap_script(
         user,
         &password,
+        // This is the user included in the server. It changed since 6.0-alpha.2.
         if info.get_version()?.specific() >= Specific::from_str("6.0-alpha.2").unwrap() {
-            "admin"
+            BRANDING_DEFAULT_USERNAME
         } else {
-            "edgedb"
+            BRANDING_DEFAULT_USERNAME_LEGACY
         },
     );
 

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -335,9 +335,10 @@ pub struct Create {
     pub start_conf: Option<StartConf>,
 
     /// Default user name (created during initialization and saved in
-    /// credentials file).
-    #[arg(long, default_value = "admin")]
-    pub default_user: String,
+    /// credentials file). This defaults to 'admin' on EdgeDB >=6.x; otherwise
+    /// 'edgedb' is used.
+    #[arg(long)]
+    pub default_user: Option<String>,
 
     /// The default branch name. This defaults to 'main' on EdgeDB >=5.x; otherwise
     /// 'edgedb' is used.

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -849,12 +849,7 @@ fn do_init(
             installation: Some(inst),
             port,
         };
-        create::bootstrap(
-            &paths,
-            &info,
-            get_default_user_name(&version),
-            database,
-        )?;
+        create::bootstrap(&paths, &info, get_default_user_name(&version), database)?;
         match create::create_service(&info) {
             Ok(()) => {}
             Err(e) => {

--- a/src/portable/project.rs
+++ b/src/portable/project.rs
@@ -23,6 +23,7 @@ use crate::branding::QUERY_TAG;
 use crate::branding::{
     BRANDING, BRANDING_CLI_CMD, BRANDING_SCHEMA_FILE_EXT, CONFIG_FILE_DISPLAY_NAME,
 };
+use crate::branding::{BRANDING_DEFAULT_USERNAME, BRANDING_DEFAULT_USERNAME_LEGACY};
 use crate::cloud;
 use crate::cloud::client::CloudClient;
 use crate::commands::ExitCode;
@@ -412,9 +413,9 @@ pub fn get_default_branch_name(version: &Specific) -> String {
 
 pub fn get_default_user_name(version: &Specific) -> &'static str {
     if version.major >= 6 {
-        "admin"
+        BRANDING_DEFAULT_USERNAME
     } else {
-        "edgedb"
+        BRANDING_DEFAULT_USERNAME_LEGACY
     }
 }
 


### PR DESCRIPTION
* Check 6.0 alpha versions correctly (early 6.0 nightlies are no longer supported)
* Still bootstrap 5.x and earlier instances with "edgedb" as the default default_user

Refs #1412, #1413