### PR TITLE
Use edgedb/edgeql mirror instead of the main repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "edgeql-parser"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb#38d246d886953dcf3fa2ca233ff85cd002c2879d"
+source = "git+https://github.com/edgedb/edgeql#2bfe1e0d9ed774ca60c93e17ce62d3ea6426573b"
 dependencies = [
  "append-only-vec",
  "base32",
@@ -1295,7 +1295,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "snafu",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "unicode-width 0.1.14",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ indexmap = {version = "2.4", features=["serde"]}
 heck = "0.5.0"
 
 [dependencies]
-edgeql-parser = {git = "https://github.com/edgedb/edgedb"}
+edgeql-parser = {git = "https://github.com/edgedb/edgeql"}
 gel-protocol = {git = "https://github.com/edgedb/edgedb-rust/", features=["all-types"]}
 gel-derive = {git = "https://github.com/edgedb/edgedb-rust/"}
 gel-errors = {git = "https://github.com/edgedb/edgedb-rust/"}


### PR DESCRIPTION
The CLI depends on the main github.com/edgedb/edgedb repo for the
tokenizer of EdegQL in the edgeql-parser crate.

When cargo resolves a git dependency it does a recursive clone.
There is currenctly no way around this.

So the build of the cli has to clone the main repo and all git submodules,
which includes `postgres`, `libpg_query` and a few smaller repos. None of
them are actaully needed.

---

To get around that, I've setup a mirror repo, with a script that clones
the main repo and extracts only the edgeql-parser crate
(and one derive subcrate).

This mirror repo must be updated manually for now, but this is not a big deal,
as changes to edgeql-parser are sparse currently.
