### PR TITLE
Don't quote strings in tabular mode

### DIFF
--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -252,6 +252,12 @@ fn is_numeric(v: &Value) -> bool {
 
 fn to_cell(prn: &mut Printer<&mut String>, v: &Option<Value>) -> table::Cell {
     match v {
+        Some(Value::Str(s)) => {
+            let s = native::format_string(s, prn.expand_strings());
+            prn.const_string(&s[1..s.len() - 1])
+                .unwrap_exc()
+                .unwrap_infallible()
+        }
         Some(vi) => vi.format(prn).unwrap_exc().unwrap_infallible(),
         None => {}
     };

--- a/src/print/native.rs
+++ b/src/print/native.rs
@@ -13,7 +13,7 @@ pub trait FormatExt {
     fn format<F: Formatter>(&self, prn: &mut F) -> Result<F::Error>;
 }
 
-fn format_string(s: &str, expanded: bool) -> String {
+pub fn format_string(s: &str, expanded: bool) -> String {
     let mut buf = String::with_capacity(s.len() + 2);
     buf.push('\'');
     for c in s.chars() {


### PR DESCRIPTION
Tabular mode isn't really for precision, anyway. This is what postgres
does, and I think it looks better.

![Screenshot from 2025-02-12 13-10-47](https://github.com/user-attachments/assets/8881cadf-ac70-478f-97d3-8b866635ecd4)
