### PR TITLE
Implement extension loader on WSL

### DIFF
--- a/src/portable/extension.rs
+++ b/src/portable/extension.rs
@@ -14,6 +14,7 @@ use crate::portable::options::{instance_arg, InstanceName};
 use crate::portable::platform::get_server;
 use crate::portable::repository::{get_platform_extension_packages, Channel};
 use crate::portable::server::install::download_package;
+use crate::portable::windows;
 use crate::table;
 
 pub fn run(cmd: &Command, options: &Options) -> Result<(), anyhow::Error> {
@@ -242,6 +243,10 @@ fn run_extension_loader(
     command: Option<impl AsRef<OsStr>>,
     file: Option<impl AsRef<OsStr>>,
 ) -> Result<String, anyhow::Error> {
+    if cfg!(windows) {
+        return windows::extension_loader(extension_installer, command, file);
+    }
+
     let mut cmd = std::process::Command::new(extension_installer);
 
     if let Some(cmd_str) = command {

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -95,6 +95,14 @@ impl Wsl {
         pro.no_proxy();
         pro
     }
+    pub fn extension_loader(&self, path: &Path) -> process::Native {
+        let mut pro = process::Native::new("edgedb", "edgedb", "wsl");
+        pro.arg("--user").arg("edgedb");
+        pro.arg("--distribution").arg(&self.distribution);
+        pro.arg(path);
+        pro.no_proxy();
+        pro
+    }
     #[cfg(windows)]
     fn copy_out(&self, src: impl AsRef<str>, destination: impl AsRef<Path>) -> anyhow::Result<()> {
         let dest = path_to_linux(destination.as_ref())?;
@@ -1071,4 +1079,24 @@ pub fn get_instance_info(name: &str) -> anyhow::Result<String> {
 
 pub fn is_in_wsl() -> bool {
     *IS_IN_WSL
+}
+
+pub fn extension_loader(
+    extension_installer: &Path,
+    command: Option<impl AsRef<std::ffi::OsStr>>,
+    file: Option<impl AsRef<std::ffi::OsStr>>,
+) -> anyhow::Result<String> {
+    let wsl = ensure_wsl()?;
+
+    let pro = &mut wsl.extension_loader(extension_installer);
+
+    if let Some(cmd_str) = command {
+        pro.arg(cmd_str);
+    }
+
+    if let Some(file_path) = file {
+        pro.arg(file_path);
+    }
+
+    Ok(pro.get_stdout_text()?)
 }


### PR DESCRIPTION
I wasn't aware how "gel on windows" works, but because gel-server does not run on windows, we run it in WSL. This is implemented as a "command redirection" where a CLI command is converted back into a process invocation, when it is determined that it has to run in WSL.

The same goes for `edgedb-load-ext`. So I've implemented the redirect for `extension install` and `extension uninstall` and converted `extension list` to always query over gel proto.