### PR TITLE
Update package name and authors to new name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,7 +1136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
-name = "edgedb-cli"
+name = "gel-cli"
 version = "6.2.0-dev"
 dependencies = [
  "anes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ members = [
 ]
 
 [package]
-name = "edgedb-cli"
+name = "gel-cli"
 license = "MIT/Apache-2.0"
 version = "6.2.0-dev"
-authors = ["EdgeDB Inc. <hello@edgedb.com>"]
+authors = ["Gel Data Inc. <yo@geldata.com>"]
 edition = "2018"
 
 [[bin]]


### PR DESCRIPTION
We should probably also change the default binary, but I don't want to
have to chase down and fix the copies/symlinks that packaging/server
do right now.