### PR TITLE
Update and fix nightly install tests

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -15,17 +15,16 @@ env:
 jobs:
 
   nightly-test:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
     strategy:
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest]
         test_suite:
         - compat
         - install
         - upgrade
         - project
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -35,7 +35,7 @@ jobs:
         run: "sudo apt-get install musl-tools"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@d0e72ca3bfdc51937a4f81431ccbed269ef9f2a2
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: "cargo,rustc,rust-std"
           toolchain: "stable"

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install musl-tools
         run: "sudo apt-get install musl-tools"
 
+      - name: Remove rust-toolchain.toml
+        run: rm rust-toolchain.toml
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,9 +136,9 @@ gethostname = "0.5.0"
 bitvec = "1.0.1"
 nom = "7.1.3"
 bitflags = "2.6"
-renamore = "0.3.2"
+renamore = {version="0.3.2", features = ["always-fallback"]}
 anes = "0.2.0"
-geozero = {version="0.14.0",features=["with-wkb"]}
+geozero = {version="0.14.0", features=["with-wkb"]}
 
 [dependencies.bzip2]
 version = "*"

--- a/flake.nix
+++ b/flake.nix
@@ -38,10 +38,16 @@
         in {
           devShells.default = pkgs.mkShell {
             buildInputs = common ++ [
-              (fenix_pkgs.fromToolchainFile {
-                file = ./rust-toolchain.toml;
-                sha256 = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
-              })
+              (fenix_pkgs.combine [
+                (fenix_pkgs.fromToolchainFile {
+                  file = ./rust-toolchain.toml;
+                  sha256 = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
+                })
+                (fenix_pkgs.targets.x86_64-unknown-linux-musl.fromToolchainFile {
+                  file = ./rust-toolchain.toml;
+                  sha256 = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
+                })
+              ])
             ];
           };
         };

--- a/tests/common/docker.rs
+++ b/tests/common/docker.rs
@@ -28,7 +28,7 @@ import edgedb
 assert edgedb.create_client(sys.argv[1]).query_single("SELECT 1+1") == 2
 
 async def test_async():
-    conn = await edgedb.create_async_client(sys.argv[1])
+    conn = edgedb.create_async_client(sys.argv[1])
     return await conn.query_single("SELECT 1+1")
 assert asyncio.get_event_loop().run_until_complete(test_async()) == 2
     "###

--- a/tests/common/docker.rs
+++ b/tests/common/docker.rs
@@ -37,18 +37,16 @@ assert asyncio.get_event_loop().run_until_complete(test_async()) == 2
 pub fn edbconnect_js() -> &'static str {
     r###"
 const edgedb = require('edgedb')
-edgedb.createClient(process.argv[2])
-.then(function(conn) {
-    return conn.querySingle('SELECT 1+1')
-})
-.then(function(value) {
-    console.assert(value == 2, value)
-    process.exit(0)
-})
-.catch(e => {
-    console.error("Error", e)
-    process.exit(1)
-})
+let client = edgedb.createClient(process.argv[2])
+conn.querySingle('SELECT 1+1')
+    .then(function(value) {
+        console.assert(value == 2, value)
+        process.exit(0)
+    })
+    .catch(e => {
+        console.error("Error", e)
+        process.exit(1)
+    })
     "###
 }
 

--- a/tests/common/docker.rs
+++ b/tests/common/docker.rs
@@ -25,7 +25,7 @@ import asyncio
 import sys
 import edgedb
 
-assert edgedb.connect(sys.argv[1]).query_one("SELECT 1+1") == 2
+assert edgedb.create_client(sys.argv[1]).query_one("SELECT 1+1") == 2
 
 async def test_async():
     conn = await edgedb.async_connect(sys.argv[1])
@@ -37,7 +37,7 @@ assert asyncio.get_event_loop().run_until_complete(test_async()) == 2
 pub fn edbconnect_js() -> &'static str {
     r###"
 const edgedb = require('edgedb')
-edgedb.connect(process.argv[2])
+edgedb.createClient(process.argv[2])
 .then(function(conn) {
     return conn.queryOne('SELECT 1+1')
 })

--- a/tests/common/docker.rs
+++ b/tests/common/docker.rs
@@ -25,7 +25,7 @@ import asyncio
 import sys
 import edgedb
 
-assert edgedb.create_client(sys.argv[1]).query_one("SELECT 1+1") == 2
+assert edgedb.create_client(sys.argv[1]).query_single("SELECT 1+1") == 2
 
 async def test_async():
     conn = await edgedb.async_connect(sys.argv[1])

--- a/tests/common/docker.rs
+++ b/tests/common/docker.rs
@@ -28,7 +28,7 @@ import edgedb
 assert edgedb.create_client(sys.argv[1]).query_single("SELECT 1+1") == 2
 
 async def test_async():
-    conn = await edgedb.async_connect(sys.argv[1])
+    conn = await edgedb.create_async_client(sys.argv[1])
     return await conn.query_single("SELECT 1+1")
 assert asyncio.get_event_loop().run_until_complete(test_async()) == 2
     "###

--- a/tests/common/docker.rs
+++ b/tests/common/docker.rs
@@ -38,7 +38,7 @@ pub fn edbconnect_js() -> &'static str {
     r###"
 const edgedb = require('edgedb')
 let client = edgedb.createClient(process.argv[2])
-conn.querySingle('SELECT 1+1')
+client.querySingle('SELECT 1+1')
     .then(function(value) {
         console.assert(value == 2, value)
         process.exit(0)

--- a/tests/common/docker.rs
+++ b/tests/common/docker.rs
@@ -29,7 +29,7 @@ assert edgedb.create_client(sys.argv[1]).query_one("SELECT 1+1") == 2
 
 async def test_async():
     conn = await edgedb.async_connect(sys.argv[1])
-    return await conn.query_one("SELECT 1+1")
+    return await conn.query_single("SELECT 1+1")
 assert asyncio.get_event_loop().run_until_complete(test_async()) == 2
     "###
 }
@@ -39,7 +39,7 @@ pub fn edbconnect_js() -> &'static str {
 const edgedb = require('edgedb')
 edgedb.createClient(process.argv[2])
 .then(function(conn) {
-    return conn.queryOne('SELECT 1+1')
+    return conn.querySingle('SELECT 1+1')
 })
 .then(function(value) {
     console.assert(value == 2, value)

--- a/tests/github-nightly/common.rs
+++ b/tests/github-nightly/common.rs
@@ -56,8 +56,7 @@ pub fn dock_centos(codename: u32) -> String {
         r###"
         FROM centos:{codename}
         RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-        RUN sed -i 's|#baseurl=http://mirror.centos.org\
-                     |baseurl=http://vault.centos.org|g' \
+        RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' \
                      /etc/yum.repos.d/CentOS-*
         RUN yum -y install sudo yum-utils systemd
         RUN yum-config-manager \

--- a/tests/github-nightly/common.rs
+++ b/tests/github-nightly/common.rs
@@ -44,39 +44,6 @@ pub fn dock_ubuntu(codename: &str) -> String {
     )
 }
 
-pub fn dock_ubuntu_jspy(codename: &str) -> String {
-    format!(
-        r###"
-        FROM ubuntu:{codename}
-        ENV DEBIAN_FRONTEND=noninteractive
-        RUN apt-get update && apt-get install -y \
-            ca-certificates sudo gnupg2 apt-transport-https curl \
-            software-properties-common dbus-user-session \
-            python3-pip
-        RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-        RUN add-apt-repository \
-           "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-           $(lsb_release -cs) \
-           stable"
-        RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-        RUN add-apt-repository \
-            "deb [arch=amd64] https://deb.nodesource.com/node_17.x \
-            $(lsb_release -cs) \
-            main"
-        RUN apt-get update && apt-get install -y docker-ce-cli nodejs
-        RUN adduser --uid 1000 --home /home/user1 \
-            --shell /bin/bash --ingroup users --gecos "Test User" \
-            user1
-        RUN pip3 install edgedb
-        ADD ./edgedb /usr/bin/edgedb
-        ADD ./sudoers /etc/sudoers
-        ADD ./edbconnect.py /usr/bin/edbconnect.py
-        ADD ./edbconnect.js /usr/bin/edbconnect.js
-    "###,
-        codename = codename
-    )
-}
-
 pub fn dock_debian(codename: &str) -> String {
     format!(
         r###"

--- a/tests/github-nightly/common.rs
+++ b/tests/github-nightly/common.rs
@@ -55,6 +55,10 @@ pub fn dock_centos(codename: u32) -> String {
     format!(
         r###"
         FROM centos:{codename}
+        RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        RUN sed -i 's|#baseurl=http://mirror.centos.org\
+                     |baseurl=http://vault.centos.org|g' \
+                     /etc/yum.repos.d/CentOS-*
         RUN yum -y install sudo yum-utils systemd
         RUN yum-config-manager \
             --add-repo \

--- a/tests/github-nightly/common.rs
+++ b/tests/github-nightly/common.rs
@@ -51,28 +51,6 @@ pub fn dock_ubuntu_jspy(codename: &str) -> String {
     )
 }
 
-pub fn dock_centos(codename: u32) -> String {
-    format!(
-        r###"
-        FROM centos:{codename}
-        RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-        RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' \
-                     /etc/yum.repos.d/CentOS-*
-        RUN yum -y install sudo yum-utils systemd
-        RUN yum-config-manager \
-            --add-repo \
-            https://download.docker.com/linux/centos/docker-ce.repo
-        RUN yum -y install docker-ce-cli
-        RUN adduser --uid 1000 --home /home/user1 \
-            --shell /bin/bash --group users \
-            user1
-        ADD ./edgedb /usr/bin/edgedb
-        ADD ./sudoers /etc/sudoers
-    "###,
-        codename = codename
-    )
-}
-
 pub fn dock_debian(codename: &str) -> String {
     format!(
         r###"

--- a/tests/github-nightly/common.rs
+++ b/tests/github-nightly/common.rs
@@ -46,7 +46,6 @@ pub fn dock_ubuntu_jspy(codename: &str) -> String {
             --shell /bin/bash --ingroup users --gecos "Test User" \
             user1
         RUN pip3 install edgedb
-        RUN npm install edgedb
         ADD ./edgedb /usr/bin/edgedb
         ADD ./sudoers /etc/sudoers
         ADD ./edbconnect.py /usr/bin/edbconnect.py

--- a/tests/github-nightly/common.rs
+++ b/tests/github-nightly/common.rs
@@ -30,13 +30,17 @@ pub fn dock_ubuntu_jspy(codename: &str) -> String {
         RUN apt-get update && apt-get install -y \
             ca-certificates sudo gnupg2 apt-transport-https curl \
             software-properties-common dbus-user-session \
-            python3-pip npm
+            python3-pip
         RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
         RUN add-apt-repository \
            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
            $(lsb_release -cs) \
            stable"
-        RUN apt-get update && apt-get install -y docker-ce-cli
+        RUN add-apt-repository \
+            "deb [arch=amd64] https://deb.nodesource.com/node_17.x \
+            $(lsb_release -cs) \
+            main"
+        RUN apt-get update && apt-get install -y docker-ce-cli nodejs
         RUN adduser --uid 1000 --home /home/user1 \
             --shell /bin/bash --ingroup users --gecos "Test User" \
             user1

--- a/tests/github-nightly/common.rs
+++ b/tests/github-nightly/common.rs
@@ -1,3 +1,25 @@
+#[derive(Debug, Clone)]
+pub enum Distro {
+    Ubuntu(&'static str),
+    Debian(&'static str),
+}
+
+impl Distro {
+    pub fn tag_name(&self) -> String {
+        match self {
+            Distro::Ubuntu(cn) => format!("test-ubuntu-{cn}"),
+            Distro::Debian(cn) => format!("test-debian-{cn}"),
+        }
+    }
+
+    pub fn dockerfile(&self) -> String {
+        match self {
+            Distro::Ubuntu(codename) => dock_ubuntu(codename),
+            Distro::Debian(codename) => dock_debian(codename),
+        }
+    }
+}
+
 pub fn dock_ubuntu(codename: &str) -> String {
     format!(
         r###"

--- a/tests/github-nightly/common.rs
+++ b/tests/github-nightly/common.rs
@@ -36,6 +36,7 @@ pub fn dock_ubuntu_jspy(codename: &str) -> String {
            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
            $(lsb_release -cs) \
            stable"
+        RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
         RUN add-apt-repository \
             "deb [arch=amd64] https://deb.nodesource.com/node_17.x \
             $(lsb_release -cs) \

--- a/tests/github-nightly/common.rs
+++ b/tests/github-nightly/common.rs
@@ -82,14 +82,15 @@ pub fn dock_debian(codename: &str) -> String {
         r###"
         FROM debian:{codename}
         ENV DEBIAN_FRONTEND=noninteractive
-        RUN apt-get update && apt-get install -y \
-            ca-certificates sudo gnupg2 apt-transport-https curl \
-            software-properties-common dbus-user-session
-        RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-        RUN add-apt-repository \
-           "deb [arch=amd64] https://download.docker.com/linux/debian \
-           $(lsb_release -cs) \
-           stable"
+        RUN apt-get update && apt-get install -y ca-certificates curl sudo
+        RUN install -m 0755 -d /etc/apt/keyrings
+        RUN curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+        RUN chmod a+r /etc/apt/keyrings/docker.asc
+
+        RUN echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+            > /etc/apt/sources.list.d/docker.list
         RUN apt-get update && apt-get install -y docker-ce-cli
         RUN adduser --uid 1000 --home /home/user1 \
             --shell /bin/bash --ingroup users --gecos "Test User" \

--- a/tests/github-nightly/compat.rs
+++ b/tests/github-nightly/compat.rs
@@ -13,12 +13,12 @@ use crate::measure::Time;
 #[test_case("edbtest_stretch", &dock_debian("stretch"), "")]
 #[test_case("edbtest_focal", &dock_ubuntu("focal"), "")]
 // alpha7
-#[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "--version=1-alpha7")]
-#[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "--version=1-alpha7")]
-#[test_case("edbtest_centos8", &dock_centos(8), "--version=1-alpha7")]
-#[test_case("edbtest_buster", &dock_debian("buster"), "--version=1-alpha7")]
-#[test_case("edbtest_stretch", &dock_debian("stretch"), "--version=1-alpha7")]
-#[test_case("edbtest_focal", &dock_ubuntu("focal"), "--version=1-alpha7")]
+#[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "--version=1-rc.5")]
+#[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "--version=1-rc.5")]
+#[test_case("edbtest_centos8", &dock_centos(8), "--version=1-rc.5")]
+#[test_case("edbtest_buster", &dock_debian("buster"), "--version=1-rc.5")]
+#[test_case("edbtest_stretch", &dock_debian("stretch"), "--version=1-rc.5")]
+#[test_case("edbtest_focal", &dock_ubuntu("focal"), "--version=1-rc.5")]
 // nightly
 #[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "--nightly")]
 #[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "--nightly")]
@@ -43,7 +43,6 @@ fn cli(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result<()> {
                 query "SELECT 1+1")
             test "$val" = "2"
 
-            # changed in 1-alpha.7 due to dropping implicit __tid__
             edgedb -Itest1 list scalars --system
         "###,
             version = version,

--- a/tests/github-nightly/compat.rs
+++ b/tests/github-nightly/compat.rs
@@ -1,6 +1,6 @@
 use test_case::test_case;
 
-use crate::common::{dock_centos, dock_debian, dock_ubuntu};
+use crate::common::{dock_debian, dock_ubuntu};
 use crate::docker::run_systemd;
 use crate::docker::{build_image, Context};
 use crate::measure::Time;
@@ -8,21 +8,18 @@ use crate::measure::Time;
 // stable
 #[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "")]
 #[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "")]
-#[test_case("edbtest_centos8", &dock_centos(8), "")]
 #[test_case("edbtest_buster", &dock_debian("buster"), "")]
 #[test_case("edbtest_stretch", &dock_debian("stretch"), "")]
 #[test_case("edbtest_focal", &dock_ubuntu("focal"), "")]
 // alpha7
 #[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "--version=1-rc.5")]
 #[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "--version=1-rc.5")]
-#[test_case("edbtest_centos8", &dock_centos(8), "--version=1-rc.5")]
 #[test_case("edbtest_buster", &dock_debian("buster"), "--version=1-rc.5")]
 #[test_case("edbtest_stretch", &dock_debian("stretch"), "--version=1-rc.5")]
 #[test_case("edbtest_focal", &dock_ubuntu("focal"), "--version=1-rc.5")]
 // nightly
 #[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "--nightly")]
 #[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "--nightly")]
-#[test_case("edbtest_centos8", &dock_centos(8), "--nightly")]
 #[test_case("edbtest_buster", &dock_debian("buster"), "--nightly")]
 #[test_case("edbtest_stretch", &dock_debian("stretch"), "--nightly")]
 #[test_case("edbtest_focal", &dock_ubuntu("focal"), "--nightly")]

--- a/tests/github-nightly/compat.rs
+++ b/tests/github-nightly/compat.rs
@@ -44,7 +44,7 @@ fn cli(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result<()> {
             test "$val" = "2"
 
             # changed in 1-alpha.7 due to dropping implicit __tid__
-            edgedb -Itest1 list-scalar-types --system
+            edgedb -Itest1 list scalars --system
         "###,
             version = version,
         ),

--- a/tests/github-nightly/compat.rs
+++ b/tests/github-nightly/compat.rs
@@ -1,37 +1,37 @@
-use test_case::test_case;
+use test_case::test_matrix;
 
-use crate::common::{dock_debian, dock_ubuntu};
+use crate::common::Distro;
 use crate::docker::run_systemd;
 use crate::docker::{build_image, Context};
 use crate::measure::Time;
 
-// stable
-#[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "")]
-#[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "")]
-#[test_case("edbtest_buster", &dock_debian("buster"), "")]
-#[test_case("edbtest_stretch", &dock_debian("stretch"), "")]
-#[test_case("edbtest_focal", &dock_ubuntu("focal"), "")]
-// alpha7
-#[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "--version=1-rc.5")]
-#[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "--version=1-rc.5")]
-#[test_case("edbtest_buster", &dock_debian("buster"), "--version=1-rc.5")]
-#[test_case("edbtest_stretch", &dock_debian("stretch"), "--version=1-rc.5")]
-#[test_case("edbtest_focal", &dock_ubuntu("focal"), "--version=1-rc.5")]
-// nightly
-#[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "--nightly")]
-#[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "--nightly")]
-#[test_case("edbtest_buster", &dock_debian("buster"), "--nightly")]
-#[test_case("edbtest_stretch", &dock_debian("stretch"), "--nightly")]
-#[test_case("edbtest_focal", &dock_ubuntu("focal"), "--nightly")]
-fn cli(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result<()> {
+#[test_matrix(
+    [
+        Distro::Ubuntu("focal"),
+        Distro::Ubuntu("bionic"),
+        Distro::Ubuntu("xenial"),
+        Distro::Debian("bookworm"),
+        Distro::Debian("bullseye"),
+        Distro::Debian("buster"),
+    ],
+    [
+        "", // latest
+        "--version=4.8", // previous
+        "--nightly", // nightly
+    ]
+)]
+fn cli(distro: Distro, version: &str) -> anyhow::Result<()> {
+    let dockerfile = distro.dockerfile();
+    let tag_name = distro.tag_name();
+
     let _tm = Time::measure();
     let context = Context::new()
         .add_file("Dockerfile", dockerfile)?
         .add_sudoers()?
         .add_bin()?;
-    build_image(context, tagname)?;
+    build_image(context, &tag_name)?;
     run_systemd(
-        tagname,
+        &tag_name,
         &format!(
             r###"
             edgedb server install {version}

--- a/tests/github-nightly/install.rs
+++ b/tests/github-nightly/install.rs
@@ -21,7 +21,7 @@ fn package_no_systemd(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
         edgedb instance create test1
     "###,
     )
-    .code(2)
+    .success()
     .stderr(contains("Bootstrapping complete"))
     .stderr(contains("start --foreground"));
     Ok(())

--- a/tests/github-nightly/install.rs
+++ b/tests/github-nightly/install.rs
@@ -119,7 +119,7 @@ fn docker(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result<()> 
         tagname,
         &format!(
             r###"
-            edgedb server install --method=docker {version}
+            edgedb server install {version}
             RUST_LOG=info edgedb instance create test1 {version}
             val=$(edgedb -Itest1 --wait-until-available=60s \
                 query "SELECT 1+1")
@@ -149,7 +149,7 @@ fn docker_jspy(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result
         tagname,
         &format!(
             r###"
-            edgedb server install --method=docker {version}
+            edgedb server install {version}
             edgedb instance create test1 {version}
             val=$(edgedb -Itest1 --wait-until-available=60s \
                 query "SELECT 1+1")

--- a/tests/github-nightly/install.rs
+++ b/tests/github-nightly/install.rs
@@ -83,8 +83,8 @@ fn package_jspy(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Resul
             val=$(edgedb -Itest1 --wait-until-available=60s \
                 query "SELECT 1+1")
             test "$val" = "2"
-            python3 /usr/bin/edbconnect.py test1
-            node /usr/bin/edbconnect.js test1
+            python3 ./edbconnect.py test1
+            node ./edbconnect.js test1
             edgedb instance logs test1
             timeout 180 edgedb instance destroy test1
             edgedb server uninstall --all --verbose
@@ -154,8 +154,8 @@ fn docker_jspy(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result
             val=$(edgedb -Itest1 --wait-until-available=60s \
                 query "SELECT 1+1")
             test "$val" = "2"
-            python3 /usr/bin/edbconnect.py test1
-            node /usr/bin/edbconnect.js test1
+            python3 ./edbconnect.py test1
+            node ./edbconnect.js test1
             edgedb instance logs test1
             timeout 180 edgedb instance destroy test1
             edgedb server uninstall --all --verbose

--- a/tests/github-nightly/install.rs
+++ b/tests/github-nightly/install.rs
@@ -1,8 +1,8 @@
-use test_case::{test_case, test_matrix};
+use test_case::test_matrix;
 
-use crate::common::{dock_ubuntu_jspy, Distro};
+use crate::common::Distro;
+use crate::docker::run_systemd;
 use crate::docker::{build_image, Context};
-use crate::docker::{run_docker, run_systemd};
 use crate::measure::Time;
 
 #[test_matrix(
@@ -32,70 +32,6 @@ fn package(distro: Distro, version: &str) -> anyhow::Result<()> {
             val=$(edgedb -Itest1 --wait-until-available=60s \
                 query "SELECT 1+1")
             test "$val" = "2"
-            edgedb instance logs -I test1
-            timeout 180 edgedb instance destroy -I test1 --non-interactive
-            edgedb server uninstall --all --verbose
-        "###,
-            version = version,
-        ),
-    )
-    .success();
-    Ok(())
-}
-
-#[test_case("edbtest_focal", &dock_ubuntu_jspy("focal"), "")]
-#[test_case("edbtest_focal", &dock_ubuntu_jspy("focal"), "--nightly")]
-fn package_jspy(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result<()> {
-    let _tm = Time::measure();
-    let context = Context::new()
-        .add_file("Dockerfile", dockerfile)?
-        .add_sudoers()?
-        .add_edbconnect()?
-        .add_bin()?;
-    build_image(context, tagname)?;
-    run_systemd(
-        tagname,
-        &format!(
-            r###"
-            edgedb server install {version}
-            edgedb instance create test1 {version}
-            val=$(edgedb -Itest1 --wait-until-available=60s \
-                query "SELECT 1+1")
-            test "$val" = "2"
-            python3 ./edbconnect.py test1
-            node ./edbconnect.js test1
-            edgedb instance logs -I test1
-            timeout 180 edgedb instance destroy -I test1 --non-interactive
-            edgedb server uninstall --all --verbose
-        "###,
-            version = version,
-        ),
-    )
-    .success();
-    Ok(())
-}
-
-#[test_case("edbtest_focal", &dock_ubuntu_jspy("focal"), "")]
-#[test_case("edbtest_focal", &dock_ubuntu_jspy("focal"), "--nightly")]
-fn docker_jspy(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result<()> {
-    let _tm = Time::measure();
-    let context = Context::new()
-        .add_file("Dockerfile", dockerfile)?
-        .add_sudoers()?
-        .add_edbconnect()?
-        .add_bin()?;
-    build_image(context, tagname)?;
-    run_docker(
-        tagname,
-        &format!(
-            r###"
-            edgedb server install {version}
-            edgedb instance create test1 {version}
-            val=$(edgedb -Itest1 --wait-until-available=60s \
-                query "SELECT 1+1")
-            test "$val" = "2"
-            python3 ./edbconnect.py test1
-            node ./edbconnect.js test1
             edgedb instance logs -I test1
             timeout 180 edgedb instance destroy -I test1 --non-interactive
             edgedb server uninstall --all --verbose

--- a/tests/github-nightly/install.rs
+++ b/tests/github-nightly/install.rs
@@ -22,8 +22,8 @@ fn package_no_systemd(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
     "###,
     )
     .success()
-    .stderr(contains("Bootstrapping complete"))
-    .stderr(contains("start --foreground"));
+    .stderr(contains("EdgeDB will not start on next login"))
+    .stderr(contains("up and running"));
     Ok(())
 }
 

--- a/tests/github-nightly/install.rs
+++ b/tests/github-nightly/install.rs
@@ -1,40 +1,17 @@
 use predicates::str::contains;
 use test_case::test_case;
 
-use crate::common::{dock_centos, dock_debian, dock_ubuntu, dock_ubuntu_jspy};
+use crate::common::{dock_debian, dock_ubuntu, dock_ubuntu_jspy};
 use crate::docker::{build_image, Context};
 use crate::docker::{run, run_docker, run_systemd};
 use crate::measure::Time;
 
-#[test_case("edbtest_centos7", &dock_centos(7))]
-fn package_no_systemd(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
-    let _tm = Time::measure();
-    let context = Context::new()
-        .add_file("Dockerfile", dockerfile)?
-        .add_sudoers()?
-        .add_bin()?;
-    build_image(context, tagname)?;
-    run(
-        tagname,
-        r###"
-        edgedb server install
-        edgedb instance create test1
-    "###,
-    )
-    .success()
-    .stderr(contains("EdgeDB will not start on next login"))
-    .stderr(contains("up and running"));
-    Ok(())
-}
-
 #[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "")]
 #[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "")]
-#[test_case("edbtest_centos8", &dock_centos(8), "")]
 #[test_case("edbtest_buster", &dock_debian("buster"), "")]
 #[test_case("edbtest_stretch", &dock_debian("stretch"), "")]
 #[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "--nightly")]
 #[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "--nightly")]
-#[test_case("edbtest_centos8", &dock_centos(8), "--nightly")]
 #[test_case("edbtest_buster", &dock_debian("buster"), "--nightly")]
 #[test_case("edbtest_stretch", &dock_debian("stretch"), "--nightly")]
 fn package(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result<()> {
@@ -98,14 +75,10 @@ fn package_jspy(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Resul
 
 #[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "")]
 #[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "")]
-#[test_case("edbtest_centos7", &dock_centos(7), "")]
-#[test_case("edbtest_centos8", &dock_centos(8), "")]
 #[test_case("edbtest_buster", &dock_debian("buster"), "")]
 #[test_case("edbtest_stretch", &dock_debian("stretch"), "")]
 #[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "--nightly")]
 #[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "--nightly")]
-#[test_case("edbtest_centos7", &dock_centos(7), "--nightly")]
-#[test_case("edbtest_centos8", &dock_centos(8), "--nightly")]
 #[test_case("edbtest_buster", &dock_debian("buster"), "--nightly")]
 #[test_case("edbtest_stretch", &dock_debian("stretch"), "--nightly")]
 fn docker(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result<()> {

--- a/tests/github-nightly/install.rs
+++ b/tests/github-nightly/install.rs
@@ -32,8 +32,8 @@ fn package(distro: Distro, version: &str) -> anyhow::Result<()> {
             val=$(edgedb -Itest1 --wait-until-available=60s \
                 query "SELECT 1+1")
             test "$val" = "2"
-            edgedb instance logs test1
-            timeout 180 edgedb instance destroy test1
+            edgedb instance logs -I test1
+            timeout 180 edgedb instance destroy -I test1 --non-interactive
             edgedb server uninstall --all --verbose
         "###,
             version = version,
@@ -64,46 +64,8 @@ fn package_jspy(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Resul
             test "$val" = "2"
             python3 ./edbconnect.py test1
             node ./edbconnect.js test1
-            edgedb instance logs test1
-            timeout 180 edgedb instance destroy test1
-            edgedb server uninstall --all --verbose
-        "###,
-            version = version,
-        ),
-    )
-    .success();
-    Ok(())
-}
-
-#[test_matrix(
-    [
-        Distro::Ubuntu("focal"),
-        Distro::Ubuntu("bionic"),
-        Distro::Debian("bookworm"),
-        Distro::Debian("bullseye"),
-    ],
-    ["", "--nightly"]
-)]
-fn docker(distro: Distro, version: &str) -> anyhow::Result<()> {
-    let tag_name = distro.tag_name();
-
-    let _tm = Time::measure();
-    let context = Context::new()
-        .add_file("Dockerfile", distro.dockerfile())?
-        .add_sudoers()?
-        .add_bin()?;
-    build_image(context, &tag_name)?;
-    run_docker(
-        &tag_name,
-        &format!(
-            r###"
-            edgedb server install {version}
-            RUST_LOG=info edgedb instance create test1 {version}
-            val=$(edgedb -Itest1 --wait-until-available=60s \
-                query "SELECT 1+1")
-            test "$val" = "2"
-            edgedb instance logs test1
-            timeout 180 edgedb instance destroy test1
+            edgedb instance logs -I test1
+            timeout 180 edgedb instance destroy -I test1 --non-interactive
             edgedb server uninstall --all --verbose
         "###,
             version = version,
@@ -134,8 +96,8 @@ fn docker_jspy(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result
             test "$val" = "2"
             python3 ./edbconnect.py test1
             node ./edbconnect.js test1
-            edgedb instance logs test1
-            timeout 180 edgedb instance destroy test1
+            edgedb instance logs -I test1
+            timeout 180 edgedb instance destroy -I test1 --non-interactive
             edgedb server uninstall --all --verbose
         "###,
             version = version,

--- a/tests/github-nightly/project.rs
+++ b/tests/github-nightly/project.rs
@@ -1,6 +1,6 @@
 use test_case::test_case;
 
-use crate::common::{dock_centos, dock_debian, dock_ubuntu};
+use crate::common::{dock_debian, dock_ubuntu};
 use crate::docker::{build_image, Context};
 use crate::docker::{run_docker, run_systemd};
 use crate::measure::Time;
@@ -9,12 +9,10 @@ const NIGHTLY: &str = "--server-version=nightly";
 
 #[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "")]
 #[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "")]
-#[test_case("edbtest_centos8", &dock_centos(8), "")]
 #[test_case("edbtest_buster", &dock_debian("buster"), "")]
 #[test_case("edbtest_stretch", &dock_debian("stretch"), "")]
 #[test_case("edbtest_bionic", &dock_ubuntu("bionic"), NIGHTLY)]
 #[test_case("edbtest_xenial", &dock_ubuntu("xenial"), NIGHTLY)]
-#[test_case("edbtest_centos8", &dock_centos(8), NIGHTLY)]
 #[test_case("edbtest_buster", &dock_debian("buster"), NIGHTLY)]
 #[test_case("edbtest_stretch", &dock_debian("stretch"), NIGHTLY)]
 fn simple_package(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result<()> {

--- a/tests/github-nightly/project.rs
+++ b/tests/github-nightly/project.rs
@@ -1,29 +1,30 @@
-use test_case::test_case;
+use test_case::test_matrix;
 
-use crate::common::{dock_debian, dock_ubuntu};
+use crate::common::Distro;
+use crate::docker::run_systemd;
 use crate::docker::{build_image, Context};
-use crate::docker::{run_docker, run_systemd};
 use crate::measure::Time;
 
-const NIGHTLY: &str = "--server-version=nightly";
+#[test_matrix(
+    [
+        Distro::Ubuntu("focal"),
+        Distro::Ubuntu("bionic"),
+        Distro::Debian("bookworm"),
+        Distro::Debian("bullseye"),
+    ],
+    ["", "--server-version=nightly"]
+)]
+fn simple_package(distro: Distro, version: &str) -> anyhow::Result<()> {
+    let tag_name = distro.tag_name();
 
-#[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "")]
-#[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "")]
-#[test_case("edbtest_buster", &dock_debian("buster"), "")]
-#[test_case("edbtest_stretch", &dock_debian("stretch"), "")]
-#[test_case("edbtest_bionic", &dock_ubuntu("bionic"), NIGHTLY)]
-#[test_case("edbtest_xenial", &dock_ubuntu("xenial"), NIGHTLY)]
-#[test_case("edbtest_buster", &dock_debian("buster"), NIGHTLY)]
-#[test_case("edbtest_stretch", &dock_debian("stretch"), NIGHTLY)]
-fn simple_package(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result<()> {
     let _tm = Time::measure();
     let context = Context::new()
-        .add_file("Dockerfile", dockerfile)?
+        .add_file("Dockerfile", distro.dockerfile())?
         .add_sudoers()?
         .add_bin()?;
-    build_image(context, tagname)?;
+    build_image(context, &tag_name)?;
     run_systemd(
-        tagname,
+        &tag_name,
         &format!(
             r###"
             mkdir -p /tmp/test1

--- a/tests/github-nightly/project.rs
+++ b/tests/github-nightly/project.rs
@@ -30,50 +30,11 @@ fn simple_package(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Res
             r###"
             mkdir -p /tmp/test1
             cd /tmp/test1
-            edgedb project init --non-interactive \
-                --server-install-method=package \
-                {version}
+            edgedb project init --non-interactive {version}
             val=$(edgedb --wait-until-available=60s query "SELECT 7+8")
             test "$val" = "15"
             timeout 120 edgedb project unlink \
                 --destroy-server-instance --non-interactive
-        "###,
-            version = version,
-        ),
-    )
-    .success();
-    Ok(())
-}
-
-#[test_case("edbtest_bionic", &dock_ubuntu("bionic"), "")]
-#[test_case("edbtest_xenial", &dock_ubuntu("xenial"), "")]
-#[test_case("edbtest_centos8", &dock_centos(8), "")]
-#[test_case("edbtest_buster", &dock_debian("buster"), "")]
-#[test_case("edbtest_stretch", &dock_debian("stretch"), "")]
-#[test_case("edbtest_bionic", &dock_ubuntu("bionic"), NIGHTLY)]
-#[test_case("edbtest_xenial", &dock_ubuntu("xenial"), NIGHTLY)]
-#[test_case("edbtest_centos8", &dock_centos(8), NIGHTLY)]
-#[test_case("edbtest_buster", &dock_debian("buster"), NIGHTLY)]
-#[test_case("edbtest_stretch", &dock_debian("stretch"), NIGHTLY)]
-fn simple_docker(tagname: &str, dockerfile: &str, version: &str) -> anyhow::Result<()> {
-    let _tm = Time::measure();
-    let context = Context::new()
-        .add_file("Dockerfile", dockerfile)?
-        .add_sudoers()?
-        .add_bin()?;
-    build_image(context, tagname)?;
-    run_docker(
-        tagname,
-        &format!(
-            r###"
-            mkdir -p /tmp/test1
-            cd /tmp/test1
-            edgedb project init --non-interactive \
-                --server-install-method=docker \
-                {version}
-            val=$(edgedb --wait-until-available=60s query "SELECT 7+8")
-            test "$val" = "15"
-            edgedb project unlink --destroy-server-instance --non-interactive
         "###,
             version = version,
         ),

--- a/tests/github-nightly/upgrade.rs
+++ b/tests/github-nightly/upgrade.rs
@@ -14,8 +14,7 @@ fn package_no_systemd(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
         .add_bin()?;
     build_image(context, tagname)?;
     run_systemd(tagname, r###"
-        edgedb server install --version=1-rc.5
-        edgedb instance create test1 --start-conf=manual || test "$?" -eq 2
+        edgedb instance create test1 --version=1-rc.5 --start-conf=manual
         edgedb instance start --foreground test1 &
         edgedb --wait-until-available=60s -Itest1 query '
             CREATE TYPE Type1 {
@@ -51,7 +50,7 @@ fn package(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
     build_image(context, tagname)?;
     run_systemd(tagname, r###"
         edgedb server install --version=1-rc.5
-        edgedb instance create test1
+        edgedb instance create test1 --version=1-rc.5
 
         ver1=$(edgedb -Itest1 --wait-until-available=60s --tab-separated query '
             SELECT sys::get_version_as_str()
@@ -86,66 +85,6 @@ fn package(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
             journalctl -xe
             exit $res
         fi
-        ver2=$(edgedb -Itest1 --wait-until-available=60s --tab-separated query '
-            SELECT sys::get_version_as_str()
-        ')
-        [[ $ver1 =~ ^1\.0-rc\.5\+ ]]
-
-        val=$(edgedb -Itest1 --wait-until-available=60s --tab-separated \
-              query 'SELECT Type1 { prop1 }')
-        test "$val" = "value1"
-    "###,
-    )
-    .success();
-    Ok(())
-}
-
-#[test_case("edbtest_bionic", &dock_ubuntu("bionic"))]
-#[test_case("edbtest_xenial", &dock_ubuntu("xenial"))]
-#[test_case("edbtest_focal", &dock_ubuntu("focal"))]
-#[test_case("edbtest_centos7", &dock_centos(7))]
-#[test_case("edbtest_centos8", &dock_centos(8))]
-#[test_case("edbtest_buster", &dock_debian("buster"))]
-#[test_case("edbtest_stretch", &dock_debian("stretch"))]
-fn docker(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
-    let _tm = Time::measure();
-    let context = Context::new()
-        .add_file("Dockerfile", dockerfile)?
-        .add_sudoers()?
-        .add_bin()?;
-    build_image(context, tagname)?;
-    run_docker(
-        tagname,
-        r###"
-        mkdir /tmp/workdir
-        cd /tmp/workdir
-
-        edgedb server install --version=1-rc.5 --method=docker
-        edgedb instance create test1
-
-        ver1=$(edgedb -Itest1 --wait-until-available=60s --tab-separated query '
-            SELECT sys::get_version_as_str()
-        ')
-        [[ $ver1 =~ ^1\.0-rc\.5\+ ]]
-
-        edgedb --wait-until-available=60s -Itest1 query '
-            CREATE TYPE Type1 {
-                CREATE PROPERTY prop1 -> str;
-            }
-        ' 'INSERT Type1 { prop1 := "value1" }'
-        edgedb instance upgrade test1
-
-        ver2=$(edgedb -Itest1 --wait-until-available=60s --tab-separated query '
-            SELECT sys::get_version_as_str()
-        ')
-        [[ $ver2 =~ ^1\.0\+ ]]
-
-        val=$(edgedb -Itest1 --wait-until-available=60s --tab-separated \
-              query 'SELECT Type1 { prop1 }')
-        test "$val" = "value1"
-
-        edgedb server revert test1 --no-confirm
-
         ver2=$(edgedb -Itest1 --wait-until-available=60s --tab-separated query '
             SELECT sys::get_version_as_str()
         ')

--- a/tests/github-nightly/upgrade.rs
+++ b/tests/github-nightly/upgrade.rs
@@ -5,10 +5,10 @@ use crate::docker::run_systemd;
 use crate::docker::{build_image, Context};
 use crate::measure::Time;
 
-#[test_case("est_focal", &dock_ubuntu("focal"))]
-#[test_case("est_bionic", &dock_ubuntu("bionic"))]
-#[test_case("est_bookworm", &dock_debian("bookworm"))]
-#[test_case("est_bullseye", &dock_debian("bullseye"))]
+#[test_case("test_focal", &dock_ubuntu("focal"))]
+#[test_case("test_bionic", &dock_ubuntu("bionic"))]
+#[test_case("test_bookworm", &dock_debian("bookworm"))]
+#[test_case("test_bullseye", &dock_debian("bullseye"))]
 fn package(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
     let _tm = Time::measure();
     let context = Context::new()
@@ -32,7 +32,7 @@ fn package(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
                 CREATE PROPERTY prop1 -> str;
             }
         ' 'INSERT Type1 { prop1 := "value1" }'
-        if ! edgedb instance upgrade test1 --to-version=1; then
+        if ! edgedb instance upgrade -I test1 --to-version=1; then
             res=$?
             journalctl -xe
             exit $res

--- a/tests/github-nightly/upgrade.rs
+++ b/tests/github-nightly/upgrade.rs
@@ -56,8 +56,6 @@ fn package(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
             SELECT sys::get_version_as_str()
         ')
         [[ $ver1 =~ ^1\.0-rc\.5\+ ]]
-        path=$(edgedb server info --bin-path)
-        test "$path" = "/usr/bin/edgedb-server-1-rc.5"
 
         edgedb --wait-until-available=60s -Itest1 query '
             CREATE TYPE Type1 {
@@ -73,8 +71,6 @@ fn package(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
             SELECT sys::get_version_as_str()
         ')
         [[ $ver2 =~ ^1\.0\+ ]]
-        path=$(edgedb server info --bin-path)
-        test "$path" = "/usr/bin/edgedb-server-1"
 
         val=$(edgedb -Itest1 --wait-until-available=60s --tab-separated \
               query 'SELECT Type1 { prop1 }')

--- a/tests/github-nightly/upgrade.rs
+++ b/tests/github-nightly/upgrade.rs
@@ -19,45 +19,42 @@ fn package(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
     run_systemd(
         tagname,
         r###"
-        edgedb server install --version=1-rc.5
-        edgedb instance create test1 --version=1-rc.5
+        edgedb server install --version=4.8
+        edgedb instance create test1 --version=4.8
 
-        ver1=$(edgedb -Itest1 --wait-until-available=60s --tab-separated query '
-            SELECT sys::get_version_as_str()
-        ')
-        [[ $ver1 =~ ^1\.0-rc\.5\+ ]]
+        ver1=$(edgedb -Itest1 --wait-until-available=60s query --output-format=tab-separated \
+            'SELECT sys::get_version_as_str()')
+        [[ $ver1 =~ ^4\.8 ]]
 
         edgedb --wait-until-available=60s -Itest1 query '
             CREATE TYPE Type1 {
                 CREATE PROPERTY prop1 -> str;
             }
         ' 'INSERT Type1 { prop1 := "value1" }'
-        if ! edgedb instance upgrade -I test1 --to-version=1; then
+        if ! edgedb instance upgrade -I test1 --to-version=5 --non-interactive; then
             res=$?
             journalctl -xe
             exit $res
         fi
-        ver2=$(edgedb -Itest1 --wait-until-available=60s --tab-separated query '
-            SELECT sys::get_version_as_str()
-        ')
-        [[ $ver2 =~ ^1\.[0-9]+\+ ]]
+        ver2=$(edgedb -Itest1 --wait-until-available=60s query --output-format=tab-separated \
+            'SELECT sys::get_version_as_str()')
+        [[ $ver2 =~ ^5\.[0-9]+\+ ]]
 
-        val=$(edgedb -Itest1 --wait-until-available=60s --tab-separated \
-              query 'SELECT Type1 { prop1 }')
+        val=$(edgedb -Itest1 --wait-until-available=60s query --output-format=tab-separated \
+            'SELECT Type1 { prop1 }')
         test "$val" = "value1"
 
-        if ! edgedb server revert test1 --no-confirm; then
+        if ! edgedb instance revert -I test1 --no-confirm; then
             res=$?
             journalctl -xe
             exit $res
         fi
-        ver2=$(edgedb -Itest1 --wait-until-available=60s --tab-separated query '
-            SELECT sys::get_version_as_str()
-        ')
-        [[ $ver1 =~ ^1\.0-rc\.5\+ ]]
+        ver2=$(edgedb -Itest1 --wait-until-available=60s query --output-format=tab-separated \
+            'SELECT sys::get_version_as_str()')
+        [[ $ver1 =~ ^4\.8 ]]
 
-        val=$(edgedb -Itest1 --wait-until-available=60s --tab-separated \
-              query 'SELECT Type1 { prop1 }')
+        val=$(edgedb -Itest1 --wait-until-available=60s query --output-format=tab-separated \
+            'SELECT Type1 { prop1 }')
         test "$val" = "value1"
     "###,
     )

--- a/tests/github-nightly/upgrade.rs
+++ b/tests/github-nightly/upgrade.rs
@@ -1,11 +1,10 @@
 use test_case::test_case;
 
-use crate::common::{dock_centos, dock_debian, dock_ubuntu};
+use crate::common::{dock_debian, dock_ubuntu};
 use crate::docker::{build_image, Context};
 use crate::docker::{run_docker, run_systemd};
 use crate::measure::Time;
 
-#[test_case("edbtest_centos7", &dock_centos(7))]
 fn package_no_systemd(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
     let _tm = Time::measure();
     let context = Context::new()
@@ -38,7 +37,6 @@ fn package_no_systemd(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
 #[test_case("edbtest_bionic", &dock_ubuntu("bionic"))]
 #[test_case("edbtest_xenial", &dock_ubuntu("xenial"))]
 #[test_case("edbtest_focal", &dock_ubuntu("focal"))]
-#[test_case("edbtest_centos8", &dock_centos(8))]
 #[test_case("edbtest_buster", &dock_debian("buster"))]
 #[test_case("edbtest_stretch", &dock_debian("stretch"))]
 fn package(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {

--- a/tests/github-nightly/upgrade.rs
+++ b/tests/github-nightly/upgrade.rs
@@ -70,7 +70,7 @@ fn package(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {
         ver2=$(edgedb -Itest1 --wait-until-available=60s --tab-separated query '
             SELECT sys::get_version_as_str()
         ')
-        [[ $ver2 =~ ^1\.0\+ ]]
+        [[ $ver2 =~ ^1\.[0-9]+\+ ]]
 
         val=$(edgedb -Itest1 --wait-until-available=60s --tab-separated \
               query 'SELECT Type1 { prop1 }')


### PR DESCRIPTION
Contains a bunch of work from @tailhook on an old nightly-test branch.

I've updated versions of tested distros and edgedb server versions.
I've also removed py & js tests, as that should be tested in their own repos.

- **Fix nightly test**
- **Update versions of edgedb in tests**
- **Fixing centos8**
- **Got rid of `--server-install-method`**
- **fixup**
- **Apply patch only to centos 8**
- **fixup**
- **Don't check bin-path any more**
- **Fix verison check**
- **Fix for new py/js libraries**
- **Fix python/js example**
- **Fix another query_one -> query_single**
- **Fix async_create_client**
- **Another python API upgrade**
- **No more code(2)**
- **Another test phrase fixed**
- **Fix test JS test**
- **fixup!**
- **Remove `--method=docker`**
- **Trying new node on ubuntu**
- **fixup**
- **Fixing npm install**
- **update rust toolchain**
- **remove rust-toolchain.toml**
- **remove tests for centos**
- **update linux distros in github-nightly tests**
- **fix debian docker installation process**
- **update "upgrade" test**
- **remove js and py library**
- **cleanup nightly tests**
