### PR TITLE
Update nightly test distros

### DIFF
--- a/tests/github-nightly/compat.rs
+++ b/tests/github-nightly/compat.rs
@@ -7,9 +7,9 @@ use crate::measure::Time;
 
 #[test_matrix(
     [
+        Distro::Ubuntu("noble"),
+        Distro::Ubuntu("jammy"),
         Distro::Ubuntu("focal"),
-        Distro::Ubuntu("bionic"),
-        Distro::Ubuntu("xenial"),
         Distro::Debian("bookworm"),
         Distro::Debian("bullseye"),
         Distro::Debian("buster"),

--- a/tests/github-nightly/install.rs
+++ b/tests/github-nightly/install.rs
@@ -7,8 +7,9 @@ use crate::measure::Time;
 
 #[test_matrix(
     [
+        Distro::Ubuntu("noble"),
+        Distro::Ubuntu("jammy"),
         Distro::Ubuntu("focal"),
-        Distro::Ubuntu("bionic"),
         Distro::Debian("bookworm"),
         Distro::Debian("bullseye"),
     ],

--- a/tests/github-nightly/project.rs
+++ b/tests/github-nightly/project.rs
@@ -7,8 +7,9 @@ use crate::measure::Time;
 
 #[test_matrix(
     [
+        Distro::Ubuntu("noble"),
+        Distro::Ubuntu("jammy"),
         Distro::Ubuntu("focal"),
-        Distro::Ubuntu("bionic"),
         Distro::Debian("bookworm"),
         Distro::Debian("bullseye"),
     ],

--- a/tests/github-nightly/upgrade.rs
+++ b/tests/github-nightly/upgrade.rs
@@ -5,8 +5,8 @@ use crate::docker::run_systemd;
 use crate::docker::{build_image, Context};
 use crate::measure::Time;
 
+#[test_case("test_jammy", &dock_ubuntu("jammy"))]
 #[test_case("test_focal", &dock_ubuntu("focal"))]
-#[test_case("test_bionic", &dock_ubuntu("bionic"))]
 #[test_case("test_bookworm", &dock_debian("bookworm"))]
 #[test_case("test_bullseye", &dock_debian("bullseye"))]
 fn package(tagname: &str, dockerfile: &str) -> anyhow::Result<()> {


### PR DESCRIPTION
As support of gel-server for Ubuntu Bionic is being
[dropped](https://github.com/edgedb/edgedb/pull/8328),
this PR removes that test and adds tests for new Ubuntu
versions.
