### PR TITLE
Fix extension package command default channel and slot

### DIFF
--- a/src/portable/extension.rs
+++ b/src/portable/extension.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use anyhow::Context;
 use edgedb_cli_derive::IntoArgs;
-use log::trace;
+use log::{debug, trace};
 use prettytable::{row, Table};
 
 use crate::branding::BRANDING_CLOUD;
@@ -180,9 +180,9 @@ fn install(cmd: &ExtensionInstall, _options: &Options) -> Result<(), anyhow::Err
     }
 
     let version = inst.get_version()?.specific();
-    let channel = cmd.channel.unwrap_or(Channel::from_version(&version)?);
-    let slot = cmd.slot.clone().unwrap_or(version.slot());
-    trace!("Instance: {version} {channel:?} {slot}");
+    let channel = cmd.channel.unwrap_or(Channel::Stable);
+    let slot = cmd.slot.clone().unwrap_or(version.extension_server_slot());
+    debug!("Instance: {version} {channel:?} {slot}");
     let packages = get_platform_extension_packages(channel, &slot, get_server()?)?;
 
     let package = packages
@@ -255,14 +255,14 @@ fn list_available(list: &ExtensionListAvailable, _options: &Options) -> Result<(
     let inst = get_local_instance(&list.instance)?;
 
     let version = inst.get_version()?.specific();
-    let channel = list.channel.unwrap_or(Channel::from_version(&version)?);
-    let slot = list.slot.clone().unwrap_or(version.slot());
-    trace!("Instance: {version} {channel:?} {slot}");
+    let channel = list.channel.unwrap_or(Channel::Stable);
+    let slot = list.slot.clone().unwrap_or(version.extension_server_slot());
+    debug!("Instance: {version} {channel:?} {slot}");
     let packages = get_platform_extension_packages(channel, &slot, get_server()?)?;
 
     let mut table = Table::new();
     table.set_format(*table::FORMAT);
-    table.add_row(row!["Name", "Version"]);
+    table.set_titles(row!["Name", "Version"]);
     for pkg in packages {
         let ext = pkg.tags.get("extension").cloned().unwrap_or_default();
         table.add_row(row![ext, pkg.version]);

--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -218,13 +218,13 @@ impl Specific {
         matches!(self.minor, MinorVersion::Minor(_))
     }
 
-    pub fn slot(&self) -> String {
+    pub fn extension_server_slot(&self) -> String {
         match self.minor {
             MinorVersion::Minor(_) => self.major.to_string(),
             MinorVersion::Dev(v) => format!("{}-dev{}", self.major, v),
-            MinorVersion::Alpha(v) => format!("{}-alpha{}", self.major, v),
-            MinorVersion::Beta(v) => format!("{}-beta{}", self.major, v),
-            MinorVersion::Rc(v) => format!("{}-rc{}", self.major, v),
+            MinorVersion::Alpha(v) => format!("{}-alpha-{}", self.major, v),
+            MinorVersion::Beta(v) => format!("{}-beta-{}", self.major, v),
+            MinorVersion::Rc(v) => format!("{}-rc-{}", self.major, v),
         }
     }
 }


### PR DESCRIPTION
Default channel should probably be Stable, since that is where we
publish postgis (even when built against an rc). Default slots need to
be formatted like `6-rc-2`, *not* `6-rc2`, since that is how it is in
the `server_slot` field. (I think this is a mismatch with what "slots"
we use for the server builds themselves?)

I will probably try to do another follow-up that does more flexible
matching against slots.