### PR TITLE
Unify --instance arg for extension commands

### DIFF
--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -53,7 +53,7 @@ pub fn main(options: &Options) -> Result<(), anyhow::Error> {
         }
         Command::Extension(cmd) => {
             directory_check::check_and_error()?;
-            portable::extension_main(cmd)
+            portable::extension_main(cmd, options)
         }
         Command::Instance(cmd) => {
             directory_check::check_and_error()?;

--- a/src/options.rs
+++ b/src/options.rs
@@ -367,7 +367,7 @@ pub enum Command {
     /// Manage local [`BRANDING`] installations
     Server(portable::options::ServerCommand),
     /// Manage local extensions
-    Extension(portable::options::ServerInstanceExtensionCommand),
+    Extension(portable::options::ExtensionCommand),
     /// Generate shell completions
     #[command(name = "_gen_completions")]
     #[command(hide = true)]

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -82,9 +82,14 @@ pub enum InstanceCommand {
 #[derive(clap::Args, Debug, Clone)]
 #[command(version = "help_expand")]
 #[command(disable_version_flag = true)]
-pub struct ServerInstanceExtensionCommand {
+pub struct ExtensionCommand {
     #[command(subcommand)]
     pub subcommand: InstanceExtensionCommand,
+
+    #[command(flatten)]
+    #[deprecated]
+    // This is here for --help only. Values gets parsed by the global args.
+    pub _conn_opts: ConnectionOptions,
 }
 
 #[derive(clap::Subcommand, Clone, Debug)]
@@ -92,27 +97,18 @@ pub enum InstanceExtensionCommand {
     /// List installed extensions for a local instance.
     List(ExtensionList),
     /// List available extensions for a local instance.
-    ListAvailable(ExtensionListExtensions),
+    ListAvailable(ExtensionListAvailable),
     /// Install an extension for a local instance.
     Install(ExtensionInstall),
     /// Uninstall an extension from a local instance.
     Uninstall(ExtensionUninstall),
 }
 
-#[derive(clap::Args, IntoArgs, Debug, Clone)]
-pub struct ExtensionList {
-    /// Specify local instance name.
-    #[arg(short = 'I', long)]
-    #[arg(value_hint=ValueHint::Other)] // TODO complete instance name
-    pub instance: Option<InstanceName>,
-}
+#[derive(clap::Args, Debug, Clone)]
+pub struct ExtensionList {}
 
 #[derive(clap::Args, IntoArgs, Debug, Clone)]
-pub struct ExtensionListExtensions {
-    /// Specify local instance name.
-    #[arg(short = 'I', long)]
-    #[arg(value_hint=ValueHint::Other)] // TODO complete instance name
-    pub instance: Option<InstanceName>,
+pub struct ExtensionListAvailable {
     /// Specify the channel override (stable, testing, or nightly)
     #[arg(long, hide = true)]
     pub channel: Option<Channel>,
@@ -123,10 +119,6 @@ pub struct ExtensionListExtensions {
 
 #[derive(clap::Args, IntoArgs, Debug, Clone)]
 pub struct ExtensionInstall {
-    /// Specify local instance name.
-    #[arg(short = 'I', long)]
-    #[arg(value_hint=ValueHint::Other)] // TODO complete instance name
-    pub instance: Option<InstanceName>,
     /// Name of the extension to install
     #[arg(short = 'E', long)]
     pub extension: String,
@@ -143,9 +135,6 @@ pub struct ExtensionInstall {
 /// Represents the options for uninstalling an extension from a local EdgeDB instance.
 #[derive(clap::Args, IntoArgs, Debug, Clone)]
 pub struct ExtensionUninstall {
-    /// Specify local instance name.
-    #[arg(short = 'I', long)]
-    pub instance: Option<InstanceName>,
     /// The name of the extension to uninstall.
     #[arg(short = 'E', long)]
     pub extension: String,

--- a/src/print/tests.rs
+++ b/src/print/tests.rs
@@ -6,7 +6,6 @@ use std::task;
 
 use bigdecimal::BigDecimal;
 use bytes::Bytes;
-use nom::AsBytes;
 use tokio_stream::Stream;
 
 use crate::print::native::FormatExt;

--- a/tests/portable_smoke.rs
+++ b/tests/portable_smoke.rs
@@ -272,6 +272,14 @@ fn install() {
         .success();
 
     Command::new("edgedb")
+        .arg("--instance=second")
+        .arg("extension")
+        .arg("list")
+        .assert()
+        .context("extension-list", "basic list of the installed extensions")
+        .success();
+
+    Command::new("edgedb")
         .arg("instance")
         .arg("destroy")
         .arg("second")
@@ -305,14 +313,5 @@ fn install() {
         .arg("SELECT 1")
         .assert()
         .context("query-1a", "late query of `inst1`")
-        .success();
-
-    Command::new("edgedb")
-        .arg("--instance")
-        .arg("inst1")
-        .arg("extension")
-        .arg("list")
-        .assert()
-        .context("extension-list", "basic list of the installed extensions")
         .success();
 }

--- a/tests/portable_smoke.rs
+++ b/tests/portable_smoke.rs
@@ -306,4 +306,13 @@ fn install() {
         .assert()
         .context("query-1a", "late query of `inst1`")
         .success();
+
+    Command::new("edgedb")
+        .arg("--instance")
+        .arg("inst1")
+        .arg("extension")
+        .arg("list")
+        .assert()
+        .context("extension-list", "basic list of the installed extensions")
+        .success();
 }


### PR DESCRIPTION
Extension commands used to have an "instance" paramater
that used same keys (--instance, -I) as the global instance connection
parameter. This PR unifies these two.

The practical effect is that `-I`/`--instance` can be specified anywhere
between commands instead of just at the end, as it used to have to be.

We might also want to infer the instance from the current project.
