### PR TITLE
Pass on generate config to the tool

### DIFF
--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -638,6 +638,7 @@ fn init_new(
             hooks: None,
             hooks_extend: None,
             watch: Vec::new(),
+            generate: None,
         };
         project::manifest::write(&location.manifest, &manifest)?;
         let ctx = project::Context::new(location, manifest)?;
@@ -704,6 +705,7 @@ fn init_new(
                 hooks: None,
                 hooks_extend: None,
                 watch: Vec::new(),
+                generate: None,
             };
             project::manifest::write(&location.manifest, &manifest)?;
             let ctx = project::Context::new(location, manifest)?;
@@ -771,6 +773,7 @@ fn init_new(
                 hooks: None,
                 hooks_extend: None,
                 watch: Vec::new(),
+                generate: None,
             };
 
             project::manifest::write(&location.manifest, &manifest)?;

--- a/src/portable/project/manifest.rs
+++ b/src/portable/project/manifest.rs
@@ -23,6 +23,7 @@ pub struct Manifest {
     pub hooks: Option<Hooks>,
     pub hooks_extend: Option<Hooks>,
     pub watch: Vec<WatchScript>,
+    pub generate: Option<BTreeMap<String, GenerateConfig>>,
 }
 
 impl Manifest {
@@ -114,6 +115,9 @@ pub struct WatchScript {
     pub script: String,
 }
 
+type GeneratorConfig = BTreeMap<String, Spanned<toml::Value>>;
+type GenerateConfig = BTreeMap<String, GeneratorConfig>;
+
 #[context("error reading project config `{}`", path.display())]
 pub fn read(path: &Path) -> anyhow::Result<Manifest> {
     let text = fs::read_to_string(path)?;
@@ -142,6 +146,7 @@ pub fn read(path: &Path) -> anyhow::Result<Manifest> {
         hooks: val.hooks,
         hooks_extend: None,
         watch: val.watch.unwrap_or_default(),
+        generate: val.generate,
     });
 }
 
@@ -263,6 +268,7 @@ pub struct SrcManifest {
     pub project: Option<SrcProject>,
     pub hooks: Option<Hooks>,
     pub watch: Option<Vec<WatchScript>>,
+    pub generate: Option<BTreeMap<String, GenerateConfig>>,
     #[serde(flatten)]
     pub extra: BTreeMap<String, toml::Value>,
 }


### PR DESCRIPTION
For `gel generate <lang>/<generator>`, it will look into `gel.toml` for `[generate.<lang>.<generator>]`, and pass the whole table in JSON format with value spans as environment variable to the tool. For example, with:

```toml
watch = []

[instance]
server-version = "6.9"

[generate.py.models]
no_cache = false
output = "backend/app/models"
```

`gel generate py/models` will invoke `gel-generate-py` with 2 environment variables:
 * `GEL_GENERATE_CONFIG`:
   ```json
   {"no_cache":{"value":false,"span":[79,84]},"output":{"value":"backend/app/models","span":[94,114]}}
   ```
 * `GEL_TOML_CONTENT`: the full `gel.toml` file above

The tools are responsible for using these environment variables to validate the values, configure the generator, or report errors properly. The tools should not depend on the existence of such environment variables.

And the final result would be like:

<img width="720" height="88" alt="image" src="https://github.com/user-attachments/assets/e149ba3c-f991-4400-ad09-19ab06255310" />

See also: geldata/gel-python#815