### PR TITLE
Implement a tabular output format and make it the default for SQL

### DIFF
--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -542,6 +542,7 @@ pub fn get_setting(s: &Setting, prompt: &repl::State) -> Cow<'static, str> {
         Language(_) => prompt.input_language.as_str().into(),
         HistorySize(_) => prompt.history_limit.to_string().into(),
         OutputFormat(_) => prompt.output_format.as_str().into(),
+        SqlOutputFormat(_) => prompt.sql_output_format.as_str().into(),
         DisplayTypenames(_) => bool_str(prompt.display_typenames).into(),
         ExpandStrings(_) => bool_str(prompt.print.expand_strings).into(),
         PrintStats(_) => prompt.print_stats.as_str().into(),
@@ -649,6 +650,9 @@ pub async fn execute(
                 }
                 OutputFormat(c) => {
                     prompt.output_format = c.value.expect("only writes here");
+                }
+                SqlOutputFormat(c) => {
+                    prompt.sql_output_format = c.value.expect("only writes here");
                 }
                 DisplayTypenames(b) => {
                     prompt.display_typenames = b.unwrap_value();

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -231,6 +231,8 @@ pub enum Setting {
     VectorDisplayLength(VectorLimitValue),
     /// Set output format
     OutputFormat(OutputFormat),
+    /// Set SQL output format
+    SqlOutputFormat(OutputFormat),
     /// Display typenames in default output mode
     DisplayTypenames(SettingBool),
     /// Disable escaping newlines in quoted strings

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,8 @@ pub struct ShellConfig {
     pub input_language: Option<repl::InputLanguage>,
     #[serde(with = "serde_str::opt", default)]
     pub output_format: Option<repl::OutputFormat>,
+    #[serde(with = "serde_str::opt", default)]
+    pub sql_output_format: Option<repl::OutputFormat>,
     #[serde(default)]
     pub display_typenames: Option<bool>,
     #[serde(with = "serde_str::opt", default)]

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -130,6 +130,10 @@ pub fn main(options: Options, cfg: Config) -> Result<(), anyhow::Error> {
             .output_format
             .or(cfg.shell.output_format)
             .unwrap_or(repl::OutputFormat::Default),
+        sql_output_format: options
+            .sql_output_format
+            .or(cfg.shell.sql_output_format)
+            .unwrap_or(repl::OutputFormat::Tabular),
         display_typenames: cfg.shell.display_typenames.unwrap_or(true),
         input_mode: cfg.shell.input_mode.unwrap_or(repl::InputMode::Emacs),
         print_stats: cfg.shell.print_stats.unwrap_or(repl::PrintStats::Off),
@@ -277,6 +281,12 @@ async fn execute_query(
     use crate::repl::PrintStats::*;
 
     let cli = state.connection.as_mut().expect("connection established");
+
+    let output_format = match state.input_language {
+        repl::InputLanguage::EdgeQl => state.output_format,
+        repl::InputLanguage::Sql => state.sql_output_format,
+    };
+
     let flags = CompilationOptions {
         implicit_limit: state.implicit_limit.map(|x| (x + 1) as u64),
         implicit_typenames: state.display_typenames && cli.protocol().supports_inline_typenames(),
@@ -284,7 +294,7 @@ async fn execute_query(
         explicit_objectids: true,
         allow_capabilities: Capabilities::ALL,
         input_language: state.input_language.into(),
-        io_format: state.output_format.into(),
+        io_format: output_format.into(),
         expected_cardinality: Cardinality::Many,
     };
 
@@ -373,7 +383,7 @@ async fn execute_query(
         // update max_width each time
         cfg.max_width(w.into());
     }
-    match state.output_format {
+    match output_format {
         TabSeparated => {
             let mut index = 0;
             while let Some(row) = items.next().await.transpose()? {
@@ -408,8 +418,7 @@ async fn execute_query(
                 index += 1;
             }
         }
-        Default if state.input_language == repl::InputLanguage::Sql => {
-            // XXX: do we want this more configurable?? probably!
+        Tabular => {
             match print::table_to_stdout(&mut items, &cfg).await {
                 Ok(()) => {}
                 Err(e) => {
@@ -425,8 +434,6 @@ async fn execute_query(
                     return Err(QueryError)?;
                 }
             }
-            println!();
-
             return Err(QueryError)?;
         }
         Default => {

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -408,6 +408,27 @@ async fn execute_query(
                 index += 1;
             }
         }
+        Default if state.input_language == repl::InputLanguage::Sql => {
+            // XXX: do we want this more configurable?? probably!
+            match print::table_to_stdout(&mut items, &cfg).await {
+                Ok(()) => {}
+                Err(e) => {
+                    match e {
+                        PrintError::StreamErr {
+                            source: ref error, ..
+                        } => {
+                            print_query_error(error, statement, state.verbose_errors, "<query>")?;
+                        }
+                        _ => eprintln!("{e:#?}"),
+                    }
+                    state.last_error = Some(e.into());
+                    return Err(QueryError)?;
+                }
+            }
+            println!();
+
+            return Err(QueryError)?;
+        }
         Default => {
             match print::native_to_stdout(&mut items, &cfg).await {
                 Ok(()) => {}

--- a/src/options.rs
+++ b/src/options.rs
@@ -465,6 +465,7 @@ pub struct Options {
     pub debug_print_codecs: bool,
     pub input_language: Option<InputLanguage>,
     pub output_format: Option<OutputFormat>,
+    pub sql_output_format: Option<OutputFormat>,
     pub no_cli_update_check: bool,
     pub test_output_conn_params: bool,
 }
@@ -853,6 +854,7 @@ impl Options {
             } else {
                 None
             },
+            sql_output_format: None,
             no_cli_update_check,
             test_output_conn_params: args.test_output_conn_params,
         })

--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -404,7 +404,7 @@ fn do_init(
     let handle = project::Handle {
         name: name.into(),
         project_dir: project.location.root.clone(),
-        schema_dir: project.resolve_schema_dir()?.into(),
+        schema_dir: project.resolve_schema_dir()?,
         instance,
         database: options.database.clone(),
     };
@@ -453,7 +453,7 @@ fn do_cloud_init(
     let handle = project::Handle {
         name: full_name.clone(),
         project_dir: project.location.root.clone(),
-        schema_dir: project.resolve_schema_dir()?.into(),
+        schema_dir: project.resolve_schema_dir()?,
         instance: project::InstanceKind::Remote,
         database: Some(database.to_owned()),
     };

--- a/src/print/buffer.rs
+++ b/src/print/buffer.rs
@@ -11,6 +11,8 @@ use crate::print::Printer;
 
 use Delim::*;
 
+use std::convert::Infallible;
+
 const HIGH_WATER_MARK: usize = 4096;
 
 #[derive(Debug)] // no Error trait, this struct should not escape to user
@@ -24,6 +26,13 @@ pub(in crate::print) enum Delim {
     None,
     Comma,
     Field,
+}
+
+pub fn fix_infallible<T>(err: Exception<Infallible>) -> Exception<T> {
+    match err {
+        Exception::DisableFlow => Exception::DisableFlow,
+        Exception::Error(e) => match e {},
+    }
 }
 
 pub(in crate::print) type Result<E> = std::result::Result<(), Exception<E>>;

--- a/src/print/buffer.rs
+++ b/src/print/buffer.rs
@@ -28,10 +28,16 @@ pub(in crate::print) enum Delim {
     Field,
 }
 
-pub fn fix_infallible<T>(err: Exception<Infallible>) -> Exception<T> {
-    match err {
-        Exception::DisableFlow => Exception::DisableFlow,
-        Exception::Error(e) => match e {},
+
+pub trait UnwrapInfallible<T>: Sized {
+    fn unwrap_infallible(self) -> T;
+}
+impl<T> UnwrapInfallible<T> for std::result::Result<T, Infallible> {
+    fn unwrap_infallible(self) -> T {
+        match self {
+            Ok(v) => v,
+            Err(i) => match i {},
+        }
     }
 }
 

--- a/src/print/buffer.rs
+++ b/src/print/buffer.rs
@@ -28,7 +28,6 @@ pub(in crate::print) enum Delim {
     Field,
 }
 
-
 pub trait UnwrapInfallible<T>: Sized {
     fn unwrap_infallible(self) -> T;
 }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -35,7 +35,6 @@ use formatter::Formatter;
 use native::FormatExt;
 use stream::Output;
 
-// XXX?
 use crate::table::{self, Cell, Row, Table};
 use gel_protocol::value::Value;
 
@@ -329,14 +328,18 @@ where
     I: FormatExt + Into<Value>,
     E: fmt::Debug + Error + 'static,
 {
+    // This is kind of hacky, but for ~performance~ and to avoid
+    // needing to pass around enough config info to recreate new ones,
+    // we repeatedly invoke a single Printer and then pull the strings
+    // out and put them in a table we are building.
     let mut buf = String::new();
     let mut prn = Printer {
-        // colors,
+        // We don't use colors yet because the table library gets
+        // confused.
         colors: false,
         indent: config.indent,
         expand_strings: config.expand_strings,
-        max_width: usize::max_value(), // lol
-        // max_width,
+        max_width: usize::MAX,
         implicit_properties: config.implicit_properties,
         max_items: config.max_items,
         max_vector_length: config.max_vector_length,

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -30,15 +30,14 @@ use gel_errors::display::display_error;
 use crate::branding::BRANDING_CLI_CMD;
 use crate::repl::VectorLimit;
 
-use buffer::{Delim, Exception, UnwrapExc, WrapErr, fix_infallible};
+use buffer::{fix_infallible, Delim, Exception, UnwrapExc, WrapErr};
 use formatter::Formatter;
 use native::FormatExt;
 use stream::Output;
 
 // XXX?
-use gel_protocol::value::Value;
 use crate::table::{self, Cell, Row, Table};
-
+use gel_protocol::value::Value;
 
 #[derive(Snafu, Debug)]
 #[snafu(context(suffix(false)))]
@@ -287,7 +286,6 @@ where
                     };
                     table_row.push(Cell::new(&get_printer_string(prn)?));
                 }
-
             }
             Value::Object { shape, fields } => {
                 for (s, vi) in shape.elements.iter().zip(fields) {
@@ -301,7 +299,6 @@ where
                     };
                     table_row.push(Cell::new(&get_printer_string(prn)?));
                 }
-
             }
             // Q: Should we do NamedTuple and Tuple also?
             _ => {
@@ -338,7 +335,7 @@ where
         colors: false,
         indent: config.indent,
         expand_strings: config.expand_strings,
-        max_width: usize::max_value(),  // lol
+        max_width: usize::max_value(), // lol
         // max_width,
         implicit_properties: config.implicit_properties,
         max_items: config.max_items,
@@ -358,13 +355,10 @@ where
         styler: config.styler.clone(),
     };
 
-    let table = format_table_rows(&mut prn, &mut rows)
-        .await
-        .unwrap_exc()?;
+    let table = format_table_rows(&mut prn, &mut rows).await.unwrap_exc()?;
 
     Ok(table)
 }
-
 
 pub async fn table_to_stdout<S, I, E>(
     rows: S,
@@ -383,7 +377,6 @@ where
     table.printstd();
     Ok(())
 }
-
 
 async fn _native_format<S, I, E, O>(
     mut rows: S,
@@ -437,7 +430,6 @@ where
     prn.end().unwrap_exc().context(PrintErr)?;
     Ok(())
 }
-
 
 fn format_rows_str<I: FormatExt>(
     prn: &mut Printer<&mut String>,

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -285,20 +285,18 @@ where
                         Some(vi) => vi.format(prn).map_err(fix_infallible)?,
                         None => {}
                     };
-                    //
                     table_row.push(Cell::new(&get_printer_string(prn)?));
                 }
 
             }
+            // TODO: tuple-like objects should be tabular also
             _ => {
-                panic!(
-                    "Expected object for SQL table but got {:?}",
-                    v
-                )
+                v.format(prn).map_err(fix_infallible)?;
+                table_row.push(Cell::new(&get_printer_string(prn)?));
             }
         }
 
-        if !titles_set {
+        if !titles_set && !title_row.is_empty() {
             table.set_titles(Row::new(title_row.clone()));
             titles_set = true;
         }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -289,7 +289,21 @@ where
                 }
 
             }
-            // TODO: tuple-like objects should be tabular also
+            Value::Object { shape, fields } => {
+                for (s, vi) in shape.elements.iter().zip(fields) {
+                    if !titles_set {
+                        title_row.push(table::header_cell(&s.name));
+                    }
+
+                    match vi {
+                        Some(vi) => vi.format(prn).map_err(fix_infallible)?,
+                        None => {}
+                    };
+                    table_row.push(Cell::new(&get_printer_string(prn)?));
+                }
+
+            }
+            // Q: Should we do NamedTuple and Tuple also?
             _ => {
                 v.format(prn).map_err(fix_infallible)?;
                 table_row.push(Cell::new(&get_printer_string(prn)?));

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -30,7 +30,7 @@ use gel_errors::display::display_error;
 use crate::branding::BRANDING_CLI_CMD;
 use crate::repl::VectorLimit;
 
-use buffer::{fix_infallible, Delim, Exception, UnwrapExc, WrapErr};
+use buffer::{Delim, Exception, UnwrapExc, UnwrapInfallible, WrapErr};
 use formatter::Formatter;
 use native::FormatExt;
 use stream::Output;
@@ -229,17 +229,13 @@ where
     _native_format(rows, config, w, colors, Stdout {}).await
 }
 
-fn get_printer_string<E>(
-    prn: &mut Printer<&mut String>,
-) -> Result<String, Exception<PrintError<E, Infallible>>>
-where
-    E: fmt::Debug + Error + 'static,
+fn get_printer_string(prn: &mut Printer<&mut String>) -> String
 {
-    prn.commit().map_err(fix_infallible)?;
-    prn.flush_buf().map_err(fix_infallible)?;
+    prn.commit().unwrap_exc().unwrap_infallible();
+    prn.flush_buf().unwrap_exc().unwrap_infallible();
     let mut s = String::new();
     std::mem::swap(prn.stream, &mut s);
-    Ok(s)
+    s
 }
 
 fn is_numeric(v: &Value) -> bool {
@@ -255,18 +251,16 @@ fn is_numeric(v: &Value) -> bool {
     )
 }
 
-fn to_cell<E>(
+fn to_cell(
     prn: &mut Printer<&mut String>,
     v: &Option<Value>,
-) -> Result<table::Cell, Exception<PrintError<E, Infallible>>>
-where
-    E: fmt::Debug + Error + 'static,
+) -> table::Cell
 {
     match v {
-        Some(vi) => vi.format(prn).map_err(fix_infallible)?,
+        Some(vi) => vi.format(prn).unwrap_exc().unwrap_infallible(),
         None => {}
     };
-    let mut cell = Cell::new(&get_printer_string(prn)?);
+    let mut cell = Cell::new(&get_printer_string(prn));
     // Right justify numbers.
     match v {
         Some(vi) if is_numeric(vi) => {
@@ -274,14 +268,14 @@ where
         }
         _ => {}
     }
-    Ok(cell)
+    cell
 }
 
 async fn format_table_rows<S, I, E>(
     // We use a Printer to do the formatting, and it needs to be a string
     prn: &mut Printer<&mut String>,
     rows: &mut S,
-) -> Result<table::Table, Exception<PrintError<E, Infallible>>>
+) -> Result<table::Table, E>
 where
     S: Stream<Item = Result<I, E>> + Send + Unpin,
     I: FormatExt + Into<Value>,
@@ -294,13 +288,13 @@ where
 
     let mut title_row = Vec::new();
     let mut titles_set = false;
-    while let Some(v) = rows.next().await.transpose().wrap_err(StreamErr)? {
+    while let Some(v) = rows.next().await.transpose()? {
         counter += 1;
         if let Some(limit) = prn.max_items {
             if counter > limit {
                 table.add_row(Row::new(vec![Cell::new("...")]));
                 // consume extra items if any
-                while rows.next().await.transpose().wrap_err(StreamErr)?.is_some() {}
+                while rows.next().await.transpose()?.is_some() {}
                 break;
             }
         }
@@ -314,7 +308,7 @@ where
                         title_row.push(table::header_cell(&s.name));
                     }
 
-                    table_row.push(to_cell(prn, vi)?);
+                    table_row.push(to_cell(prn, vi));
                 }
             }
             Value::Object { shape, fields } => {
@@ -323,12 +317,12 @@ where
                         title_row.push(table::header_cell(&s.name));
                     }
 
-                    table_row.push(to_cell(prn, vi)?);
+                    table_row.push(to_cell(prn, vi));
                 }
             }
             // Q: Should we do NamedTuple and Tuple also?
             _ => {
-                table_row.push(to_cell(prn, &Some(v))?);
+                table_row.push(to_cell(prn, &Some(v)));
             }
         }
 
@@ -348,7 +342,7 @@ async fn _table_format<S, I, E>(
     config: &Config,
     _max_width: usize,
     _colors: bool,
-) -> Result<table::Table, PrintError<E, Infallible>>
+) -> Result<table::Table, E>
 where
     S: Stream<Item = Result<I, E>> + Send + Unpin,
     I: FormatExt + Into<Value>,
@@ -384,7 +378,7 @@ where
         styler: config.styler.clone(),
     };
 
-    let table = format_table_rows(&mut prn, &mut rows).await.unwrap_exc()?;
+    let table = format_table_rows(&mut prn, &mut rows).await?;
 
     Ok(table)
 }
@@ -392,7 +386,7 @@ where
 pub async fn table_to_stdout<S, I, E>(
     rows: S,
     config: &Config,
-) -> Result<(), PrintError<E, Infallible>>
+) -> Result<(), PrintError<E, io::Error>>
 where
     S: Stream<Item = Result<I, E>> + Send + Unpin,
     I: FormatExt + Into<Value>,
@@ -402,7 +396,14 @@ where
         .max_width
         .unwrap_or_else(|| terminal_size().map(|(Width(w), _h)| w.into()).unwrap_or(80));
     let colors = config.colors.unwrap_or_else(|| io::stdout().is_terminal());
-    let table = _table_format(rows, config, w, colors).await?;
+    let table = _table_format(rows, config, w, colors).await.map_err(
+        |e| PrintError::StreamErr {source: e})?;
+
+    // TODO: We allegedly (per our type signature, and by analogy with
+    // native_to_stdout), should return a PrintErr if this write
+    // fails. But prettytable makes that kind of annoying (we'd need
+    // to pull in another dependency to do it!), so we don't.
+    // Also, who cares.
     table.printstd();
     Ok(())
 }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -229,8 +229,7 @@ where
     _native_format(rows, config, w, colors, Stdout {}).await
 }
 
-fn get_printer_string(prn: &mut Printer<&mut String>) -> String
-{
+fn get_printer_string(prn: &mut Printer<&mut String>) -> String {
     prn.commit().unwrap_exc().unwrap_infallible();
     prn.flush_buf().unwrap_exc().unwrap_infallible();
     let mut s = String::new();
@@ -251,11 +250,7 @@ fn is_numeric(v: &Value) -> bool {
     )
 }
 
-fn to_cell(
-    prn: &mut Printer<&mut String>,
-    v: &Option<Value>,
-) -> table::Cell
-{
+fn to_cell(prn: &mut Printer<&mut String>, v: &Option<Value>) -> table::Cell {
     match v {
         Some(vi) => vi.format(prn).unwrap_exc().unwrap_infallible(),
         None => {}
@@ -396,8 +391,9 @@ where
         .max_width
         .unwrap_or_else(|| terminal_size().map(|(Width(w), _h)| w.into()).unwrap_or(80));
     let colors = config.colors.unwrap_or_else(|| io::stdout().is_terminal());
-    let table = _table_format(rows, config, w, colors).await.map_err(
-        |e| PrintError::StreamErr {source: e})?;
+    let table = _table_format(rows, config, w, colors)
+        .await
+        .map_err(|e| PrintError::StreamErr { source: e })?;
 
     // TODO: We allegedly (per our type signature, and by analogy with
     // native_to_stdout), should return a PrintErr if this write

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -455,7 +455,9 @@ impl std::str::FromStr for OutputFormat {
 impl From<OutputFormat> for IoFormat {
     fn from(val: OutputFormat) -> Self {
         match val {
-            OutputFormat::Default | OutputFormat::TabSeparated | OutputFormat::Tabular => IoFormat::Binary,
+            OutputFormat::Default | OutputFormat::TabSeparated | OutputFormat::Tabular => {
+                IoFormat::Binary
+            }
             OutputFormat::JsonLines | OutputFormat::JsonPretty => IoFormat::JsonElements,
             OutputFormat::Json => IoFormat::Json,
         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -45,6 +45,7 @@ pub enum OutputFormat {
     JsonPretty,
     JsonLines,
     TabSeparated,
+    Tabular,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -90,6 +91,7 @@ pub struct State {
     pub input_language: InputLanguage,
     pub input_mode: InputMode,
     pub output_format: OutputFormat,
+    pub sql_output_format: OutputFormat,
     pub display_typenames: bool,
     pub print_stats: PrintStats,
     pub history_limit: usize,
@@ -453,7 +455,7 @@ impl std::str::FromStr for OutputFormat {
 impl From<OutputFormat> for IoFormat {
     fn from(val: OutputFormat) -> Self {
         match val {
-            OutputFormat::Default | OutputFormat::TabSeparated => IoFormat::Binary,
+            OutputFormat::Default | OutputFormat::TabSeparated | OutputFormat::Tabular => IoFormat::Binary,
             OutputFormat::JsonLines | OutputFormat::JsonPretty => IoFormat::JsonElements,
             OutputFormat::Json => IoFormat::Json,
         }
@@ -501,6 +503,7 @@ impl OutputFormat {
             JsonPretty => "json-pretty",
             JsonLines => "json-lines",
             TabSeparated => "tab-separated",
+            Tabular => "tabular",
         }
     }
 }


### PR DESCRIPTION
It uses the Printer/Formatter mechanism, since that is what actually
has fully implemented formatters.

I would like to take advantage of the coloring that Printer/Formatter
does, but the table library we use breaks if there are control
characters.  I have a plan I might do to fork the library and get
something working, but that would be a follow-up.

This adds a new `tabular` `output-format` that works for both edgeql
and SQL. We then add a `sql-output-format` mode that defaults to
`tabular`, but it can still be set back to `default`.

Fixes #1451.