### PR TITLE
Bump version to 6.2.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "edgedb-cli"
-version = "6.1.0-dev"
+version = "6.2.0-dev"
 dependencies = [
  "anes",
  "ansi-escapes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [package]
 name = "edgedb-cli"
 license = "MIT/Apache-2.0"
-version = "6.1.0-dev"
+version = "6.2.0-dev"
 authors = ["EdgeDB Inc. <hello@edgedb.com>"]
 edition = "2018"
 


### PR DESCRIPTION
I cut a 6.1.0 branch directly from the 6.0.0 branch.
Probably 6.2.0 will get cut from master, though.