### PR TITLE
Organize project manifest

### DIFF
--- a/src/branch/merge.rs
+++ b/src/branch/merge.rs
@@ -14,8 +14,8 @@ pub async fn main(
     cli_opts: &Options,
 ) -> anyhow::Result<()> {
     let current_branch = context.get_current_branch(source_connection).await?;
-    let project_config = context
-        .get_project_config()
+    let project = context
+        .get_project()
         .await?
         .ok_or_else(|| anyhow::anyhow!("Merge must be used within a project"))?;
 
@@ -30,7 +30,7 @@ pub async fn main(
             None => anyhow::bail!("The branch '{}' doesn't exist", cmd.target_branch),
         };
 
-    let migration_context = migrations::Context::for_project(&project_config)?;
+    let migration_context = migrations::Context::for_project(&project)?;
     let mut merge_migrations =
         get_merge_migrations(source_connection, &mut target_connection).await?;
 

--- a/src/branding.rs
+++ b/src/branding.rs
@@ -48,8 +48,8 @@ pub const BRANDING_SCHEMA_FILE_EXT: &str = if cfg!(feature = "gel") {
 /// The WSL distribution name.
 pub const BRANDING_WSL: &str = "EdgeDB.WSL.1";
 
-/// The display name for the configuration file.
-pub const CONFIG_FILE_DISPLAY_NAME: &str = if cfg!(feature = "gel") {
+/// The display name for the project manifest file.
+pub const MANIFEST_FILE_DISPLAY_NAME: &str = if cfg!(feature = "gel") {
     "`gel.toml` (or `edgedb.toml`)"
 } else {
     "`edgedb.toml`"

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -433,8 +433,8 @@ fn try_project_init(new_layout: bool) -> anyhow::Result<InitResult> {
     }
 
     let base_dir = env::current_dir().context("failed to get current directory")?;
-    if let Some((project_dir, config_path)) = project::project_dir(Some(&base_dir))? {
-        if get_stash_path(&project_dir)?.exists() {
+    if let Some(project) = project::find_project(Some(&base_dir))? {
+        if get_stash_path(&project.root)?.exists() {
             log::info!("Project already initialized. Skipping...");
             return Ok(Already);
         }
@@ -450,7 +450,7 @@ fn try_project_init(new_layout: bool) -> anyhow::Result<InitResult> {
         let q = question::Confirm::new(format!(
             "Do you want to initialize a new {BRANDING} server instance for the project \
              defined in `{}`?",
-            config_path.display(),
+            project.manifest.display(),
         ));
         if !q.ask()? {
             return Ok(Refused);
@@ -472,7 +472,7 @@ fn try_project_init(new_layout: bool) -> anyhow::Result<InitResult> {
             server_start_conf: None,
             cloud_opts: options.clone(),
         };
-        project::init::init_existing(&init, &project_dir, config_path, &options)?;
+        project::init::init_existing(&init, &project, &options)?;
         Ok(Initialized)
     } else {
         Ok(NotAProject)

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -38,8 +38,8 @@ use crate::migrations::source_map::{Builder, SourceMap};
 use crate::migrations::squash;
 use crate::migrations::timeout;
 use crate::platform::{is_legacy_schema_file, is_schema_file, tmp_file_name};
-use crate::print;
 use crate::print::style::Styler;
+use crate::print::{self, AsRelativeToCurrentDir};
 use crate::question;
 
 const SAFE_CONFIDENCE: f64 = 0.99999;
@@ -791,16 +791,17 @@ where
     file.flush().await?;
     drop(file);
     fs::rename(&tmp_file, &filepath).await?;
+
+    let filepath = filepath.as_relative().display();
     if verbose {
         if print::use_color() {
             eprintln!(
-                "{} {}, id: {}",
+                "{} {}, id: {id}",
                 "Created".bold().light_green(),
-                filepath.display().to_string().bold().white(),
-                id,
+                filepath.to_string().bold().white(),
             );
         } else {
-            eprintln!("Created {}, id: {}", filepath.display(), id);
+            eprintln!("Created {filepath}, id: {id}");
         }
     }
     Ok(())

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -19,8 +19,8 @@ use crate::migrations::migrate::{apply_migration, ApplyMigrationError};
 use crate::migrations::migration;
 use crate::migrations::options::UpgradeCheck;
 use crate::migrations::timeout;
-use crate::portable::config::Config;
 use crate::portable::local::InstallInfo;
+use crate::portable::project;
 use crate::portable::repository::{self, PackageInfo, Query};
 use crate::portable::server::install;
 use crate::print::{self, msg, Highlight};
@@ -112,18 +112,18 @@ pub fn upgrade_check(_options: &Options, options: &UpgradeCheck) -> anyhow::Resu
 }
 
 #[cfg(windows)]
-pub fn to_version(_: &PackageInfo, _: &Config) -> anyhow::Result<()> {
+pub fn to_version(_: &PackageInfo, _: &project::Context) -> anyhow::Result<()> {
     unreachable!();
 }
 
 #[cfg(unix)]
-pub fn to_version(pkg: &PackageInfo, config: &Config) -> anyhow::Result<()> {
+pub fn to_version(pkg: &PackageInfo, project: &project::Context) -> anyhow::Result<()> {
     use const_format::concatcp;
 
     use crate::branding::BRANDING;
 
     let info = install::package(pkg).context(concatcp!("error installing ", BRANDING))?;
-    let ctx = Context::for_project(config)?;
+    let ctx = Context::for_project(project)?;
     spawn_and_check(&info, ctx, false)
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -19,7 +19,7 @@ use crate::cli;
 use crate::cli::options::CliCommand;
 
 use crate::branch;
-use crate::branding::{BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD, CONFIG_FILE_DISPLAY_NAME};
+use crate::branding::{BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD, MANIFEST_FILE_DISPLAY_NAME};
 use crate::cloud::options::CloudCommand;
 use crate::commands::parser::Common;
 use crate::commands::ExitCode;
@@ -915,7 +915,7 @@ impl Options {
                         )
                     } else {
                         format!(
-                            "no {CONFIG_FILE_DISPLAY_NAME} found and no connection options \
+                            "no {MANIFEST_FILE_DISPLAY_NAME} found and no connection options \
                             are specified"
                         )
                     };

--- a/src/portable/mod.rs
+++ b/src/portable/mod.rs
@@ -1,4 +1,3 @@
-pub mod config;
 pub mod exit_codes;
 pub mod local;
 pub mod options;

--- a/src/portable/project/info.rs
+++ b/src/portable/project/info.rs
@@ -6,17 +6,17 @@ use const_format::concatcp;
 use gel_tokio::get_stash_path;
 
 use crate::branding::BRANDING_CLOUD;
-use crate::branding::{BRANDING_CLI_CMD, CONFIG_FILE_DISPLAY_NAME};
+use crate::branding::{BRANDING_CLI_CMD, MANIFEST_FILE_DISPLAY_NAME};
 use crate::commands::ExitCode;
 use crate::portable::project;
 use crate::print::{self, msg, Highlight};
 use crate::table;
 
 pub fn run(options: &Command) -> anyhow::Result<()> {
-    let Some((root, _)) = project::project_dir(options.project_dir.as_deref())? else {
-        anyhow::bail!("`{CONFIG_FILE_DISPLAY_NAME}` not found, unable to get project info.");
+    let Some(project) = project::find_project(options.project_dir.as_deref())? else {
+        anyhow::bail!("`{MANIFEST_FILE_DISPLAY_NAME}` not found, unable to get project info.");
     };
-    let stash_dir = get_stash_path(&root)?;
+    let stash_dir = get_stash_path(&project.root)?;
     if !stash_dir.exists() {
         msg!(
             "{} {} Run `{BRANDING_CLI_CMD} project init`.",
@@ -60,11 +60,11 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
             serde_json::to_string_pretty(&JsonInfo {
                 instance_name: &instance_name,
                 cloud_profile: cloud_profile.as_deref(),
-                root: &root,
+                root: &project.root,
             })?
         );
     } else {
-        let root = root.display().to_string();
+        let root = project.root.display().to_string();
         let mut rows: Vec<(&str, String)> =
             vec![("Instance name", instance_name), ("Project root", root)];
         if let Some(profile) = cloud_profile.as_deref() {

--- a/src/portable/project/unlink.rs
+++ b/src/portable/project/unlink.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use clap::ValueHint;
 use gel_tokio::get_stash_path;
 
-use crate::branding::CONFIG_FILE_DISPLAY_NAME;
+use crate::branding::MANIFEST_FILE_DISPLAY_NAME;
 use crate::commands::ExitCode;
 use crate::options::CloudOptions;
 use crate::portable::exit_codes;
@@ -15,11 +15,11 @@ use crate::print::{self, msg, Highlight};
 use crate::question;
 
 pub fn run(options: &Command, opts: &crate::options::Options) -> anyhow::Result<()> {
-    let Some((project_dir, _)) = project::project_dir(options.project_dir.as_deref())? else {
-        anyhow::bail!("`{CONFIG_FILE_DISPLAY_NAME}` not found, unable to unlink instance.");
+    let Some(project) = project::find_project(options.project_dir.as_deref())? else {
+        anyhow::bail!("`{MANIFEST_FILE_DISPLAY_NAME}` not found, unable to unlink instance.");
     };
-    let canon = fs::canonicalize(&project_dir)
-        .with_context(|| format!("failed to canonicalize dir {project_dir:?}"))?;
+    let canon = fs::canonicalize(&project.root)
+        .with_context(|| format!("failed to canonicalize dir {:?}", project.root))?;
     let stash_path = get_stash_path(&canon)?;
 
     if stash_path.exists() {

--- a/src/portable/server/info.rs
+++ b/src/portable/server/info.rs
@@ -4,6 +4,7 @@ use edgedb_cli_derive::IntoArgs;
 use crate::portable::local;
 use crate::portable::repository::{Channel, Query, QueryOptions};
 use crate::portable::ver;
+use crate::print::AsRelativeToCurrentDir;
 use crate::table;
 
 pub fn run(cmd: &Command) -> anyhow::Result<()> {
@@ -39,7 +40,7 @@ pub fn run(cmd: &Command) -> anyhow::Result<()> {
                     let path = path.to_str().context("cannot convert path to a string")?;
                     println!("{}", serde_json::to_string(path)?);
                 } else {
-                    println!("{}", path.display());
+                    println!("{}", path.as_relative().display());
                 }
             }
             "version" => {
@@ -63,7 +64,10 @@ pub fn run(cmd: &Command) -> anyhow::Result<()> {
     } else {
         table::settings(&[
             ("Version", inst.version.to_string()),
-            ("Binary path", inst.server_path()?.display().to_string()),
+            (
+                "Binary path",
+                inst.server_path()?.as_relative().display().to_string(),
+            ),
         ]);
     }
     Ok(())

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -462,6 +462,22 @@ pub fn write_warn(line: impl fmt::Display) {
     }
 }
 
+pub trait AsRelativeToCurrentDir {
+    fn as_relative(&self) -> &Self;
+}
+
+impl AsRelativeToCurrentDir for std::path::Path {
+    fn as_relative(&self) -> &Self {
+        let curr_dir = std::env::current_dir().ok();
+
+        if let Some(stripped) = curr_dir.and_then(|wd| self.strip_prefix(&wd).ok()) {
+            stripped
+        } else {
+            self
+        }
+    }
+}
+
 #[macro_export]
 macro_rules! warn {
     ($($args:tt)*) => {

--- a/tests/func/migrations.rs
+++ b/tests/func/migrations.rs
@@ -369,7 +369,7 @@ fn project() {
         .code(0)
         .stderr(ends_with(
             "Created \
-            ./priv/dbschema/migrations/00002-m1e5vq3.edgeql, \
+            priv/dbschema/migrations/00002-m1e5vq3.edgeql, \
             id: m1e5vq3h4oizlsp4a3zge5bqhu7yeoorc27k3yo2aaenfqgfars6uq\n",
         ));
     SERVER


### PR DESCRIPTION
This PR:
- renames project::Config to project::manifest::Manifest,
- combines `project_dir` and `config_path` into `project::Location`,
- combines `Location` and `Manifest` into `project::Context`.

