### PR TITLE
Pre-refactoring to fix some async issues with link

### DIFF
--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -824,7 +824,7 @@ fn ask_name(
         }
         return Ok((default_name, false));
     }
-    let mut q = question::String::new(concatcp!(
+    let q = question::String::new(concatcp!(
         "Specify the name of the ",
         BRANDING,
         " instance to use with this project"
@@ -833,7 +833,7 @@ fn ask_name(
     q.default(&default_name_str);
     loop {
         let default_name_clone = default_name.clone();
-        let mut q = question::String::new(concatcp!(
+        let q = question::String::new(concatcp!(
             "Specify the name of the ",
             BRANDING,
             " instance to use with this project"
@@ -899,8 +899,7 @@ fn ask_database(project_dir: &Path, options: &Command) -> anyhow::Result<String>
         return Ok(name.clone());
     }
     let default = directory_to_name(project_dir, "edgedb");
-    let mut q = question::String::new("Specify database name:");
-    q.default(&default);
+    let mut q = question::String::new("Specify database name:").default(&default);
     loop {
         let name = q.ask()?;
         if name.trim().is_empty() {
@@ -912,8 +911,7 @@ fn ask_database(project_dir: &Path, options: &Command) -> anyhow::Result<String>
 }
 
 fn ask_branch() -> anyhow::Result<String> {
-    let mut q = question::String::new("Specify branch name:");
-    q.default("main");
+    let mut q = question::String::new("Specify branch name:").default("main");
     loop {
         let name = q.ask()?;
         if name.trim().is_empty() {
@@ -945,8 +943,8 @@ fn ask_local_version(options: &Command) -> anyhow::Result<(Query, PackageInfo)> 
         "Specify the version of the ",
         BRANDING,
         " instance to use with this project"
-    ));
-    q.default(&default_ver);
+    ))
+    .default(&default_ver);
     loop {
         let value = q.ask()?;
         let value = value.trim();
@@ -1084,8 +1082,8 @@ fn ask_cloud_version(
         "Specify the version of the ",
         BRANDING,
         " instance to use with this project"
-    ));
-    q.default(&default_ver);
+    ))
+    .default(&default_ver);
     loop {
         let value = q.ask()?;
         let value = value.trim();

--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -828,9 +828,8 @@ fn ask_name(
         "Specify the name of the ",
         BRANDING,
         " instance to use with this project"
-    ));
-    let default_name_str = default_name.to_string();
-    q.default(&default_name_str);
+    ))
+    .default(&default_name.to_string());
     loop {
         let default_name_clone = default_name.clone();
         let q = question::String::new(concatcp!(

--- a/src/question.rs
+++ b/src/question.rs
@@ -14,8 +14,8 @@ pub struct Numeric<'a, T: Clone + 'a> {
 }
 
 pub struct String<'a> {
-    question: &'a str,
-    default: &'a str,
+    question: Cow<'a, str>,
+    default: Cow<'a, str>,
     initial: Option<std::string::String>,
 }
 
@@ -95,13 +95,13 @@ impl<T: Clone + Send> Numeric<'static, T> {
 impl<'a> String<'a> {
     pub fn new(question: &'a str) -> String {
         String {
-            question,
-            default: "",
+            question: question.into(),
+            default: Cow::default(),
             initial: None,
         }
     }
-    pub fn default(&mut self, default: &'a str) -> &mut Self {
-        self.default = default;
+    pub fn default<'b: 'a>(mut self, default: &'b str) -> Self {
+        self.default = default.into();
         self
     }
     pub fn ask(&mut self) -> anyhow::Result<std::string::String> {
@@ -115,21 +115,23 @@ impl<'a> String<'a> {
             .initial
             .as_ref()
             .map(|s| &s[..])
-            .unwrap_or(self.default);
+            .unwrap_or(self.default.as_ref());
         let val = editor.readline_with_initial("> ", (initial, ""))?;
         let mut val = val.trim();
         if val.is_empty() {
-            val = self.default;
+            val = self.default.as_ref();
         }
         self.initial = Some(val.into());
         Ok(val.into())
     }
-}
 
-impl String<'static> {
-    #[allow(dead_code)]
-    pub async fn async_ask(mut self) -> anyhow::Result<std::string::String> {
-        spawn_blocking(move || self.ask()).await?
+    pub async fn async_ask(self) -> anyhow::Result<std::string::String> {
+        let mut question: String<'static> = String {
+            question: self.question.to_string().into(),
+            default: self.default.to_string().into(),
+            initial: self.initial.map(|s| s.to_string()),
+        };
+        spawn_blocking(move || question.ask()).await?
     }
 }
 
@@ -200,7 +202,6 @@ impl<'a> Confirm<'a> {
 }
 
 impl Confirm<'static> {
-    #[allow(dead_code)]
     pub async fn async_ask(self) -> anyhow::Result<bool> {
         spawn_blocking(move || self.ask()).await?
     }

--- a/src/question.rs
+++ b/src/question.rs
@@ -100,6 +100,7 @@ impl<'a> String<'a> {
             initial: None,
         }
     }
+    #[must_use]
     pub fn default<'b: 'a>(mut self, default: &'b str) -> Self {
         self.default = default.into();
         self

--- a/src/tty_password.rs
+++ b/src/tty_password.rs
@@ -18,3 +18,12 @@ pub fn read_stdin() -> anyhow::Result<String> {
         .context("error reading password from stdin")?;
     Ok(passwd)
 }
+
+pub async fn read_async(prompt: impl AsRef<str>) -> anyhow::Result<String> {
+    let prompt = prompt.as_ref().to_string();
+    tokio::task::spawn_blocking(|| read(prompt)).await?
+}
+
+pub async fn read_stdin_async() -> anyhow::Result<String> {
+    tokio::task::spawn_blocking(|| read_stdin()).await?
+}

--- a/tests/func/main.rs
+++ b/tests/func/main.rs
@@ -10,6 +10,7 @@ use std::fs;
 use std::path::Path;
 use std::process;
 use std::str::FromStr;
+use std::time::Duration;
 
 use assert_cmd::Command;
 use once_cell::sync::Lazy;
@@ -42,7 +43,7 @@ pub const BRANDING_CLI_CMD: &str = if cfg!(feature = "gel") {
 
 fn edgedb_cli_cmd() -> assert_cmd::Command {
     let mut cmd = Command::cargo_bin("edgedb").expect("binary found");
-
+    cmd.timeout(Duration::from_secs(60));
     cmd.env("CLICOLOR", "0").arg("--no-cli-update-check");
     cmd
 }
@@ -161,7 +162,6 @@ impl ServerGuard {
 
     pub fn ensure_instance_linked(&self) -> &'static str {
         const INSTANCE_NAME: &str = "_test_inst";
-
         edgedb_cli_cmd()
             .arg("instance")
             .arg("link")


### PR DESCRIPTION
Moving connections between runtimes is sketchy and might cause random failures (in fact, it does when we switch to gel-stream).

Rewrite the linking function to use just one runtime.