### PR TITLE
Fix nested tokio runtimes in repository code

### DIFF
--- a/src/portable/extension.rs
+++ b/src/portable/extension.rs
@@ -184,7 +184,7 @@ async fn install(cmd: &ExtensionInstall, _options: &Options) -> Result<(), anyho
     let channel = cmd.channel.unwrap_or(Channel::Stable);
     let slot = cmd.slot.clone().unwrap_or(version.extension_server_slot());
     debug!("Instance: {version} {channel:?} {slot}");
-    let packages = get_platform_extension_packages(channel, &slot, get_server()?)?;
+    let packages = get_platform_extension_packages(channel, &slot, get_server()?).await?;
 
     let package = packages
         .iter()
@@ -275,7 +275,7 @@ async fn list_available(
     let channel = cmd.channel.unwrap_or(Channel::Stable);
     let slot = cmd.slot.clone().unwrap_or(version.extension_server_slot());
     debug!("Instance: {version} {channel:?} {slot}");
-    let packages = get_platform_extension_packages(channel, &slot, get_server()?)?;
+    let packages = get_platform_extension_packages(channel, &slot, get_server()?).await?;
 
     let mut table = Table::new();
     table.set_format(*table::FORMAT);

--- a/src/portable/server/list_versions.rs
+++ b/src/portable/server/list_versions.rs
@@ -236,17 +236,18 @@ pub struct JsonVersionInfo {
     debug_info: DebugInfo,
 }
 
-pub fn all_packages() -> Vec<PackageInfo> {
+#[tokio::main(flavor = "current_thread")]
+pub async fn all_packages() -> Vec<PackageInfo> {
     let mut pkgs = Vec::with_capacity(16);
-    match get_server_packages(Channel::Stable) {
+    match get_server_packages(Channel::Stable).await {
         Ok(stable) => pkgs.extend(stable),
         Err(e) => log::warn!("Unable to fetch stable packages: {e:#}"),
     };
-    match get_server_packages(Channel::Testing) {
+    match get_server_packages(Channel::Testing).await {
         Ok(testing) => pkgs.extend(testing),
         Err(e) => log::warn!("Unable to fetch testing packages: {e:#}"),
     };
-    match get_server_packages(Channel::Nightly) {
+    match get_server_packages(Channel::Nightly).await {
         Ok(nightly) => pkgs.extend(nightly),
         Err(e) => log::warn!("Unable to fetch nightly packages: {e:#}"),
     }

--- a/src/project/init.rs
+++ b/src/project/init.rs
@@ -1065,8 +1065,9 @@ fn parse_ver_and_find(value: &str) -> anyhow::Result<Option<(Query, PackageInfo)
     }
 }
 
-fn print_versions(title: &str) -> anyhow::Result<()> {
-    let mut avail = repository::get_server_packages(Channel::Stable)?;
+#[tokio::main(flavor = "current_thread")]
+async fn print_versions(title: &str) -> anyhow::Result<()> {
+    let mut avail = repository::get_server_packages(Channel::Stable).await?;
     avail.sort_by(|a, b| b.version.cmp(&a.version));
     println!(
         "{}: {}{}",


### PR DESCRIPTION
Fixes this:

https://github.com/geldata/gel-js/actions/runs/18895931771/job/53933237648?pr=1319#step:10:9
```
thread 'main' panicked at src/portable/repository.rs:198:1:
Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks.
```


Function `portable::repository::get_json` was spawning a tokio runtime to make a HTTP request with some advanced timing and retry nuances. A completely valid use case for `async`.

This function was called from many functions in `portable::repository`, all of them sync.

The problem was that in `portable::extension`, we also had a tokio runtime (for other valid reasons), but called one of the sync functions in `portable::repository` that then called `get_json`. This is problematic, because tokio does not allow entering of multiple runtimesat once.

This is particularly annoying because this was not caught at compile time or at the tests, because the type system (or any other rust rules) allow this usage and because this particular code path was not tested. We might want to have a test for it now, but it makes me wonder how many such code paths do we have.

We need a better long-term strategy here.

---

Maybe we avoid spawning new runtimes in "small" or "low level" functions?