### PR TITLE
Fix more (hopefully all) of the tokio runtime bugs

### DIFF
--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -210,7 +210,6 @@ pub fn prompt_cloud_login(client: &mut CloudClient) -> anyhow::Result<()> {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
 pub async fn restart_cloud_instance(
     name: &CloudName,
     options: &CloudOptions,

--- a/src/instance/control.rs
+++ b/src/instance/control.rs
@@ -591,7 +591,7 @@ pub async fn restart(cmd: &Restart, options: &crate::Options) -> anyhow::Result<
             do_restart(&meta)
         }
         InstanceName::Cloud(name) => {
-            crate::cloud::ops::restart_cloud_instance(&name, &options.cloud_options)
+            crate::cloud::ops::restart_cloud_instance(&name, &options.cloud_options).await
         }
     }
 }


### PR DESCRIPTION
This time I wrote an ad-hoc callgraph based static analyzer to try to
find all of the places where this could happen.  (It potentially could
have false negatives because of unknown function calls, etc, but I'd
be a little surprised.)

The analyzer is here: https://gist.github.com/msullivan/6840f5c38b30b21b708d8b4ff553a95b

This found the windows problem reported in #1755 as well as an
all-platforms bug in restarts of cloud instances.