### PR TITLE
Rename edgedb to instance in gel.toml

### DIFF
--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -167,7 +167,7 @@ pub fn init_existing(
     let ver_query = if let Some(sver) = &options.server_version {
         sver.clone()
     } else {
-        config.edgedb.server_version
+        config.instance.server_version
     };
     let mut client = CloudClient::new(cloud_options)?;
     let (name, exists) = ask_name(project_dir, options, &mut client)?;
@@ -492,7 +492,7 @@ fn link(
     }
 
     let config = config::read(&config_path)?;
-    let ver_query = config.edgedb.server_version;
+    let ver_query = config.instance.server_version;
 
     let mut client = CloudClient::new(cloud_options)?;
     let name = if let Some(name) = &options.server_instance {

--- a/src/portable/project/upgrade.rs
+++ b/src/portable/project/upgrade.rs
@@ -214,7 +214,7 @@ pub fn upgrade_instance(options: &Command, opts: &crate::options::Options) -> an
         anyhow::bail!("`{CONFIG_FILE_DISPLAY_NAME}` not found, unable to upgrade {BRANDING} instance without an initialized project.");
     };
     let config = config::read(&config_path)?;
-    let cfg_ver = &config.edgedb.server_version;
+    let cfg_ver = &config.instance.server_version;
     let schema_dir = &config.project.schema_dir;
 
     let stash_dir = get_stash_path(&root)?;


### PR DESCRIPTION
edgedb.toml has already been renamed to gel.toml, but `[edgedb]` was left behind.

Because it feels confusing that `gel.toml` would contain a `[gel]` table, I've renamed `[edgedb]` to `[instance]`. Currently, the only property of `[instance]` is `server-version`.

This is backwards compatible.