### PR TITLE
CI: Fix jq to handle missing metadata

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -27,7 +27,7 @@
       shell: bash
       run: |
         rev=$(git rev-parse HEAD)
-        jq_filter='.packages[] | select(.basename == "edgedb-cli") | select(.architecture == $ARCH) | .version_details.metadata.scm_revision | . as $rev | select($REV | startswith($rev))'
+        jq_filter='.packages[] | select(.basename == "edgedb-cli") | select(.architecture == $ARCH) | .version_details.metadata.scm_revision | select(. != null) | . as $rev | select($REV | startswith($rev))'
 <% for tgt in targets.linux %>
         val=true
 <% if tgt.family == "debian" %>

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,7 +84,7 @@ jobs:
       shell: bash
       run: |
         rev=$(git rev-parse HEAD)
-        jq_filter='.packages[] | select(.basename == "edgedb-cli") | select(.architecture == $ARCH) | .version_details.metadata.scm_revision | . as $rev | select($REV | startswith($rev))'
+        jq_filter='.packages[] | select(.basename == "edgedb-cli") | select(.architecture == $ARCH) | .version_details.metadata.scm_revision | select(. != null) | . as $rev | select($REV | startswith($rev))'
 
         val=true
 


### PR DESCRIPTION
Sample JSON losing metadata:

```json
{
  "basename": "edgedb-cli",
  "name": "edgedb-cli",
  "slot": null,
  "version": "6.1.0-dev.1225+a647d8a",
  "version_details": {
    "major": 6,
    "minor": null,
    "patch": 0,
    "prerelease": [
      {
        "phase": "dev",
        "number": 1225
      }
    ],
    "metadata": {}
  },
  "version_key": "6~dev.1225.202412070027nightly.el9",
  "revision": "202412070027nightly.el9",
  "build_date": "1970-01-01T00:00:00+00:00",
  "tags": {},
  "architecture": "aarch64",
  "installref": "edgedb-cli-6.1.0_dev.1225+a647d8a-202412070027nightly.el9.aarch64",
  "installrefs": [
    {
      "ref": "edgedb-cli-6.1.0_dev.1225+a647d8a-202412070027nightly.el9.aarch64",
      "type": null,
      "encoding": null,
      "verification": {}
    }
  ]
}
```