### PR TITLE
Colors on light terminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,7 @@ dependencies = [
  "term 1.0.1",
  "termcolor",
  "termimad",
+ "terminal-light",
  "terminal_size",
  "test-case",
  "test-utils",
@@ -4047,6 +4048,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal-light"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9474484d1a0c031cd7d065c6f027a376859c9fedb32c94df3d7a797218bbb7"
+dependencies = [
+ "coolor",
+ "crossterm",
+ "thiserror 1.0.69",
+ "xterm-query",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5142,6 +5155,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "xterm-query"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775333f1c03ec9f81f7f295de5a8dac7350b91f7e03e2dd730593ba4ec3515d1"
+dependencies = [
+ "nix 0.29.0",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ bitflags = "2.6"
 renamore = {version="0.3.2", features = ["always-fallback"]}
 anes = "0.2.0"
 geozero = {version="0.14.0", features=["with-wkb"]}
+terminal-light = "1.7.0"
 
 [dependencies.bzip2]
 version = "*"

--- a/src/analyze/contexts.rs
+++ b/src/analyze/contexts.rs
@@ -149,7 +149,7 @@ pub fn print(explain: &Analysis) {
 
 fn print_buffer(buffer: &Buffer, title: impl fmt::Display) {
     let mut markup = String::with_capacity(buffer.text.len());
-    let styler = Styler::dark_256();
+    let styler = Styler::new();
     highlight::edgeql(&mut markup, &buffer.text, &styler);
 
     let mut out = String::with_capacity(markup.len());

--- a/src/analyze/table.rs
+++ b/src/analyze/table.rs
@@ -204,9 +204,9 @@ pub fn print_title(title: impl fmt::Display, width: usize) {
     let filler = max(width.saturating_sub(twidth) / 2, 5);
     println!(
         "{} {} {}",
-        format_args!("{0:─^filler$}", "").fade(),
-        title.emphasize(),
-        format_args!("{0:─^filler$}", "").fade(),
+        format_args!("{0:─^filler$}", "").to_string().muted(),
+        title.to_string().emphasized(),
+        format_args!("{0:─^filler$}", "").to_string().muted(),
     );
 }
 

--- a/src/analyze/tree.rs
+++ b/src/analyze/tree.rs
@@ -56,7 +56,7 @@ pub fn print_debug_plan(explain: &Analysis) {
             let mut header = Vec::with_capacity(9);
             header.push(Box::new("") as Box<_>);
             cost_header(&mut header, &explain.arguments);
-            header.push(Box::new("Plan Info".emphasize()) as Box<_>);
+            header.push(Box::new("Plan Info".emphasized()) as Box<_>);
 
             let marker = NarrowMarker::new(node);
 
@@ -84,11 +84,11 @@ pub fn print_shape(explain: &Analysis) {
         let mut header = Vec::with_capacity(8);
         header.push(Box::new("") as Box<_>);
         cost_header(&mut header, &explain.arguments);
-        header.push(Box::new("Relations".emphasize()) as Box<_>);
+        header.push(Box::new("Relations".emphasized()) as Box<_>);
 
         let mut root = Vec::with_capacity(3);
         let context = explain.context(&shape.contexts);
-        root.push(Box::new(format!("{context}{}", "root".fade())) as Box<_>);
+        root.push(Box::new(format!("{context}{}", "root".muted())) as Box<_>);
         cost_columns(&mut root, &shape.cost, &explain.arguments);
         root.push(Box::new(table::WordList(Relations(&shape.relations))));
 
@@ -143,7 +143,7 @@ pub fn print_expanded_tree(explain: &Analysis) {
         let mut header = Vec::with_capacity(9);
         header.push(Box::new("") as Box<_>);
         cost_header(&mut header, &explain.arguments);
-        header.push(Box::new("Plan Info".emphasize()) as Box<_>);
+        header.push(Box::new("Plan Info".emphasized()) as Box<_>);
 
         let marker = NarrowMarker::new(node);
         let mut rows = vec![header];
@@ -440,7 +440,7 @@ impl table::Contents for Border {
     }
     fn render(&self, _width: usize, height: usize, f: &mut fmt::Formatter) -> fmt::Result {
         for _ in 0..height {
-            writeln!(f, "{}", "│".emphasize())?;
+            writeln!(f, "{}", "│".emphasized())?;
         }
         Ok(())
     }
@@ -449,15 +449,15 @@ impl table::Contents for Border {
 fn cost_header(header: &mut Vec<Box<dyn table::Contents + '_>>, args: &Arguments) {
     header.push(Box::new(Border) as Box<_>);
     if args.execute {
-        header.push(Box::new(table::Right("Time".emphasize())) as Box<_>);
-        header.push(Box::new(table::Right("Cost".emphasize())) as Box<_>);
-        header.push(Box::new(table::Right("Loops".emphasize())) as Box<_>);
-        header.push(Box::new(table::Right("Rows".emphasize())) as Box<_>);
-        header.push(Box::new(table::Right("Width".emphasize())) as Box<_>);
+        header.push(Box::new(table::Right("Time".emphasized())) as Box<_>);
+        header.push(Box::new(table::Right("Cost".emphasized())) as Box<_>);
+        header.push(Box::new(table::Right("Loops".emphasized())) as Box<_>);
+        header.push(Box::new(table::Right("Rows".emphasized())) as Box<_>);
+        header.push(Box::new(table::Right("Width".emphasized())) as Box<_>);
     } else {
-        header.push(Box::new(table::Right("Cost".emphasize())) as Box<_>);
-        header.push(Box::new(table::Right("Plan Rows".emphasize())) as Box<_>);
-        header.push(Box::new(table::Right("Width".emphasize())) as Box<_>);
+        header.push(Box::new(table::Right("Cost".emphasized())) as Box<_>);
+        header.push(Box::new(table::Right("Plan Rows".emphasized())) as Box<_>);
+        header.push(Box::new(table::Right("Width".emphasized())) as Box<_>);
     }
     header.push(Box::new(Border) as Box<_>);
 }
@@ -553,6 +553,6 @@ impl fmt::Display for NodeTitle<'_> {
 
 impl<T: fmt::Display> fmt::Display for Property<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}={}", self.0.fade(), self.1)
+        write!(f, "{}={}", self.0.muted(), self.1)
     }
 }

--- a/src/branch/rebase.rs
+++ b/src/branch/rebase.rs
@@ -1,5 +1,3 @@
-use colorful::Colorful;
-
 use crate::branch::connections::get_connection_to_modify;
 use crate::branch::context::Context;
 use crate::commands::Options;
@@ -8,6 +6,7 @@ use crate::migrations::rebase::{
     do_rebase, get_diverging_migrations, write_rebased_migration_files,
 };
 use crate::portable::project;
+use crate::print::Highlight;
 use crate::{migrations, print};
 use uuid::Uuid;
 
@@ -146,7 +145,7 @@ async fn rename_temp_to_source(
 }
 
 async fn clone_target_branch(branch: &str, connection: &mut Connection) -> anyhow::Result<String> {
-    eprintln!("Cloning target branch '{}' for rebase...", branch.green());
+    eprintln!("Cloning target branch '{}' for rebase...", branch.success());
 
     let temp_branch_name = Uuid::new_v4().to_string();
 

--- a/src/branch/switch.rs
+++ b/src/branch/switch.rs
@@ -3,7 +3,6 @@ use crate::branch::connections::connect_if_branch_exists;
 use crate::branch::context::Context;
 use crate::branch::create::create_branch;
 use crate::connect::Connector;
-use crate::print::Highlight;
 
 pub async fn run(
     options: &Command,
@@ -63,8 +62,7 @@ pub async fn run(
 
     eprintln!(
         "Switching from '{}' to '{}'",
-        current_branch.emphasized(),
-        options.target_branch.clone().emphasized()
+        current_branch, options.target_branch
     );
 
     context

--- a/src/branch/switch.rs
+++ b/src/branch/switch.rs
@@ -3,6 +3,7 @@ use crate::branch::connections::connect_if_branch_exists;
 use crate::branch::context::Context;
 use crate::branch::create::create_branch;
 use crate::connect::Connector;
+use crate::print::Highlight;
 
 pub async fn run(
     options: &Command,
@@ -62,7 +63,8 @@ pub async fn run(
 
     eprintln!(
         "Switching from '{}' to '{}'",
-        current_branch, options.target_branch
+        current_branch.emphasized(),
+        options.target_branch.clone().emphasized()
     );
 
     context

--- a/src/cli/logo.rs
+++ b/src/cli/logo.rs
@@ -33,13 +33,25 @@ pub fn print_logo(allow_animation: bool, small: bool) {
         .max()
         .unwrap();
 
+    let is_light = terminal_light::luma().map_or(false, |x| x > 0.6);
+    let primary = if is_light {
+        Color::DarkMagenta
+    } else {
+        Color::Magenta
+    };
+    let secondary = if is_light {
+        Color::DarkYellow
+    } else {
+        Color::Yellow
+    };
+
     let normal = |c| {
         write_ansi!(ResetAttributes);
         write_ansi!(SetAttribute(Attribute::Bold));
         if c == '$' || c == '█' || c == '▄' || c == '▀' {
-            write_ansi!(SetForegroundColor(Color::Magenta));
+            write_ansi!(SetForegroundColor(primary));
         } else {
-            write_ansi!(SetForegroundColor(Color::Yellow));
+            write_ansi!(SetForegroundColor(secondary));
         }
         write_ansi!(SetAttribute(Attribute::Bold));
     };

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -225,7 +225,10 @@ fn _main(options: &CliUpgrade, path: PathBuf) -> anyhow::Result<()> {
         .run()?;
     fs::remove_file(&tmp_path).ok();
     if !options.quiet {
-        msg!("Upgraded to version {}", pkg.version.emphasize());
+        msg!(
+            "Upgraded to version {}",
+            pkg.version.to_string().emphasized()
+        );
     }
     Ok(())
 }

--- a/src/cloud/secret_keys.rs
+++ b/src/cloud/secret_keys.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use colorful::Colorful;
 
 use crate::branding::BRANDING_CLOUD;
 use crate::cloud::client::CloudClient;
@@ -147,9 +146,9 @@ pub async fn _do_create(c: &options::CreateSecretKey, client: &CloudClient) -> a
                 " secret key is printed below. \
                  Be sure to copy and store it securely, as you will \
                  not be able to see it again.\n"
-                    .green()
+                    .success()
             );
-            msg!("{}", sk.emphasize());
+            msg!("{}", sk.emphasized());
         }
     }
 

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -578,7 +578,7 @@ pub async fn execute(
 
     let options = Options {
         command_line: false,
-        styler: Some(Styler::dark_256()),
+        styler: Some(Styler::new()),
         conn_params: prompt.conn_params.clone(),
     };
     match cmd {

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -90,7 +90,7 @@ fn init_command_opts(options: &Options) -> Result<commands::Options, anyhow::Err
     Ok(commands::Options {
         command_line: true,
         styler: if std::io::stdout().is_terminal() {
-            Some(Styler::dark_256())
+            Some(Styler::new())
         } else {
             None
         },

--- a/src/error_display.rs
+++ b/src/error_display.rs
@@ -3,8 +3,6 @@ use std::str;
 use codespan_reporting::diagnostic::{Diagnostic, Label, LabelStyle};
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term::emit;
-use colorful::core::color_string::CString;
-use colorful::Colorful;
 use const_format::concatcp;
 use gel_protocol::annotations::Warning;
 use termcolor::{ColorChoice, StandardStream};
@@ -12,7 +10,7 @@ use termcolor::{ColorChoice, StandardStream};
 use gel_errors::{Error, InternalServerError};
 
 use crate::branding::BRANDING_CLI_CMD;
-use crate::print::{self, msg};
+use crate::print::{self, msg, Highlight};
 
 pub fn print_query_error(
     err: &Error,
@@ -112,12 +110,9 @@ pub fn print_query_warning(
 }
 
 fn print_query_warning_plain(warning: &Warning) {
-    let marker = concatcp!(BRANDING_CLI_CMD, " warning:");
-    let marker = if print::use_color() {
-        marker.bold().yellow()
-    } else {
-        CString::new(marker)
-    };
+    let marker = concatcp!(BRANDING_CLI_CMD, " warning:")
+        .emphasized()
+        .warning();
 
     msg!("{marker} {warning}");
 }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -378,10 +378,7 @@ async fn execute_query(
             let mut index = 0;
             while let Some(row) = items.next().await.transpose()? {
                 if index == 0 && state.print_stats == Detailed {
-                    eprintln!(
-                        "{}",
-                        format!("First row: {:?}", start.elapsed()).muted()
-                    );
+                    eprintln!("{}", format!("First row: {:?}", start.elapsed()).muted());
                 }
                 if let Some(limit) = state.implicit_limit {
                     if index >= limit {
@@ -433,10 +430,7 @@ async fn execute_query(
             let mut index = 0;
             while let Some(row) = items.next().await.transpose()? {
                 if index == 0 && state.print_stats == Detailed {
-                    eprintln!(
-                        "{}",
-                        format!("First row: {:?}", start.elapsed()).muted()
-                    );
+                    eprintln!("{}", format!("First row: {:?}", start.elapsed()).muted());
                 }
                 index += 1;
                 let text = match row {
@@ -472,10 +466,7 @@ async fn execute_query(
             let mut index = 0;
             while let Some(row) = items.next().await.transpose()? {
                 if index == 0 && state.print_stats == Detailed {
-                    eprintln!(
-                        "{}",
-                        format!("First row: {:?}", start.elapsed()).muted()
-                    );
+                    eprintln!("{}", format!("First row: {:?}", start.elapsed()).muted());
                 }
                 let mut text = match row {
                     Value::Str(s) => s,

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -2,7 +2,6 @@ use std::str;
 use std::time::Instant;
 
 use anyhow::Context;
-use colorful::Colorful;
 use is_terminal::IsTerminal;
 use terminal_size::{terminal_size, Width};
 use tokio::io::{stdout, AsyncWriteExt};
@@ -159,10 +158,12 @@ pub async fn _main(options: Options, mut state: repl::State, cfg: Config) -> any
     if let Some(config_path) = &cfg.file_name {
         msg!(
             "{}",
-            format_args!("Applied {} configuration file", config_path.display(),).fade()
+            format_args!("Applied {} configuration file", config_path.display(),)
+                .to_string()
+                .muted()
         );
     }
-    msg!("{}", r#"Type \help for help, \quit to quit."#.light_gray());
+    msg!("{}", r#"Type \help for help, \quit to quit."#.muted());
     state.set_history_limit(state.history_limit).await?;
     match _interactive_main(&options, &mut state).await {
         Ok(()) => Ok(()),
@@ -379,7 +380,7 @@ async fn execute_query(
                 if index == 0 && state.print_stats == Detailed {
                     eprintln!(
                         "{}",
-                        format!("First row: {:?}", start.elapsed()).dark_gray()
+                        format!("First row: {:?}", start.elapsed()).muted()
                     );
                 }
                 if let Some(limit) = state.implicit_limit {
@@ -434,7 +435,7 @@ async fn execute_query(
                 if index == 0 && state.print_stats == Detailed {
                     eprintln!(
                         "{}",
-                        format!("First row: {:?}", start.elapsed()).dark_gray()
+                        format!("First row: {:?}", start.elapsed()).muted()
                     );
                 }
                 index += 1;
@@ -473,7 +474,7 @@ async fn execute_query(
                 if index == 0 && state.print_stats == Detailed {
                     eprintln!(
                         "{}",
-                        format!("First row: {:?}", start.elapsed()).dark_gray()
+                        format!("First row: {:?}", start.elapsed()).muted()
                     );
                 }
                 let mut text = match row {
@@ -524,7 +525,7 @@ async fn execute_query(
                 "Query time (including output formatting): {:?}",
                 start.elapsed() - input_duration
             )
-            .dark_gray()
+            .muted()
         );
     }
     state.last_error = None;

--- a/src/migrations/edit.rs
+++ b/src/migrations/edit.rs
@@ -56,12 +56,12 @@ fn print_diff(path1: &Path, data1: &str, path2: &Path, data2: &str) {
             }
             Chunk::Insert(block) => {
                 for line in block.split('\n') {
-                    println!("+{}", line.added());
+                    println!("+{}", line.success());
                 }
             }
             Chunk::Delete(block) => {
                 for line in block.split('\n') {
-                    println!("-{}", line.deleted());
+                    println!("-{}", line.danger());
                 }
             }
         }
@@ -100,9 +100,9 @@ pub async fn edit_no_check(
         }
         fs::write(&tmp_file, migration.replace_id(&text, &new_id)).await?;
         fs::rename(&tmp_file, &path).await?;
-        msg!("Updated migration id to {}", new_id.emphasize());
+        msg!("Updated migration id to {}", new_id.emphasized());
     } else {
-        msg!("Id {} is already correct.", migration.id.emphasize());
+        msg!("Id {} is already correct.", migration.id.emphasized());
     }
     Ok(())
 }
@@ -170,9 +170,9 @@ async fn _edit(
                 anyhow::Ok(())
             })
             .await?;
-            msg!("Updated migration id to {}", new_id.emphasize());
+            msg!("Updated migration id to {}", new_id.emphasized());
         } else {
-            msg!("Id {} is already correct.", migration.id.emphasize());
+            msg!("Id {} is already correct.", migration.id.emphasized());
         }
     } else {
         let temp_path = path.parent().unwrap().join(format!(".editing.{n}.edgeql"));
@@ -271,9 +271,9 @@ async fn _edit(
             if migration.id != new_id {
                 new_data = migration.replace_id(&new_data, &new_id);
                 fs::write(&temp_path, &new_data).await?;
-                msg!("Updated migration id to {}", new_id.emphasize());
+                msg!("Updated migration id to {}", new_id.emphasized());
             } else {
-                msg!("Id {} is already correct.", migration.id.emphasize());
+                msg!("Id {} is already correct.", migration.id.emphasized());
             }
             match check_migration(cli, &new_data, &path).await {
                 Ok(()) => {}

--- a/src/migrations/migrate.rs
+++ b/src/migrations/migrate.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, VecDeque};
 use std::path::Path;
 
 use anyhow::Context as _;
-use colorful::Colorful;
 use gel_protocol::common::{
     Capabilities, Cardinality, CompilationOptions, InputLanguage, IoFormat,
 };
@@ -26,7 +25,7 @@ use crate::migrations::edb::{execute, execute_if_connected};
 use crate::migrations::migration::{self, MigrationFile};
 use crate::migrations::options::Migrate;
 use crate::migrations::timeout;
-use crate::print;
+use crate::print::{self, Highlight};
 
 #[derive(Debug, Clone, Copy)]
 pub enum Operation<'a> {
@@ -136,14 +135,11 @@ async fn _migrate(
         };
         if let Some(db_rev) = db_rev {
             if !migrate.quiet {
-                let mut msg = "Database is up to date.".to_string();
-                if print::use_color() {
-                    msg = format!("{}", msg.bold().light_green());
-                }
+                let msg = "Database is up to date.".to_string().emphasized().success();
                 if Some(&db_rev.name) == last_db_rev {
-                    eprintln!("{} Revision {}", msg, db_rev.name);
+                    print::msg!("{} Revision {}", msg, db_rev.name);
                 } else {
-                    eprintln!(
+                    print::msg!(
                         "{} Revision {} is the ancestor of the latest {}",
                         msg,
                         db_rev.name,
@@ -183,22 +179,14 @@ async fn _migrate(
     let migrations = slice(&migrations, last_db_rev, target_rev.as_ref())?;
     if migrations.is_empty() {
         if !migrate.quiet {
-            if print::use_color() {
-                eprintln!(
-                    "{} Revision {}",
-                    "Everything is up to date.".bold().light_green(),
-                    last_db_rev
-                        .map(|m| &m[..])
-                        .unwrap_or("initial")
-                        .bold()
-                        .white(),
-                );
-            } else {
-                eprintln!(
-                    "Everything is up to date. Revision {}",
-                    last_db_rev.map(|m| &m[..]).unwrap_or("initial"),
-                );
-            }
+            eprintln!(
+                "{} Revision {}",
+                "Everything is up to date.".emphasized().success(),
+                last_db_rev
+                    .map(|m| &m[..])
+                    .unwrap_or("initial")
+                    .emphasized(),
+            );
         }
         return Ok(());
     }
@@ -485,19 +473,12 @@ pub async fn apply_migration(
 ) -> anyhow::Result<()> {
     if verbose {
         let file_name = migration.path.file_name().unwrap();
-        if print::use_color() {
-            eprintln!(
-                "Applying {} ({})",
-                migration.data.id[..].bold().white(),
-                Path::new(file_name).display(),
-            );
-        } else {
-            eprintln!(
-                "Applying {} ({})",
-                migration.data.id,
-                Path::new(file_name).display(),
-            );
-        }
+
+        eprintln!(
+            "Applying {} ({})",
+            migration.data.id[..].emphasized(),
+            Path::new(file_name).display(),
+        );
     }
 
     let data = fs::read_to_string(&migration.path)
@@ -520,11 +501,7 @@ pub async fn apply_migration(
     })?;
 
     if verbose {
-        if print::use_color() {
-            eprintln!("... {}", "applied".bold().green());
-        } else {
-            eprintln!("... applied");
-        }
+        eprintln!("... {}", "applied".emphasized().success());
     }
     Ok(())
 }

--- a/src/migrations/prompt.rs
+++ b/src/migrations/prompt.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use anyhow::Context as _;
-use colorful::Colorful;
 use edgeql_parser::expr;
 use rustyline::completion::Completer;
 use rustyline::config::EditMode;
@@ -14,6 +13,7 @@ use rustyline::{Config, Editor, Helper};
 
 use crate::highlight;
 use crate::print::style::Styler;
+use crate::print::Highlight;
 use crate::prompt::{load_history, save_history};
 
 pub struct ExpressionHelper {
@@ -41,7 +41,7 @@ impl Highlighter for ExpressionHelper {
         true
     }
     fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
-        hint.light_gray().to_string().into()
+        hint.muted().to_string().into()
     }
 }
 
@@ -83,7 +83,7 @@ pub fn expression(
         })
         .ok();
     editor.set_helper(Some(ExpressionHelper {
-        styler: Styler::dark_256(),
+        styler: Styler::new(),
     }));
     let text = editor
         .readline_with_initial(prompt, (default, ""))

--- a/src/migrations/rebase.rs
+++ b/src/migrations/rebase.rs
@@ -7,9 +7,8 @@ use crate::migrations::create::{MigrationKey, MigrationToText};
 use crate::migrations::db_migration::{read_all, DBMigration};
 use crate::migrations::migration::MigrationFile;
 use crate::migrations::{create, migrate, migration, Context};
-use crate::print;
+use crate::print::{self, Highlight};
 use anyhow::Context as _;
-use colorful::Colorful;
 use indexmap::IndexMap;
 
 #[derive(PartialEq)]
@@ -69,7 +68,7 @@ impl RebaseMigrations {
             .last()
             .map(|v| v.0.as_str())
             .unwrap_or("initial")
-            .green();
+            .success();
 
         let format_migration_on_length = |c: usize| {
             if c > 1 {
@@ -82,9 +81,9 @@ impl RebaseMigrations {
         eprintln!("Last common migration is {last_common}");
         eprintln!(
             "Since then, there are:\n- {} new {} on the target branch,\n- {} {} to rebase",
-            self.target_migrations.len().to_string().green(),
+            self.target_migrations.len().to_string().success(),
             format_migration_on_length(self.target_migrations.len()),
-            self.source_migrations.len().to_string().green(),
+            self.source_migrations.len().to_string().success(),
             format_migration_on_length(self.source_migrations.len())
         );
     }

--- a/src/migrations/squash.rs
+++ b/src/migrations/squash.rs
@@ -189,11 +189,7 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
         msg!("{}", "    git add dbschema".emphasized());
         msg!();
         msg!("You can now wipe your instances and apply the new schema:");
-        msg!(
-            "    {} {}",
-            BRANDING_CLI_CMD,
-            "database wipe".emphasized()
-        );
+        msg!("    {} {}", BRANDING_CLI_CMD, "database wipe".emphasized());
         msg!("    {} {}", BRANDING_CLI_CMD, "migrate".emphasized());
     }
     Ok(())

--- a/src/migrations/squash.rs
+++ b/src/migrations/squash.rs
@@ -122,7 +122,7 @@ async fn create_revision(
 }
 
 async fn confirm_squashing(db_rev: &str) -> anyhow::Result<()> {
-    msg!("Current database revision: {}", db_rev.emphasize());
+    msg!("Current database revision: {}", db_rev.emphasized());
     msg!(
         "While squashing migrations is non-destructive, it may lead to manual work \
            if done incorrectly."
@@ -138,7 +138,7 @@ async fn confirm_squashing(db_rev: &str) -> anyhow::Result<()> {
     msg!(
         "       {} {}",
         BRANDING_CLI_CMD,
-        " -I <name> migration log --from-db --newest-first --limit 1".command_hint()
+        " -I <name> migration log --from-db --newest-first --limit 1".emphasized()
     );
     msg!(
         "  3. Merge version control branches that contain schema changes \
@@ -175,10 +175,10 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
             "Remember to commit the `dbschema` directory including deleted \
                files and `fixups` subdirectory. Recommended command:"
         );
-        msg!("{}", "    git add dbschema".command_hint());
+        msg!("{}", "    git add dbschema".emphasized());
         msg!();
         msg!("The normal migration process will update your migration history:");
-        msg!("    {} {}", BRANDING_CLI_CMD, "migrate".command_hint());
+        msg!("    {} {}", BRANDING_CLI_CMD, "migrate".emphasized());
     } else {
         msg!("Squash is complete.");
         msg!();
@@ -186,15 +186,15 @@ fn print_final_message(fixup_created: bool) -> anyhow::Result<()> {
             "Remember to commit the `dbschema` directory including deleted \
                files. Recommended command:"
         );
-        msg!("{}", "    git add dbschema".command_hint());
+        msg!("{}", "    git add dbschema".emphasized());
         msg!();
         msg!("You can now wipe your instances and apply the new schema:");
         msg!(
             "    {} {}",
             BRANDING_CLI_CMD,
-            "database wipe".command_hint()
+            "database wipe".emphasized()
         );
-        msg!("    {} {}", BRANDING_CLI_CMD, "migrate".command_hint());
+        msg!("    {} {}", BRANDING_CLI_CMD, "migrate".emphasized());
     }
     Ok(())
 }

--- a/src/migrations/status.rs
+++ b/src/migrations/status.rs
@@ -1,4 +1,3 @@
-use colorful::Colorful;
 use indexmap::IndexMap;
 
 use crate::async_try;
@@ -10,7 +9,7 @@ use crate::migrations::create::{execute_start_migration, CurrentMigration};
 use crate::migrations::edb::execute_if_connected;
 use crate::migrations::migration::{self, MigrationFile};
 use crate::migrations::options::ShowStatus;
-use crate::print;
+use crate::print::{self, Highlight};
 
 async fn ensure_diff_is_empty(cli: &mut Connection, ctx: &Context) -> Result<(), anyhow::Error> {
     let data = cli
@@ -53,15 +52,11 @@ pub async fn status(
     match up_to_date_check(cli, &ctx, &migrations).await? {
         Some(_) if status.quiet => Ok(()),
         Some(migration) => {
-            if print::use_color() {
-                eprintln!(
-                    "{} Last migration: {}.",
-                    "Database is up to date.".bold().light_green(),
-                    migration.bold().white(),
-                );
-            } else {
-                eprintln!("Database is up to date. Last migration: {migration}.",);
-            }
+            print::msg!(
+                "{} Last migration: {}.",
+                "Database is up to date.".emphasized().success(),
+                migration.emphasized(),
+            );
             Ok(())
         }
         None => Err(ExitCode::new(3).into()),

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -218,7 +218,7 @@ async fn do_check(ctx: &Context, status_file: &Path, watch: bool) -> anyhow::Res
                 msg!(
                     "    {} {}",
                     BRANDING_CLI_CMD,
-                    " migration upgrade-check --watch".command_hint()
+                    " migration upgrade-check --watch".emphasized()
                 );
                 return Err(ExitCode::new(3))?;
             }
@@ -298,7 +298,7 @@ fn print_apply_migration_error() {
     msg!(
         "    {} {}",
         BRANDING_CLI_CMD,
-        " migration create --squash".command_hint()
+        " migration create --squash".emphasized()
     );
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use color_print::cformat;
-use colorful::Colorful;
 use const_format::concatcp;
 use gel_errors::{ClientNoCredentialsError, ResultExt};
 use gel_protocol::model;
@@ -30,7 +29,7 @@ use crate::portable;
 use crate::portable::local::{instance_data_dir, runstate_dir};
 use crate::portable::options::InstanceName;
 use crate::portable::project;
-use crate::print;
+use crate::print::{self, Highlight};
 use crate::repl::{InputLanguage, OutputFormat};
 use crate::tty_password;
 use crate::watch::options::WatchCommand;
@@ -498,12 +497,8 @@ fn parse_duration(value: &str) -> anyhow::Result<Duration> {
 }
 
 fn say_option_is_deprecated(option_name: &str, suggestion: &str) {
-    let mut error = "warning:".to_string();
-    let mut instead = suggestion.to_string();
-    if print::use_color() {
-        error = format!("{}", error.bold().light_yellow());
-        instead = format!("{}", instead.green());
-    }
+    let error = "warning:".to_string().emphasized().warning();
+    let instead = suggestion.to_string().success();
     eprintln!(
         "\
         {error} The '{opt}' option is deprecated.\n\
@@ -512,7 +507,7 @@ fn say_option_is_deprecated(option_name: &str, suggestion: &str) {
         \n\
     ",
         error = error,
-        opt = option_name.green(),
+        opt = option_name.success(),
         instead = instead
     );
 }
@@ -831,13 +826,10 @@ impl Options {
         let mut no_cli_update_check = args.no_cli_update_check;
         if args.no_version_check {
             no_cli_update_check = true;
-            let mut error = "warning:".to_string();
-            if print::use_color() {
-                error = format!("{}", error.bold().light_yellow());
-            }
+            let warning = "warning:".to_string().emphasized().warning();
             eprintln!(
                 "\
-                {error} The '--no-version-check' option was renamed.\n\
+                {warning} The '--no-version-check' option was renamed.\n\
                 \n         \
                     Use '--no-cli-update-check' instead.\
                 \n\

--- a/src/portable/instance/create.rs
+++ b/src/portable/instance/create.rs
@@ -175,7 +175,7 @@ pub fn run(cmd: &Command, opts: &crate::options::Options) -> anyhow::Result<()> 
         }
     }
 
-    msg!("Instance {} is up and running.", name.emphasize());
+    msg!("Instance {} is up and running.", name.clone().emphasized());
     msg!("To connect to the instance run:");
     msg!("  {BRANDING_CLI_CMD} -I {name}");
     Ok(())
@@ -310,7 +310,7 @@ fn ask_name(cloud_client: &mut cloud::client::CloudClient) -> anyhow::Result<Ins
             msg!(
                 "{} Instance {} already exists.",
                 err_marker(),
-                name.emphasize()
+                name.emphasized()
             );
         } else {
             return Ok(inst_name);

--- a/src/portable/instance/destroy.rs
+++ b/src/portable/instance/destroy.rs
@@ -38,7 +38,10 @@ pub fn run(options: &Command, opts: &Options) -> anyhow::Result<()> {
         }
     })?;
     if !options.quiet {
-        msg!("Instance {} is successfully deleted.", name_str.emphasized());
+        msg!(
+            "Instance {} is successfully deleted.",
+            name_str.emphasized()
+        );
     }
     Ok(())
 }

--- a/src/portable/instance/destroy.rs
+++ b/src/portable/instance/destroy.rs
@@ -38,7 +38,7 @@ pub fn run(options: &Command, opts: &Options) -> anyhow::Result<()> {
         }
     })?;
     if !options.quiet {
-        msg!("Instance {} is successfully deleted.", name_str.emphasize());
+        msg!("Instance {} is successfully deleted.", name_str.emphasized());
     }
     Ok(())
 }

--- a/src/portable/instance/link.rs
+++ b/src/portable/instance/link.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
-use colorful::Colorful;
 use ring::digest;
 
 use rustls::client::danger::HandshakeSignatureValid;
@@ -25,7 +24,7 @@ use crate::options::{ConnectionOptions, Options};
 use crate::portable::local::is_valid_local_instance_name;
 use crate::portable::options::InstanceName;
 use crate::portable::ver::Build;
-use crate::print;
+use crate::print::{self, Highlight};
 use crate::question;
 use crate::tty_password;
 
@@ -152,14 +151,12 @@ pub fn run(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
 
     credentials::write(&cred_path, &creds)?;
     if !cmd.quiet {
-        let mut msg = "Successfully linked to remote instance.".to_string();
-        if print::use_color() {
-            msg = format!("{}", msg.bold().light_green());
-        }
         eprintln!(
             "{} To connect run:\
             \n  {BRANDING_CLI_CMD} -I {}",
-            msg,
+            "Successfully linked to remote instance."
+                .emphasized()
+                .success(),
             instance_name.escape_default(),
         );
     }

--- a/src/portable/instance/revert.rs
+++ b/src/portable/instance/revert.rs
@@ -61,7 +61,7 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
                 msg!(
                     "Upgrade appears to still be in progress \
                     with pid {}",
-                    up.pid.emphasize()
+                    up.pid.to_string().emphasized()
                 );
                 msg!("Run with `--ignore-pid-check` to override");
                 Err(ExitCode::new(exit_codes::NEEDS_FORCE))?;
@@ -76,7 +76,7 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
         eprintln!();
         msg!(
             "Currently stored data {} and overwritten by the backup.",
-            "will be lost".emphasize()
+            "will be lost".emphasized()
         );
         let q = question::Confirm::new_dangerous("Do you really want to revert?");
         if !q.ask()? {
@@ -116,8 +116,8 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
     control::do_restart(&inst)?;
     msg!(
         "Instance {} is successfully reverted to {}",
-        inst.name.emphasize(),
-        inst.get_version()?.emphasize()
+        inst.name.as_str().emphasized(),
+        inst.get_version()?.to_string().emphasized()
     );
 
     fs::remove_file(paths.data_dir.join("backup.json"))?;

--- a/src/portable/instance/status.rs
+++ b/src/portable/instance/status.rs
@@ -382,7 +382,7 @@ async fn _remote_status(name: &str, quiet: bool) -> anyhow::Result<RemoteStatus>
             msg!(
                 "{} No instance {} found",
                 print::err_marker(),
-                name.emphasize()
+                name.emphasized()
             );
         }
         return Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into());

--- a/src/portable/instance/upgrade.rs
+++ b/src/portable/instance/upgrade.rs
@@ -209,9 +209,9 @@ fn upgrade_local_cmd(cmd: &Command, name: &str) -> anyhow::Result<()> {
 
     if pkg_ver <= inst_ver && !cmd.force {
         msg!(
-            "Latest version found {} current instance version is {} Already up to date.",
-            pkg.version.to_string() + ",",
-            inst.get_version()?.emphasize().to_string() + "."
+            "Latest version found {}, current instance version is {}. Already up to date.",
+            pkg.version.to_string(),
+            inst.get_version()?.to_string().emphasized()
         );
         return Ok(());
     }
@@ -250,7 +250,7 @@ fn upgrade_cloud_cmd(
     client.ensure_authenticated()?;
 
     let _inst_name = format!("{org}/{name}");
-    let inst_name = _inst_name.emphasize();
+    let inst_name = _inst_name.emphasized();
 
     let result = upgrade_cloud(org, name, &query, &client, cmd.force, |target_ver| {
         let target_ver_str = target_ver.to_string();
@@ -279,7 +279,11 @@ fn upgrade_cloud_cmd(
             msg!("Canceled.");
         }
         UpgradeAction::None => {
-            msg!("Already up to date.\nRequested upgrade version is {} current instance version is {}", target_ver_str.emphasize().to_string() + ",", result.prior_version.emphasize().to_string() + ".");
+            msg!(
+                "Already up to date.\nRequested upgrade version is {}, current instance version is {}.",
+                target_ver_str.emphasized(),
+                result.prior_version.to_string().emphasized()
+            );
         }
     }
 
@@ -334,7 +338,7 @@ pub fn upgrade_cloud(
 }
 
 pub fn upgrade_compatible(mut inst: InstanceInfo, pkg: PackageInfo) -> anyhow::Result<()> {
-    msg!("Upgrading to a minor version {}", pkg.version.emphasize());
+    msg!("Upgrading to a minor version {}", pkg.version.to_string().emphasized());
     let install = install::package(&pkg).context(concatcp!("error installing ", BRANDING))?;
     inst.installation = Some(install);
 
@@ -349,8 +353,8 @@ pub fn upgrade_compatible(mut inst: InstanceInfo, pkg: PackageInfo) -> anyhow::R
     control::do_restart(&inst)?;
     msg!(
         "Instance {} successfully upgraded to {}",
-        inst.name.emphasize(),
-        pkg.version.emphasize()
+        inst.name.emphasized(),
+        pkg.version.to_string().emphasized()
     );
     Ok(())
 }
@@ -360,7 +364,7 @@ pub fn upgrade_incompatible(
     pkg: PackageInfo,
     non_interactive: bool,
 ) -> anyhow::Result<()> {
-    msg!("Upgrading to a major version {}", pkg.version.emphasize());
+    msg!("Upgrading to a major version {}", pkg.version.to_string().emphasized());
 
     let old_version = inst.get_version()?.clone();
 
@@ -427,8 +431,8 @@ pub fn upgrade_incompatible(
 
     msg!(
         "Instance {} successfully upgraded to {}",
-        inst.name.emphasize(),
-        pkg.version.emphasize()
+        inst.name.emphasized(),
+        pkg.version.to_string().emphasized()
     );
 
     Ok(())

--- a/src/portable/instance/upgrade.rs
+++ b/src/portable/instance/upgrade.rs
@@ -338,7 +338,10 @@ pub fn upgrade_cloud(
 }
 
 pub fn upgrade_compatible(mut inst: InstanceInfo, pkg: PackageInfo) -> anyhow::Result<()> {
-    msg!("Upgrading to a minor version {}", pkg.version.to_string().emphasized());
+    msg!(
+        "Upgrading to a minor version {}",
+        pkg.version.to_string().emphasized()
+    );
     let install = install::package(&pkg).context(concatcp!("error installing ", BRANDING))?;
     inst.installation = Some(install);
 
@@ -364,7 +367,10 @@ pub fn upgrade_incompatible(
     pkg: PackageInfo,
     non_interactive: bool,
 ) -> anyhow::Result<()> {
-    msg!("Upgrading to a major version {}", pkg.version.to_string().emphasized());
+    msg!(
+        "Upgrading to a major version {}",
+        pkg.version.to_string().emphasized()
+    );
 
     let old_version = inst.get_version()?.clone();
 

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -386,7 +386,7 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
                 msg!(
                     "{} {} with exit code {}",
                     print::err_marker(),
-                    "{BRANDING} failed".emphasize(),
+                    "{BRANDING} failed".emphasized(),
                     code
                 );
             }
@@ -395,7 +395,7 @@ fn wait_started(name: &str) -> anyhow::Result<()> {
                     "{} {} {}",
                     print::err_marker(),
                     BRANDING,
-                    "failed".emphasize()
+                    "failed".emphasized()
                 );
             }
         }

--- a/src/portable/project/info.rs
+++ b/src/portable/project/info.rs
@@ -21,7 +21,7 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
         msg!(
             "{} {} Run `{BRANDING_CLI_CMD} project init`.",
             print::err_marker(),
-            "Project is not initialized.".emphasize()
+            "Project is not initialized.".emphasized()
         );
         return Err(ExitCode::new(1).into());
     }

--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -1120,14 +1120,14 @@ fn print_initialized(name: &str, dir_option: &Option<PathBuf>) {
     if let Some(dir) = dir_option {
         msg!(
             "To connect to {}, navigate to {} and run `{}`",
-            name.emphasize(),
+            name.emphasized(),
             dir.display(),
             BRANDING_CLI_CMD
         );
     } else {
         msg!(
             "To connect to {}, run `{}`",
-            name.emphasize(),
+            name.emphasized(),
             BRANDING_CLI_CMD
         );
     }

--- a/src/portable/project/manifest.rs
+++ b/src/portable/project/manifest.rs
@@ -171,7 +171,7 @@ where
 pub fn modify_server_ver(config: &Path, ver: &Query) -> anyhow::Result<bool> {
     msg!(
         "Setting `server-version = {}` in `{}`",
-        format_args!("{:?}", ver.as_config_value()).emphasize(),
+        format_args!("{:?}", ver.as_config_value()).to_string().emphasized(),
         config.file_name().unwrap_or_default().to_string_lossy()
     );
     read_modify_write(

--- a/src/portable/project/manifest.rs
+++ b/src/portable/project/manifest.rs
@@ -171,7 +171,9 @@ where
 pub fn modify_server_ver(config: &Path, ver: &Query) -> anyhow::Result<bool> {
     msg!(
         "Setting `server-version = {}` in `{}`",
-        format_args!("{:?}", ver.as_config_value()).to_string().emphasized(),
+        format_args!("{:?}", ver.as_config_value())
+            .to_string()
+            .emphasized(),
         config.file_name().unwrap_or_default().to_string_lossy()
     );
     read_modify_write(

--- a/src/portable/project/unlink.rs
+++ b/src/portable/project/unlink.rs
@@ -51,7 +51,7 @@ pub fn run(options: &Command, opts: &crate::options::Options) -> anyhow::Result<
         } else {
             match fs::read_to_string(stash_path.join("instance-name")) {
                 Ok(name) => {
-                    msg!("Unlinking instance {}", name.emphasize());
+                    msg!("Unlinking instance {}", name.emphasized());
                 }
                 Err(e) => {
                     print::error!("Cannot read instance name: {e}");

--- a/src/portable/project/upgrade.rs
+++ b/src/portable/project/upgrade.rs
@@ -127,7 +127,7 @@ pub fn update_toml(
         msg!(
             "Run {} {} to initialize an instance.",
             BRANDING_CLI_CMD,
-            " project init".command_hint()
+            " project init".emphasized()
         );
     } else {
         let name = project::instance_name(&stash_dir)?;
@@ -167,7 +167,11 @@ pub fn update_toml(
                 msg!("Canceled.");
             }
             upgrade::UpgradeAction::None => {
-                msg!("Already up to date.\nRequested upgrade version is {} current instance version is {}", result.requested_version.emphasize().to_string() + ",", result.prior_version.emphasize().to_string() + ".");
+                msg!(
+                    "Already up to date.\nRequested upgrade version is {}, current instance version is {}.",
+                    result.requested_version.to_string().emphasized(),
+                    result.prior_version.to_string().emphasized()
+                );
             }
         }
     };
@@ -257,7 +261,10 @@ pub fn upgrade_instance(cmd: &Command, opts: &crate::options::Options) -> anyhow
                     .to_string_lossy()
             );
             if let Some(available) = result.available_upgrade {
-                msg!("New major version is available: {}", available.emphasize());
+                msg!(
+                    "New major version is available: {}",
+                    available.to_string().emphasized()
+                );
                 msg!(
                     "To update `{}` and upgrade to this version, \
                         run:\n    {} project upgrade --to-latest",
@@ -366,7 +373,7 @@ fn upgrade_cloud(
     let result = upgrade::upgrade_cloud(org, name, to_version, &client, cmd.force, |target_ver| {
         let target_ver_str = target_ver.to_string();
         let _inst_name = format!("{org}/{name}");
-        let inst_name = _inst_name.emphasize();
+        let inst_name = _inst_name.emphasized();
         if !cmd.non_interactive {
             question::Confirm::new(format!(
                 "This will upgrade {inst_name} to version {target_ver_str}.\
@@ -381,9 +388,9 @@ fn upgrade_cloud(
     if let upgrade::UpgradeAction::Upgraded = result.action {
         let inst_name = format!("{org}/{name}");
         msg!(
-            "Instance {} has been successfully upgraded to {}",
-            inst_name.emphasize(),
-            result.requested_version.emphasize().to_string() + "."
+            "Instance {} has been successfully upgraded to {}.",
+            inst_name.emphasized(),
+            result.requested_version.to_string().emphasized(),
         );
     }
 

--- a/src/portable/server/install.rs
+++ b/src/portable/server/install.rs
@@ -84,7 +84,10 @@ pub fn package(pkg_info: &PackageInfo) -> anyhow::Result<InstallInfo> {
             .unwrap()
             .insert(meta.version.clone())
         {
-            msg!("Version {} is already downloaded", meta.version.emphasize());
+            msg!(
+                "Version {} is already downloaded",
+                meta.version.to_string().emphasized()
+            );
         }
         return Ok(meta);
     }
@@ -104,7 +107,10 @@ pub fn package(pkg_info: &PackageInfo) -> anyhow::Result<InstallInfo> {
     fs::rename(&tmp_target, &target_dir)
         .with_context(|| format!("cannot rename {tmp_target:?} -> {target_dir:?}"))?;
     unlink_cache(&cache_path);
-    msg!("Successfully installed {}", pkg_info.version.emphasize());
+    msg!(
+        "Successfully installed {}",
+        pkg_info.version.to_string().emphasized()
+    );
     INSTALLED_VERSIONS
         .lock()
         .unwrap()

--- a/src/portable/server/uninstall.rs
+++ b/src/portable/server/uninstall.rs
@@ -68,13 +68,16 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
     }
 
     if !all && !options.unused {
-        msg!("Uninstalled {} versions.", uninstalled.emphasize());
+        msg!(
+            "Uninstalled {} versions.",
+            uninstalled.to_string().emphasized()
+        );
         print::error!("some instances are in use. See messages above.");
         Err(ExitCode::new(exit_codes::PARTIAL_SUCCESS))?;
     } else if uninstalled > 0 {
         msg!(
             "Successfully uninstalled {} versions.",
-            uninstalled.emphasize()
+            uninstalled.to_string().emphasized()
         );
     } else {
         print::success!("Nothing to uninstall.")

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -398,7 +398,7 @@ pub fn print_version_hint(version: &Specific, ver_query: &Query) {
         if !filter.matches_exact(version) {
             msg!(
                 "Using {} (matches `{}`), use `{}` for exact version",
-                version.emphasize(),
+                version.to_string().emphasized(),
                 filter,
                 filter.clone().with_exact()
             );

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -278,7 +278,7 @@ pub fn destroy(options: &destroy::Command, name: &str) -> anyhow::Result<()> {
         }
     }
     if !found {
-        msg!("No instance named {} found", name.emphasize());
+        msg!("No instance named {} found", name.emphasized());
         return Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into());
     }
     Ok(())

--- a/src/print/buffer.rs
+++ b/src/print/buffer.rs
@@ -2,11 +2,10 @@ use std::fmt::Write;
 
 use colorful::core::color_string::CString;
 use colorful::core::StrMarker;
-use colorful::Colorful;
 use snafu::{Error, ErrorCompat, IntoError};
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::print::formatter::ColorfulExt;
+use crate::print::color::Highlight;
 use crate::print::stream::Output;
 use crate::print::Printer;
 
@@ -173,7 +172,7 @@ impl<T: Output> Printer<T> {
         if self.flow || !self.trailing_comma {
             self.delim = Comma;
         } else {
-            self.write(",".clear())?;
+            self.write(",".unstyled())?;
             self.commit_line()?;
         }
         Ok(())
@@ -182,23 +181,23 @@ impl<T: Output> Printer<T> {
     pub(in crate::print) fn ellipsis(&mut self) -> Result<T::Error> {
         self.delimit()?;
         if self.flow {
-            self.write("...".clear())?;
+            self.write("...".unstyled())?;
         } else {
-            self.write("...".clear())?;
+            self.write("...".unstyled())?;
             self.write(
                 format!(
                     " (further results hidden \
                 `\\set limit {limit}`)\n",
                     limit = self.max_items.unwrap_or(0)
                 )
-                .dark_gray(),
+                .muted(),
             )?;
         }
         Ok(())
     }
     pub(in crate::print) fn field(&mut self) -> Result<T::Error> {
         self.delim = Field;
-        self.write(": ".clear())
+        self.write(": ".unstyled())
     }
     pub(in crate::print) fn close_block(&mut self, val: &CString, flag: bool) -> Result<T::Error> {
         if self.delim == Comma && !self.flow {
@@ -242,9 +241,9 @@ impl<T: Output> Printer<T> {
     pub(in crate::print) fn delimit(&mut self) -> Result<T::Error> {
         if self.delim == Comma {
             if self.flow {
-                self.write(", ".clear())?;
+                self.write(", ".unstyled())?;
             } else {
-                self.write(",".clear())?;
+                self.write(",".unstyled())?;
                 debug_assert!(!self.trailing_comma);
                 self.commit_line()?;
             }

--- a/src/print/color.rs
+++ b/src/print/color.rs
@@ -1,149 +1,157 @@
-use std::fmt;
+use colorful::core::color_string::CString;
+use colorful::{Color, Colorful};
 
-use colorful::core::ColorInterface;
-use colorful::Color;
+use super::style::Style;
 
-static THEME: once_cell::sync::Lazy<Theme> = once_cell::sync::Lazy::new(|| {
-    if concolor::get(concolor::Stream::Stdout).color() {
+pub trait Highlight: colorful::Colorful + colorful::core::StrMarker + Sized {
+    fn unstyled(self) -> CString {
+        CString::new(self.to_str())
+    }
+
+    fn muted(self) -> CString {
+        if let Some(t) = THEME.as_ref() {
+            self.color(t.muted)
+        } else {
+            CString::new(self)
+        }
+    }
+
+    fn danger(self) -> CString {
+        if let Some(t) = THEME.as_ref() {
+            self.color(t.danger)
+        } else {
+            CString::new(self)
+        }
+    }
+
+    fn success(self) -> CString {
+        if let Some(t) = THEME.as_ref() {
+            self.color(t.success)
+        } else {
+            CString::new(self)
+        }
+    }
+
+    fn warning(self) -> CString {
+        if let Some(t) = THEME.as_ref() {
+            self.color(t.warning)
+        } else {
+            CString::new(self)
+        }
+    }
+
+    fn emphasized(self) -> CString {
+        if THEME.is_some() {
+            self.bold()
+        } else {
+            CString::new(self)
+        }
+    }
+}
+
+impl<T: colorful::Colorful + colorful::core::StrMarker + Sized> Highlight for T {}
+
+static THEME: once_cell::sync::Lazy<Option<Theme>> = once_cell::sync::Lazy::new(|| {
+    if !concolor::get(concolor::Stream::Stdout).color() {
+        return None;
+    }
+
+    let is_term_light = terminal_light::luma().map_or(false, |x| x > 0.6);
+
+    Some(if is_term_light {
         Theme {
-            fade: Some(Style {
-                color: Color::Grey37,
-                bold: true,
-                underline: false,
-            }),
-            err_marker: Some(Style {
-                color: Color::LightRed,
-                bold: true,
-                underline: false,
-            }),
-            emphasize: Some(Style {
-                color: Color::White,
-                bold: true,
-                underline: false,
-            }),
-            command_hint: Some(Style {
-                color: Color::White,
-                bold: true,
-                underline: false,
-            }),
-            title: Some(Style {
-                color: Color::White,
-                bold: true,
-                underline: true,
-            }),
-            deleted: Some(Style {
-                color: Color::Red,
-                bold: false,
-                underline: false,
-            }),
-            added: Some(Style {
-                color: Color::Green,
-                bold: false,
-                underline: false,
-            }),
+            muted: Color::Grey63,
+            danger: Color::DarkRed1,
+            success: Color::DarkGreen,
+            warning: Color::Yellow,
+
+            syntax_string: Color::DarkOliveGreen3a,
+            syntax_set: Color::SteelBlue,
+            syntax_object: Color::Grey37,
+            syntax_link_property: Color::IndianRed1b,
+            syntax_number: Color::CadetBlue1,
+            syntax_boolean: Color::LightSalmon3b,
+            syntax_enum: Color::DarkGoldenrod,
+            syntax_uuid: Color::LightGoldenrod3,
+            syntax_keyword: Color::DarkRed2,
+            syntax_operator: Color::DarkRed2,
+            syntax_comment: Color::Grey35,
+            syntax_cast: Color::DarkRed2,
+            syntax_backslash: Color::DarkRed1,
         }
     } else {
         Theme {
-            fade: None,
-            err_marker: None,
-            emphasize: None,
-            command_hint: None,
-            title: None,
-            deleted: None,
-            added: None,
+            muted: Color::Grey37,
+            danger: Color::LightRed,
+            success: Color::Green,
+            warning: Color::LightYellow,
+
+            syntax_string: Color::DarkOliveGreen3a,
+            syntax_set: Color::SteelBlue,
+            syntax_object: Color::Grey63,
+            syntax_link_property: Color::IndianRed1b,
+            syntax_number: Color::CadetBlue1,
+            syntax_boolean: Color::LightSalmon3b,
+            syntax_enum: Color::DarkGoldenrod,
+            syntax_uuid: Color::LightGoldenrod3,
+            syntax_keyword: Color::IndianRed1b,
+            syntax_operator: Color::IndianRed1b,
+            syntax_comment: Color::Grey66,
+            syntax_cast: Color::IndianRed1b,
+            syntax_backslash: Color::IndianRed1c,
         }
-    }
+    })
 });
 
-#[derive(Clone, Copy)]
-struct Style {
-    color: Color,
-    bold: bool,
-    underline: bool,
-}
-
 struct Theme {
-    fade: Option<Style>,
-    err_marker: Option<Style>,
-    emphasize: Option<Style>,
-    command_hint: Option<Style>,
-    #[allow(dead_code)]
-    title: Option<Style>,
-    added: Option<Style>,
-    deleted: Option<Style>,
+    muted: Color,
+    danger: Color,
+    success: Color,
+    warning: Color,
+
+    syntax_string: Color,
+    syntax_set: Color,
+    syntax_object: Color,
+    syntax_link_property: Color,
+    syntax_number: Color,
+    syntax_boolean: Color,
+    syntax_enum: Color,
+    syntax_uuid: Color,
+    syntax_keyword: Color,
+    syntax_operator: Color,
+    syntax_comment: Color,
+    syntax_cast: Color,
+    syntax_backslash: Color,
 }
 
-pub struct Colored<T> {
-    style: Option<Style>,
-    value: T,
-}
+pub(super) fn apply_syntax_style(style: Style, data: &str) -> CString {
+    if let Some(theme) = super::color::THEME.as_ref() {
+        match style {
+            Style::Comment => data.color(theme.syntax_comment),
+            Style::String => data.color(theme.syntax_string),
+            Style::Set => data.color(theme.syntax_set),
+            Style::Object => data.color(theme.syntax_object),
+            Style::Number => data.color(theme.syntax_number),
+            Style::Boolean => data.color(theme.syntax_boolean),
+            Style::UUID => data.color(theme.syntax_uuid),
+            Style::Enum => data.color(theme.syntax_enum),
+            Style::Cast => data.color(theme.syntax_cast),
+            Style::LinkProperty => data.color(theme.syntax_link_property),
 
-pub trait Highlight: fmt::Display + Sized {
-    fn fade(self) -> Colored<Self> {
-        Colored {
-            style: theme().fade,
-            value: self,
-        }
-    }
-    #[allow(dead_code)]
-    fn title(self) -> Colored<Self> {
-        Colored {
-            style: theme().title,
-            value: self,
-        }
-    }
-    fn err_marker(self) -> Colored<Self> {
-        Colored {
-            style: theme().err_marker,
-            value: self,
-        }
-    }
-    fn emphasize(self) -> Colored<Self> {
-        Colored {
-            style: theme().emphasize,
-            value: self,
-        }
-    }
-    fn command_hint(self) -> Colored<Self> {
-        Colored {
-            style: theme().command_hint,
-            value: self,
-        }
-    }
-    fn deleted(self) -> Colored<Self> {
-        Colored {
-            style: theme().deleted,
-            value: self,
-        }
-    }
-    fn added(self) -> Colored<Self> {
-        Colored {
-            style: theme().added,
-            value: self,
-        }
-    }
-}
+            Style::Keyword => data.color(theme.syntax_keyword),
+            Style::Operator => data.color(theme.syntax_operator),
+            Style::BackslashCommand => data.color(theme.syntax_backslash).bold(),
+            Style::Error => data.color(theme.danger),
 
-fn theme() -> &'static Theme {
-    &THEME
-}
-
-impl<T: fmt::Display> Highlight for &T {}
-
-impl<T: fmt::Display> fmt::Display for Colored<&T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(style) = self.style {
-            write!(
-                f,
-                "\x1B[38;5;{}{}{}m{}\x1B[0m",
-                style.color.to_color_str(),
-                if style.bold { ";1" } else { "" },
-                if style.underline { ";4" } else { "" },
-                self.value
-            )
-        } else {
-            self.value.fmt(f)
+            Style::Decorator
+            | Style::Array
+            | Style::Tuple
+            | Style::TupleField
+            | Style::Pointer
+            | Style::Punctuation => CString::new(data),
         }
+    } else {
+        CString::new(data)
     }
 }
 

--- a/src/print/formatter.rs
+++ b/src/print/formatter.rs
@@ -221,8 +221,7 @@ where
         self.delimit()?;
         if let Some(type_name) = type_name {
             self.block(
-                self.styler
-                    .apply(Style::Array, &format!("<{type_name}>[")),
+                self.styler.apply(Style::Array, &format!("<{type_name}>[")),
                 f,
                 self.styler.apply(Style::Array, "]"),
             )?;
@@ -240,10 +239,7 @@ where
         iter: impl IntoIterator<Item = &'x f32> + Copy,
     ) -> Result<Self::Error> {
         self.delimit()?;
-        let flag = self.open_block(
-            self.styler
-                .apply(Style::Array, "<ext::pgvector::vector>["),
-        )?;
+        let flag = self.open_block(self.styler.apply(Style::Array, "<ext::pgvector::vector>["))?;
         let close = self.styler.apply(Style::Array, "]");
         if self.flow {
             let mut printed = 0;

--- a/src/print/formatter.rs
+++ b/src/print/formatter.rs
@@ -1,22 +1,12 @@
 use crate::print::stream::Output;
 use crate::print::Printer;
 
-use colorful::core::color_string::CString;
-
 use crate::print::buffer::{Exception, Result};
 
 use crate::print::style::Style;
 use crate::repl::VectorLimit;
 
-pub(in crate::print) trait ColorfulExt {
-    fn clear(&self) -> CString;
-}
-
-impl<'a> ColorfulExt for &'a str {
-    fn clear(&self) -> CString {
-        CString::new(*self)
-    }
-}
+use super::color::Highlight;
 
 pub trait Formatter {
     type Error;
@@ -92,7 +82,7 @@ where
     }
     fn nil(&mut self) -> Result<Self::Error> {
         self.delimit()?;
-        self.write(self.styler.apply(Style::SetLiteral, "{}"))
+        self.write(self.styler.apply(Style::Set, "{}"))
     }
     fn typed<S: ToString>(&mut self, typ: &str, s: S) -> Result<Self::Error> {
         self.delimit()?;
@@ -116,9 +106,9 @@ where
     {
         self.delimit()?;
         self.block(
-            self.styler.apply(Style::SetLiteral, "{"),
+            self.styler.apply(Style::Set, "{"),
             f,
-            self.styler.apply(Style::SetLiteral, "}"),
+            self.styler.apply(Style::Set, "}"),
         )?;
         Ok(())
     }
@@ -137,24 +127,24 @@ where
             Some(type_name) => {
                 if type_name == "std::FreeObject" {
                     self.block(
-                        self.styler.apply(Style::ObjectLiteral, "{"),
+                        self.styler.apply(Style::Object, "{"),
                         f,
-                        self.styler.apply(Style::ObjectLiteral, "}"),
+                        self.styler.apply(Style::Object, "}"),
                     )?;
                 } else {
                     self.block(
                         self.styler
-                            .apply(Style::ObjectLiteral, &(String::from(type_name) + " {")),
+                            .apply(Style::Object, &(String::from(type_name) + " {")),
                         f,
-                        self.styler.apply(Style::ObjectLiteral, "}"),
+                        self.styler.apply(Style::Object, "}"),
                     )?;
                 }
             }
             _ => {
                 self.block(
-                    self.styler.apply(Style::ObjectLiteral, "Object {"),
+                    self.styler.apply(Style::Object, "Object {"),
                     f,
-                    self.styler.apply(Style::ObjectLiteral, "}"),
+                    self.styler.apply(Style::Object, "}"),
                 )?;
             }
         }
@@ -166,18 +156,18 @@ where
     {
         self.delimit()?;
         self.block(
-            self.styler.apply(Style::ObjectLiteral, "{"),
+            self.styler.apply(Style::Object, "{"),
             f,
-            self.styler.apply(Style::ObjectLiteral, "}"),
+            self.styler.apply(Style::Object, "}"),
         )?;
         Ok(())
     }
     fn object_field(&mut self, f: &str, linkprop: bool) -> Result<Self::Error> {
         self.delimit()?;
         if linkprop {
-            self.write(self.styler.apply(Style::ObjectLinkProperty, f))?;
+            self.write(self.styler.apply(Style::LinkProperty, f))?;
         } else {
-            self.write(self.styler.apply(Style::ObjectPointer, f))?;
+            self.write(self.styler.apply(Style::Pointer, f))?;
         }
         self.field()?;
         Ok(())
@@ -188,9 +178,9 @@ where
     {
         self.delimit()?;
         self.block(
-            self.styler.apply(Style::TupleLiteral, "("),
+            self.styler.apply(Style::Tuple, "("),
             f,
-            self.styler.apply(Style::TupleLiteral, ")"),
+            self.styler.apply(Style::Tuple, ")"),
         )?;
         Ok(())
     }
@@ -200,9 +190,9 @@ where
     {
         self.delimit()?;
         self.block(
-            self.styler.apply(Style::TupleLiteral, "("),
+            self.styler.apply(Style::Tuple, "("),
             f,
-            self.styler.apply(Style::TupleLiteral, ")"),
+            self.styler.apply(Style::Tuple, ")"),
         )?;
         Ok(())
     }
@@ -212,16 +202,16 @@ where
     {
         self.delimit()?;
         self.block(
-            self.styler.apply(Style::TupleLiteral, &format!("{name}(")),
+            self.styler.apply(Style::Tuple, &format!("{name}(")),
             f,
-            self.styler.apply(Style::TupleLiteral, ")"),
+            self.styler.apply(Style::Tuple, ")"),
         )?;
         Ok(())
     }
     fn tuple_field(&mut self, f: &str) -> Result<Self::Error> {
         self.delimit()?;
         self.write(self.styler.apply(Style::TupleField, f))?;
-        self.write(self.styler.apply(Style::TupleLiteral, " := "))?;
+        self.write(self.styler.apply(Style::Tuple, " := "))?;
         Ok(())
     }
     fn array<F>(&mut self, type_name: Option<&str>, f: F) -> Result<Self::Error>
@@ -232,15 +222,15 @@ where
         if let Some(type_name) = type_name {
             self.block(
                 self.styler
-                    .apply(Style::ArrayLiteral, &format!("<{type_name}>[")),
+                    .apply(Style::Array, &format!("<{type_name}>[")),
                 f,
-                self.styler.apply(Style::ArrayLiteral, "]"),
+                self.styler.apply(Style::Array, "]"),
             )?;
         } else {
             self.block(
-                self.styler.apply(Style::ArrayLiteral, "["),
+                self.styler.apply(Style::Array, "["),
                 f,
-                self.styler.apply(Style::ArrayLiteral, "]"),
+                self.styler.apply(Style::Array, "]"),
             )?;
         }
         Ok(())
@@ -252,9 +242,9 @@ where
         self.delimit()?;
         let flag = self.open_block(
             self.styler
-                .apply(Style::ArrayLiteral, "<ext::pgvector::vector>["),
+                .apply(Style::Array, "<ext::pgvector::vector>["),
         )?;
-        let close = self.styler.apply(Style::ArrayLiteral, "]");
+        let close = self.styler.apply(Style::Array, "]");
         if self.flow {
             let mut printed = 0;
             let mut savepoint = (self.buffer.len(), self.column);
@@ -280,7 +270,7 @@ where
                         self.column = savepoint.1;
                         let tmp_res = self
                             .delimit()
-                            .and_then(|()| self.write("...".clear()))
+                            .and_then(|()| self.write("...".unstyled()))
                             .and_then(|()| self.close_block(&close, flag));
                         match tmp_res {
                             Ok(()) => return Ok(()),
@@ -296,7 +286,7 @@ where
                     }
                     if iter.next().is_some() {
                         self.delimit()?;
-                        self.write("...\n".clear())?;
+                        self.write("...\n".unstyled())?;
                     }
                     self.close_block(&close, flag)?;
                 }
@@ -310,7 +300,7 @@ where
             }
             if iter.next().is_some() {
                 self.delimit()?;
-                self.write("...".clear())?;
+                self.write("...".unstyled())?;
             }
             self.close_block(&close, flag)?;
         }

--- a/src/print/style.rs
+++ b/src/print/style.rs
@@ -1,9 +1,6 @@
-use std::collections::HashMap;
 use std::fmt::Write;
-use std::sync::Arc;
 
 use colorful::core::color_string::CString;
-use colorful::{Color, Colorful, Style as TermStyle};
 
 #[derive(Hash, PartialEq, Eq, Debug, Clone, Copy)]
 #[allow(clippy::upper_case_acronyms)]
@@ -16,13 +13,13 @@ pub enum Style {
     UUID,
     Enum,
     Cast,
-    SetLiteral,
-    ArrayLiteral,
-    TupleLiteral,
+    Set,
+    Array,
+    Tuple,
     TupleField,
-    ObjectLiteral,
-    ObjectLinkProperty,
-    ObjectPointer,
+    Object,
+    LinkProperty,
+    Pointer,
     Punctuation,
     Keyword,
     Operator,
@@ -30,56 +27,23 @@ pub enum Style {
     Error,
 }
 
-#[derive(Debug)]
-pub struct Item(Option<Color>, Option<TermStyle>);
-
-#[derive(Debug)]
-pub struct Theme {
-    items: HashMap<Style, Item>,
-}
-
 #[derive(Debug, Clone)]
-pub struct Styler(Arc<Theme>);
+pub struct Styler;
 
 impl Styler {
-    pub fn dark_256() -> Styler {
-        use self::Style::*;
-        use colorful::Style::*;
-
-        let mut t = HashMap::new();
-        t.insert(String, Item(Some(Color::DarkOliveGreen3a), None));
-        t.insert(SetLiteral, Item(Some(Color::SteelBlue), None));
-        t.insert(ObjectLiteral, Item(Some(Color::Grey63), None));
-        t.insert(ObjectLinkProperty, Item(Some(Color::IndianRed1b), None));
-        t.insert(Number, Item(Some(Color::CadetBlue1), None));
-        t.insert(Boolean, Item(Some(Color::LightSalmon3b), None));
-        t.insert(Enum, Item(Some(Color::DarkGoldenrod), None));
-        t.insert(UUID, Item(Some(Color::LightGoldenrod3), None));
-        t.insert(Keyword, Item(Some(Color::IndianRed1b), None));
-        t.insert(Operator, Item(Some(Color::IndianRed1b), None));
-        t.insert(Comment, Item(Some(Color::Grey66), None));
-        t.insert(Cast, Item(Some(Color::IndianRed1b), None));
-        t.insert(Error, Item(Some(Color::IndianRed1c), None));
-        t.insert(
-            BackslashCommand,
-            Item(Some(Color::MediumPurple2a), Some(Bold)),
-        );
-
-        Styler(Arc::new(Theme { items: t }))
+    pub fn new() -> Styler {
+        Styler
     }
     pub fn write(&self, style: Style, data: &str, buf: &mut String) {
         write!(buf, "{}", self.apply(style, data)).unwrap();
     }
     pub fn apply(&self, style: Style, data: &str) -> CString {
-        if let Some(Item(col, style)) = self.0.items.get(&style) {
-            match (col, style) {
-                (Some(c), Some(s)) => data.color(*c).style(*s),
-                (Some(c), None) => data.color(*c),
-                (None, Some(s)) => data.style(*s),
-                (None, None) => CString::new(data),
-            }
-        } else {
-            CString::new(data)
-        }
+        super::color::apply_syntax_style(style, data)
+    }
+}
+
+impl Default for Styler {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/print/tests.rs
+++ b/src/print/tests.rs
@@ -73,7 +73,7 @@ fn test_format<I: FormatExt + Clone + Send + Sync>(items: &[I]) -> Result<String
             implicit_properties: false,
             max_items: None,
             max_vector_length: VectorLimit::Unlimited,
-            styler: Styler::dark_256(),
+            styler: Styler::new(),
         },
     )
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -29,8 +29,6 @@ use crate::repl::{FAILURE_MARKER, TX_MARKER};
 use edgeql_parser::preparser::full_statement;
 use gel_protocol::value::Value;
 
-use colorful::Colorful;
-
 pub mod variable;
 
 pub enum Control {
@@ -94,14 +92,14 @@ impl Highlighter for EdgeqlHelper {
                 format!(
                     "{}{}> ",
                     &content[..content.len() - TX_MARKER.len()],
-                    TX_MARKER.green()
+                    TX_MARKER.success()
                 )
                 .into()
             } else if content.ends_with(FAILURE_MARKER) {
                 return format!(
                     "{}{}> ",
                     &content[..content.len() - FAILURE_MARKER.len()],
-                    FAILURE_MARKER.red()
+                    FAILURE_MARKER.danger()
                 )
                 .into();
             } else {
@@ -142,7 +140,7 @@ impl Highlighter for EdgeqlHelper {
         true
     }
     fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
-        hint.rgb(0x56, 0x56, 0x56).to_string().into()
+        hint.muted().to_string().into()
     }
     fn highlight_candidate<'h>(
         &self,
@@ -155,7 +153,7 @@ impl Highlighter for EdgeqlHelper {
             let mut buf = String::with_capacity(item.len() + 8);
             let (value, descr) = item.split_at(pos);
             buf.push_str(value);
-            write!(buf, "{}", descr.light_gray()).unwrap();
+            write!(buf, "{}", descr.muted()).unwrap();
             buf.into()
         } else {
             item.into()
@@ -246,7 +244,7 @@ pub fn create_editor(config: &ConfigBuilder) -> anyhow::Result<Editor<EdgeqlHelp
         })
         .ok();
     editor.set_helper(Some(EdgeqlHelper {
-        styler: Styler::dark_256(),
+        styler: Styler::new(),
     }));
     Ok(editor)
 }
@@ -334,7 +332,7 @@ pub fn main(mut control: Receiver<Control>) -> Result<(), anyhow::Error> {
                     &var_type.type_name(),
                     &name,
                     if optional {
-                        " (Ctrl+D for empty set `{}`)".fade().to_string()
+                        " (Ctrl+D for empty set `{}`)".muted().to_string()
                     } else {
                         String::new()
                     },

--- a/src/prompt/variable.rs
+++ b/src/prompt/variable.rs
@@ -12,7 +12,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use bigdecimal::BigDecimal;
-use colorful::Colorful;
 use edgeql_parser::helpers::unquote_string;
 use gel_protocol::codec::NamedTupleShape;
 use gel_protocol::model;
@@ -34,6 +33,8 @@ use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
 use rustyline::validate::{ValidationContext, ValidationResult, Validator};
 use rustyline::{Context, Helper};
+
+use crate::print::Highlight;
 
 type ParseResult<'a, I = &'a str, R = Value> = IResult<I, R, ParsingError>;
 
@@ -716,14 +717,14 @@ impl Highlighter for VarHelper {
                 let mut str = line[..(line.len() - r.0.len())].to_string();
 
                 // add it back, but with it highlighted red
-                str.push_str(&r.0.light_red().to_string());
+                str.push_str(&r.0.danger().to_string());
                 str.into()
             }
-            Err(_) => line.light_red().to_string().into(),
+            Err(_) => line.danger().to_string().into(),
         }
     }
     fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
-        hint.rgb(0x56, 0x56, 0x56).to_string().into()
+        hint.muted().to_string().into()
     }
     fn highlight_char(&self, _line: &str, _pos: usize, _forced: bool) -> bool {
         // needed to highlight hint

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -174,9 +174,13 @@ impl State {
     fn print_banner(&self, version: &ver::Build) -> anyhow::Result<()> {
         msg!(
             "{} {} {}",
-            format!("{}\r{BRANDING}", ansi_escapes::EraseLine).muted().emphasized(),
+            format!("{}\r{BRANDING}", ansi_escapes::EraseLine)
+                .muted()
+                .emphasized(),
             version.to_string().muted(),
-            format_args!("(repl {})", env!("CARGO_PKG_VERSION")).to_string().muted()
+            format_args!("(repl {})", env!("CARGO_PKG_VERSION"))
+                .to_string()
+                .muted()
         );
         Ok(())
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use anyhow::Context;
 use bytes::BytesMut;
-use colorful::Colorful;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot;
 
@@ -175,9 +174,9 @@ impl State {
     fn print_banner(&self, version: &ver::Build) -> anyhow::Result<()> {
         msg!(
             "{} {} {}",
-            format!("{}\r{BRANDING}", ansi_escapes::EraseLine).light_gray(),
-            version.to_string().light_gray(),
-            format_args!("(repl {})", env!("CARGO_PKG_VERSION")).fade()
+            format!("{}\r{BRANDING}", ansi_escapes::EraseLine).muted().emphasized(),
+            version.to_string().muted(),
+            format_args!("(repl {})", env!("CARGO_PKG_VERSION")).to_string().muted()
         );
         Ok(())
     }


### PR DESCRIPTION
Motivation for this PR is printing on terminals with light color scheme.

Before:

![image](https://github.com/user-attachments/assets/293e54d4-78ae-4686-991a-fa86310256e8)


After:

![image](https://github.com/user-attachments/assets/1019f7e2-9a7b-42c0-929a-5cbb34ef8a09)


To be honest, I'm not sure if I improved the situation.

---

The code has been improved though. Instead of using `colorful::Colorful` all over the codebase, I've replaced the usages with our `print::Highlight`, which applies colors from the current theme. That theme is:
- `None` if we detect that terminal does not support colors, has NO_COLOR or is not even a terminal,
- `Some(light_theme)` if [terminal-light](https://docs.rs/terminal-light/latest/terminal_light/) says that the "luma" of the terminal is >0.6,
- `Some(light_theme)` otherwise.

So light theme can now be set here: https://github.com/edgedb/edgedb-cli/pull/1453/files#diff-fa9f9b1716877750c185f94c61aba7d11d29aa88968cd9e5eb937954bf702da1R62-R81
