### PR TITLE
Fix highlighting of string interpolations

### DIFF
--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -143,6 +143,10 @@ fn token_style(kind: Kind, value: &str) -> Option<Style> {
         T::BacktickName => None,
         T::Substitution => Some(S::Decorator),
 
-        t => unreachable!("unexpected token kind: {:?}", t),
+        T::StrInterpStart => Some(S::String),
+        T::StrInterpCont => Some(S::String),
+        T::StrInterpEnd => Some(S::String),
+
+        _ => None,
     }
 }


### PR DESCRIPTION
Currently it crashes. Make it do the right thing, and also
don't crash.