### PR TITLE
Remove duplicated `branching` command group

### DIFF
--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -11,18 +11,12 @@ pub mod switch;
 pub mod wipe;
 
 use crate::branding::BRANDING;
-use crate::commands::parser::BranchingCmd;
 use crate::commands::Options;
 use crate::connect::{Connection, Connector};
 use crate::options::ConnectionOptions;
 use crate::portable;
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn run(options: &Options, cmd: &Command) -> anyhow::Result<CommandResult> {
-    do_run(&cmd.subcommand, options, None, cmd.conn.instance.as_ref()).await
-}
-
-pub async fn do_run(
+pub async fn run(
     cmd: &Subcommand,
     options: &Options,
     connection: Option<&mut Connection>,
@@ -106,17 +100,4 @@ pub async fn verify_server_can_use_branches(connection: &mut Connection) -> anyh
     }
 
     Ok(())
-}
-
-impl From<BranchingCmd> for Subcommand {
-    fn from(cmd: BranchingCmd) -> Self {
-        match cmd {
-            BranchingCmd::Create(args) => Subcommand::Create(args),
-            BranchingCmd::Drop(args) => Subcommand::Drop(args),
-            BranchingCmd::Wipe(args) => Subcommand::Wipe(args),
-            BranchingCmd::List(args) => Subcommand::List(args),
-            BranchingCmd::Switch(args) => Subcommand::Switch(args),
-            BranchingCmd::Rename(args) => Subcommand::Rename(args),
-        }
-    }
 }

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -67,6 +67,7 @@ Editing
                             Defaults to vi (Notepad in Windows).
 
 Connection
+  \b, \branch ...           Branch commands
   \c, \connect [DBNAME]     Connect to database/branch DBNAME
 
 Settings
@@ -342,8 +343,8 @@ impl CommandCache {
         aliases.insert("quit", &["exit"]);
         aliases.insert("?", &["help"]);
         aliases.insert("h", &["help"]);
-        aliases.insert("branch", &["branching"]);
-        aliases.insert("b", &["branching"]);
+        aliases.insert("branch", &["branch"]);
+        aliases.insert("b", &["branch"]);
         let mut setting_cmd = None;
         let commands: BTreeMap<_, _> = clap
             .get_subcommands_mut()
@@ -589,8 +590,8 @@ pub async fn execute(
         }
         Common(ref cmd) => {
             prompt.soft_reconnect().await?;
-            let cli = prompt.connection.as_mut().expect("connection established");
-            let result = execute::common(cli, cmd, &options).await?;
+            let conn = prompt.connection.as_mut().expect("connection established");
+            let result = execute::common(conn, cmd, &options).await?;
 
             if let Some(branch) = result.new_branch {
                 prompt.try_connect(&branch).await?;

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -593,7 +593,7 @@ pub async fn execute(
         Common(ref cmd) => {
             prompt.soft_reconnect().await?;
             let conn = prompt.connection.as_mut().expect("connection established");
-            let result = execute::common(conn, cmd, &options).await?;
+            let result = execute::common(Some(conn), cmd, &options).await?;
 
             if let Some(branch) = result.new_branch {
                 prompt.try_connect(&branch).await?;

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -578,11 +578,13 @@ pub async fn execute(
     use ExecuteResult::*;
     use Setting::*;
 
-    let options = Options {
+    let mut options = Options {
         command_line: false,
         styler: Some(Styler::new()),
         conn_params: prompt.conn_params.clone(),
+        instance_name: None,
     };
+    options.infer_instance_name()?;
     match cmd {
         Help => {
             print!("{HELP}");

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -19,8 +19,7 @@ async fn common_cmd(
     cmdopt: commands::Options,
     cmd: &Common,
 ) -> Result<(), anyhow::Error> {
-    let mut conn = cmdopt.conn_params.connect().await?;
-    commands::execute::common(&mut conn, cmd, &cmdopt).await?;
+    commands::execute::common(None, cmd, &cmdopt).await?;
     Ok(())
 }
 

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -1,5 +1,6 @@
 use is_terminal::IsTerminal;
 
+use crate::cli;
 use crate::cli::directory_check;
 use crate::cloud::main::cloud_main;
 use crate::commands;
@@ -11,7 +12,6 @@ use crate::options::{Command, Options};
 use crate::portable;
 use crate::print::style::Styler;
 use crate::watch;
-use crate::{branch, cli};
 
 #[tokio::main(flavor = "current_thread")]
 async fn common_cmd(
@@ -74,11 +74,6 @@ pub fn main(options: &Options) -> Result<(), anyhow::Error> {
         Command::UI(c) => commands::show_ui(c, options),
         Command::Cloud(c) => cloud_main(c, &options.cloud_options),
         Command::Watch(c) => watch::run(options, c),
-        Command::Branch(c) => {
-            let opts = init_command_opts(options)?;
-            branch::run(&opts, c)?;
-            Ok(())
-        }
         Command::HashPassword(cmd) => {
             println!("{}", portable::password_hash(&cmd.password));
             Ok(())

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -89,6 +89,7 @@ fn init_command_opts(options: &Options) -> Result<commands::Options, anyhow::Err
         } else {
             None
         },
+        instance_name: options.conn_options.instance.clone(),
         conn_params: options.block_on_create_connector()?,
     })
 }

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -12,7 +12,7 @@ use crate::migrations::options::MigrationCmd;
 use crate::print;
 
 pub async fn common(
-    cli: &mut Connection,
+    conn: &mut Connection,
     cmd: &Common,
     options: &Options,
 ) -> Result<branch::CommandResult, anyhow::Error> {
@@ -21,7 +21,7 @@ pub async fn common(
         List(c) => match &c.subcommand {
             ListCmd::Aliases(c) => {
                 commands::list_aliases(
-                    cli,
+                    conn,
                     options,
                     &c.pattern,
                     c.system,
@@ -31,11 +31,11 @@ pub async fn common(
                 .await?;
             }
             ListCmd::Casts(c) => {
-                commands::list_casts(cli, options, &c.pattern, c.case_sensitive).await?;
+                commands::list_casts(conn, options, &c.pattern, c.case_sensitive).await?;
             }
             ListCmd::Indexes(c) => {
                 commands::list_indexes(
-                    cli,
+                    conn,
                     options,
                     &c.pattern,
                     c.system,
@@ -45,37 +45,37 @@ pub async fn common(
                 .await?;
             }
             ListCmd::Databases => {
-                commands::list_databases(cli, options).await?;
+                commands::list_databases(conn, options).await?;
             }
             ListCmd::Branches => {
-                commands::list_branches(cli, options).await?;
+                commands::list_branches(conn, options).await?;
             }
             ListCmd::Scalars(c) => {
-                commands::list_scalar_types(cli, options, &c.pattern, c.system, c.case_sensitive)
+                commands::list_scalar_types(conn, options, &c.pattern, c.system, c.case_sensitive)
                     .await?;
             }
             ListCmd::Types(c) => {
-                commands::list_object_types(cli, options, &c.pattern, c.system, c.case_sensitive)
+                commands::list_object_types(conn, options, &c.pattern, c.system, c.case_sensitive)
                     .await?;
             }
             ListCmd::Modules(c) => {
-                commands::list_modules(cli, options, &c.pattern, c.case_sensitive).await?;
+                commands::list_modules(conn, options, &c.pattern, c.case_sensitive).await?;
             }
             ListCmd::Roles(c) => {
-                commands::list_roles(cli, options, &c.pattern, c.case_sensitive).await?;
+                commands::list_roles(conn, options, &c.pattern, c.case_sensitive).await?;
             }
         },
         Analyze(c) => {
-            analyze::command(cli, c).await?;
+            analyze::command(conn, c).await?;
         }
-        Pgaddr => match cli.get_server_param::<PostgresAddress>() {
+        Pgaddr => match conn.get_server_param::<PostgresAddress>() {
             Some(addr) => {
                 // < 6.x
                 println!("{}", serde_json::to_string_pretty(addr)?);
             }
             None => {
                 // >= 6.x
-                match cli.get_server_param::<PostgresDsn>() {
+                match conn.get_server_param::<PostgresDsn>() {
                     Some(addr) => {
                         println!("{}", addr.0);
                     }
@@ -84,67 +84,66 @@ pub async fn common(
             }
         },
         Psql => {
-            commands::psql(cli, options).await?;
+            commands::psql(conn, options).await?;
         }
         Describe(c) => match &c.subcommand {
             DescribeCmd::Object(c) => {
-                commands::describe(cli, options, &c.name, c.verbose).await?;
+                commands::describe(conn, options, &c.name, c.verbose).await?;
             }
             DescribeCmd::Schema(_) => {
-                commands::describe_schema(cli, options).await?;
+                commands::describe_schema(conn, options).await?;
             }
         },
         Dump(c) => {
-            commands::dump(cli, options, c).await?;
+            commands::dump(conn, options, c).await?;
         }
         Restore(params) => {
-            commands::restore(cli, options, params).await?;
+            commands::restore(conn, options, params).await?;
         }
         Configure(c) => {
-            commands::configure(cli, options, c).await?;
+            commands::configure(conn, options, c).await?;
         }
         Database(c) => match &c.subcommand {
             DatabaseCmd::Create(c) => {
-                commands::database::create(cli, c, options).await?;
+                commands::database::create(conn, c, options).await?;
             }
             DatabaseCmd::Drop(d) => {
-                commands::database::drop(cli, d, options).await?;
+                commands::database::drop(conn, d, options).await?;
             }
             DatabaseCmd::Wipe(w) => {
-                commands::database::wipe(cli, w).await?;
+                commands::database::wipe(conn, w).await?;
             }
         },
-        Branching(cmd) => {
-            let cmd = branch::Subcommand::from(cmd.subcommand.clone());
-            return branch::do_run(&cmd, options, Some(cli), None).await;
+        Branch(cmd) => {
+            return branch::run(&cmd.subcommand, options, Some(conn), None).await;
         }
         Migrate(cmd) => {
-            migrations::apply::run(cmd, cli, options).await?;
+            migrations::apply::run(cmd, conn, options).await?;
         }
         Migration(m) => match &m.subcommand {
             MigrationCmd::Apply(cmd) => {
-                migrations::apply::run(cmd, cli, options).await?;
+                migrations::apply::run(cmd, conn, options).await?;
             }
             MigrationCmd::Create(cmd) => {
-                migrations::create::run(cmd, cli, options).await?;
+                migrations::create::run(cmd, conn, options).await?;
             }
             MigrationCmd::Status(params) => {
-                migrations::status(cli, options, params).await?;
+                migrations::status(conn, options, params).await?;
             }
             MigrationCmd::Log(params) => {
-                migrations::log(cli, options, params).await?;
+                migrations::log(conn, options, params).await?;
             }
             MigrationCmd::Edit(params) => {
-                migrations::edit(cli, options, params).await?;
+                migrations::edit(conn, options, params).await?;
             }
             MigrationCmd::UpgradeCheck(_) => {
                 anyhow::bail!("cannot be run in REPL mode");
             }
             MigrationCmd::Extract(params) => {
-                migrations::extract(cli, options, params).await?;
+                migrations::extract(conn, options, params).await?;
             }
             MigrationCmd::UpgradeFormat(params) => {
-                migrations::upgrade_format(cli, options, params).await?;
+                migrations::upgrade_format(conn, options, params).await?;
             }
         },
     }

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -115,7 +115,7 @@ pub async fn common(
             }
         },
         Branch(cmd) => {
-            return branch::run(&cmd.subcommand, options, Some(conn), None).await;
+            return branch::run(&cmd.subcommand, options, conn).await;
         }
         Migrate(cmd) => {
             migrations::apply::run(cmd, conn, options).await?;

--- a/src/commands/options.rs
+++ b/src/commands/options.rs
@@ -1,8 +1,24 @@
+use std::str::FromStr;
+
 use crate::connect::Connector;
+use crate::portable;
 use crate::print::style::Styler;
 
 pub struct Options {
     pub command_line: bool,
     pub styler: Option<Styler>,
     pub conn_params: Connector,
+    pub instance_name: Option<portable::options::InstanceName>,
+}
+
+impl Options {
+    pub fn infer_instance_name(&mut self) -> anyhow::Result<()> {
+        self.instance_name = self
+            .conn_params
+            .get()?
+            .instance_name()
+            .map(|x| portable::options::InstanceName::from_str(&x.to_string()))
+            .transpose()?;
+        Ok(())
+    }
 }

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
 use crate::branding::BRANDING_CLI_CMD;
-use crate::migrations;
 use crate::migrations::options::Migration;
 use crate::options::ConnectionOptions;
 use crate::portable::options::InstanceName;
 use crate::repl::{self, VectorLimit};
+use crate::{branch, migrations};
 
 use const_format::concatcp;
 
@@ -27,7 +27,8 @@ pub enum Common {
 
     /// Database commands
     Database(Database),
-    Branching(Branching),
+    /// Manage branches
+    Branch(branch::Command),
     /// Describe database schema or object
     Describe(Describe),
 
@@ -122,34 +123,6 @@ pub enum ListCmd {
     Scalars(ListTypes),
     /// Display list of object types defined in the schema
     Types(ListTypes),
-}
-
-#[derive(clap::Args, Clone, Debug)]
-#[command(version = "help_expand", hide = true)]
-#[command(disable_version_flag = true)]
-pub struct Branching {
-    #[command(flatten)]
-    pub conn: ConnectionOptions,
-
-    #[command(subcommand)]
-    pub subcommand: BranchingCmd,
-}
-
-#[derive(clap::Subcommand, Clone, Debug)]
-pub enum BranchingCmd {
-    /// Create a new branch
-    Create(crate::branch::create::Command),
-    /// Delete a branch along with its data
-    Drop(crate::branch::drop::Command),
-    /// Delete a branch's data and reset its schema while preserving the branch
-    /// itself (its `cfg::DatabaseConfig`) and existing migration scripts
-    Wipe(crate::branch::wipe::Command),
-    /// List all branches.
-    List(crate::branch::list::Command),
-    /// Switches the current branch to a different one.
-    Switch(crate::branch::switch::Command),
-    /// Renames a branch.
-    Rename(crate::branch::rename::Command),
 }
 
 #[derive(clap::Args, Clone, Debug)]

--- a/src/options.rs
+++ b/src/options.rs
@@ -16,7 +16,6 @@ use edgedb_cli_derive::IntoArgs;
 
 use crate::{cli, watch};
 
-use crate::branch;
 use crate::branding::{BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD, MANIFEST_FILE_DISPLAY_NAME};
 use crate::cloud::options::CloudCommand;
 use crate::commands::parser::Common;
@@ -381,8 +380,6 @@ pub enum Command {
     /// Start a long-running process that watches the project directory
     /// and runs scripts
     Watch(watch::Command),
-    /// Manage branches
-    Branch(branch::Command),
     /// Generate a `SCRAM-SHA-256` hash for a password.
     HashPassword(HashPasswordCommand),
 }

--- a/src/portable/instance/upgrade.rs
+++ b/src/portable/instance/upgrade.rs
@@ -488,6 +488,7 @@ pub async fn dump_instance(inst: &InstanceInfo, destination: &Path) -> anyhow::R
         command_line: true,
         styler: None,
         conn_params: Connector::new(Ok(config)),
+        instance_name: Some(InstanceName::Local(inst.name.clone())),
     };
     commands::dump_all(
         &mut cli,
@@ -578,6 +579,7 @@ async fn restore_instance(inst: &InstanceInfo, path: &Path) -> anyhow::Result<()
         command_line: true,
         styler: None,
         conn_params: Connector::new(Ok(cfg)),
+        instance_name: Some(InstanceName::Local(inst.name.clone())),
     };
     commands::restore_all(
         &mut cli,

--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -1261,6 +1261,7 @@ async fn migrate_async(inst: &project::Handle<'_>, ask_for_running: bool) -> any
             command_line: true,
             styler: None,
             conn_params: Connector::new(inst.get_builder()?.build_env().await.map_err(Into::into)),
+            instance_name: Some(InstanceName::Local(inst.name.clone())),
         },
     )
     .await?;

--- a/tests/func/interactive.rs
+++ b/tests/func/interactive.rs
@@ -48,7 +48,8 @@ fn create_report() {
 
     cmd.exp_string(&format!("{main}>")).unwrap();
     cmd.send_line("CREATE TYPE default::Type1;\n").unwrap();
-    cmd.exp_string("OK: CREATE").unwrap();
+    cmd.exp_string("OK: ").unwrap();
+    cmd.exp_string("CREATE").unwrap();
 }
 
 #[test]


### PR DESCRIPTION
For the repl backslash commands, we had a separate `Branching` cmd struct. This was implemented via being in the `Common` cmd (which contains all "common" commands that can be executed in repl backslash or as normal CLI command).

But this meant that we also had CLI command named `branching`:
```
# gel branching current

# gel branch current
```

???

So I've removed `Branching` struct in favor of `Common::Branch`, renamed `\branching` to `\branch` and cleaned-up a lot of code duplication and generalization.